### PR TITLE
mcp: name the source config file when a server fails to load

### DIFF
--- a/cmd/whip/mcp.go
+++ b/cmd/whip/mcp.go
@@ -170,6 +170,9 @@ func mcpTestCLI(name string) error {
 		if res.Note != "" {
 			fmt.Println("  note:", res.Note)
 		}
+		if res.Source != "" {
+			fmt.Println("  config:", res.Source)
+		}
 		return fmt.Errorf("server %q failed", name)
 	}
 }

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -38,6 +38,12 @@ type ServerConfig struct {
 	Note           string `json:"note,omitempty"`           // surfaced in /mcp status (e.g. unsupported import)
 	StartupTimeout int    `json:"startupTimeout,omitempty"` // seconds to connect + list tools (default 30)
 	ToolTimeout    int    `json:"toolTimeout,omitempty"`    // seconds per tool call (default 60)
+
+	// Source is the config file this server came from (".mcp.json",
+	// "~/.codex/config.toml", "~/.whip/config.json"). Set by discovery for
+	// display (a failed server should point at the file to fix); never
+	// persisted.
+	Source string `json:"-"`
 }
 
 // Remote reports whether the server connects over HTTP rather than stdio.
@@ -209,7 +215,9 @@ func (p ImportSourcePolicy) Admits(name string) bool {
 // list) instead of vanishing silently. Blocked never shadows a whip entry of
 // the same name. Sources attributes every discovered name (merged or
 // blocked) to the file that contributes/would contribute it ("whip",
-// ".mcp.json", or "codex") — codex wins over claude, whip over both.
+// ".mcp.json", or "codex") — codex wins over claude, whip over both. Each
+// merged/blocked ServerConfig also carries its Source file path so a failed
+// server can point at the file to fix.
 type Filtered struct {
 	Merged  map[string]ServerConfig
 	Blocked map[string]ServerConfig
@@ -217,19 +225,32 @@ type Filtered struct {
 	Errs    map[string]error
 }
 
+// setSource stamps every entry of src with the file it was discovered from.
+func setSource(src map[string]ServerConfig, path string) {
+	for name, c := range src {
+		c.Source = path
+		src[name] = c
+	}
+}
+
 // LoadMergedFiltered discovers server configs like LoadMerged, then applies
 // the import policy: filtered-out claude/codex entries land in Blocked as
 // disabled+noted copies. whipCfg entries always pass through.
 func LoadMergedFiltered(cwd string, whipCfg map[string]ServerConfig, policy ImportPolicy) Filtered {
 	errs := map[string]error{}
-	claude, err := LoadClaude(filepath.Join(cwd, ".mcp.json"))
+	claudePath := filepath.Join(cwd, ".mcp.json")
+	claude, err := LoadClaude(claudePath)
 	if err != nil && !os.IsNotExist(err) {
 		errs[".mcp.json"] = err
 	}
-	codex, err := LoadCodex(CodexPath())
+	codexPath := CodexPath()
+	codex, err := LoadCodex(codexPath)
 	if err != nil && !os.IsNotExist(err) {
-		errs[CodexPath()] = err
+		errs[codexPath] = err
 	}
+	setSource(claude, claudePath)
+	setSource(codex, codexPath)
+	setSource(whipCfg, whipConfigPath())
 	blocked := map[string]ServerConfig{}
 	split := func(src map[string]ServerConfig, p ImportSourcePolicy) map[string]ServerConfig {
 		kept := make(map[string]ServerConfig, len(src))
@@ -285,6 +306,17 @@ func LoadMerged(cwd string, whipCfg map[string]ServerConfig) (map[string]ServerC
 // CodexPath is the codex CLI's config file location (~/.codex/config.toml).
 // A variable so tests can point it at fixtures.
 var CodexPath = defaultCodexPath
+
+// whipConfigPath is whip's own config file location (~/.whip/config.json) —
+// the source of any server from the config's "mcp" block. Best-effort: ""
+// when the home dir isn't resolvable.
+func whipConfigPath() string {
+	dir, err := config.Dir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "config.json")
+}
 
 // FromConfigMap converts whip's config-file MCP block (identical field
 // shape, defined in internal/config to keep that package a leaf) into

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -290,6 +290,20 @@ func TestLoadMergedFilteredPolicy(t *testing.T) {
 	if len(def.Merged) != 4 || len(def.Blocked) != 0 {
 		t.Errorf("nil policy must import everything, got merged=%v blocked=%v", def.Merged, def.Blocked)
 	}
+
+	// Every discovered entry carries the file it came from, so a failed
+	// server can point at the config to fix.
+	for name, want := range map[string]string{
+		"proj":      filepath.Join(dir, ".mcp.json"),
+		"node_repl": codexFile,
+	} {
+		if got := def.Merged[name].Source; got != want {
+			t.Errorf("Merged[%q].Source = %q, want %q", name, got, want)
+		}
+	}
+	if got := f.Blocked["ghost"].Source; got != filepath.Join(dir, ".mcp.json") {
+		t.Errorf("Blocked[ghost].Source = %q", got)
+	}
 }
 
 // TestManagerFromBlockedDiscovery pins the original failure scenario end to
@@ -321,6 +335,30 @@ func TestManagerFromBlockedDiscovery(t *testing.T) {
 	blocked := mgr.Blocked()
 	if len(blocked) != 1 || blocked[0].Status != StatusDisabled || blocked[0].Note == "" {
 		t.Errorf("blocked snapshot: %+v", blocked)
+	}
+	if blocked[0].Source != codexFile {
+		t.Errorf("blocked row should point at its source file, got %q", blocked[0].Source)
+	}
+}
+
+// TestManagerStatusSource pins the end-to-end handoff: the file a server was
+// discovered from survives NewManager and shows up in the Statuses snapshot,
+// so the /mcp failure row can name the config to fix.
+func TestManagerStatusSource(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(
+		`{"mcpServers": {"proj": {"command": "proj-srv"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	codexFile := filepath.Join(dir, "codex.toml") // absent: keeps the real ~/.codex out
+	orig := CodexPath
+	CodexPath = func() string { return codexFile }
+	defer func() { CodexPath = orig }()
+	f := LoadMergedFiltered(dir, nil, ImportPolicyFrom(nil))
+	mgr := NewManager(f.Merged)
+	sts := mgr.Statuses()
+	if len(sts) != 1 || sts[0].Source != filepath.Join(dir, ".mcp.json") {
+		t.Errorf("status source: %+v", sts)
 	}
 }
 

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -54,6 +54,7 @@ type Server struct {
 	Note   string // import notes (e.g. claude sse transport)
 	Err    string // failure detail when Status == StatusFailed
 	Tools  int    // tools contributed when ready
+	Source string // config file the server was discovered from ("" when unknown)
 }
 
 // server holds one server's live state.
@@ -628,7 +629,7 @@ func (m *Manager) SetBlocked(cfgs map[string]ServerConfig) {
 	defer m.onChangeMu.Unlock()
 	m.blocked = make([]Server, 0, len(cfgs))
 	for name, c := range cfgs {
-		m.blocked = append(m.blocked, Server{Name: name, Status: StatusDisabled, Note: c.Note})
+		m.blocked = append(m.blocked, Server{Name: name, Status: StatusDisabled, Note: c.Note, Source: c.Source})
 	}
 	sort.Slice(m.blocked, func(i, j int) bool { return m.blocked[i].Name < m.blocked[j].Name })
 }
@@ -658,7 +659,7 @@ func (m *Manager) Statuses() []Server {
 	out := make([]Server, 0, len(m.servers))
 	for _, s := range m.servers {
 		s.mu.Lock()
-		out = append(out, Server{Name: s.name, Status: s.status, Note: s.note, Err: s.err, Tools: len(s.defs)})
+		out = append(out, Server{Name: s.name, Status: s.status, Note: s.note, Err: s.err, Tools: len(s.defs), Source: s.cfg.Source})
 		s.mu.Unlock()
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })

--- a/internal/tui/mcp.go
+++ b/internal/tui/mcp.go
@@ -100,6 +100,9 @@ func (m *model) mcpStatusView() string {
 		case mcp.StatusFailed:
 			icon = "✗"
 			detail = s.Err
+			if s.Source != "" {
+				detail += " (" + s.Source + ")"
+			}
 		case mcp.StatusDisabled:
 			icon = "○"
 			detail = "disabled"

--- a/internal/tui/mcp_test.go
+++ b/internal/tui/mcp_test.go
@@ -160,7 +160,7 @@ var _ = context.Background
 func TestMCPFirstSettleNote(t *testing.T) {
 	disabled := false
 	m := mcpModel(t, map[string]mcp.ServerConfig{
-		"dead": {Command: []string{"nope-not-a-binary-xyz"}, StartupTimeout: 2},
+		"dead": {Command: []string{"nope-not-a-binary-xyz"}, StartupTimeout: 2, Source: "/proj/.mcp.json"},
 		"off":  {Command: []string{"true"}, Enabled: &disabled},
 	})
 	// OnChange fires from manager connect goroutines; guard the model the
@@ -195,6 +195,9 @@ func TestMCPFirstSettleNote(t *testing.T) {
 	mu.Unlock()
 	if !strings.Contains(text, "mcp: dead failed") || !strings.Contains(text, "/mcp dead reconnect") {
 		t.Errorf("missing failure note:\n%s", text)
+	}
+	if !strings.Contains(text, "(/proj/.mcp.json)") {
+		t.Errorf("failure note should name the config file:\n%s", text)
 	}
 	if !strings.Contains(text, "mcp: off disabled") {
 		t.Errorf("missing disabled note:\n%s", text)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1763,7 +1763,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case mcp.StatusReady:
 					m.append(dimStyle.Render(fmt.Sprintf("⚡ mcp: %s ready (%d tools)", srv.Name, srv.Tools)))
 				case mcp.StatusFailed:
-					m.append(errStyle.Render(fmt.Sprintf("✗ mcp: %s failed: %s (/mcp %s reconnect)", srv.Name, srv.Err, srv.Name)))
+					line := fmt.Sprintf("✗ mcp: %s failed: %s", srv.Name, srv.Err)
+					if srv.Source != "" {
+						line += " (" + srv.Source + ")"
+					}
+					m.append(errStyle.Render(line + fmt.Sprintf(" (/mcp %s reconnect)", srv.Name)))
 				case mcp.StatusDisabled:
 					m.append(dimStyle.Render(fmt.Sprintf("○ mcp: %s disabled", srv.Name)))
 				}


### PR DESCRIPTION
## What

When an MCP server fails to load, whip now tells you **which config file it came from**, so the failure ends in an edit instead of a hunt.

The source path appears in all three failure surfaces:

- **Inline transcript note** (shown when the UI opens / a server settles):
  ```
  ✗ mcp: dead failed: fork/exec …: no such file or directory (/proj/.mcp.json) (/mcp dead reconnect)
  ```
- **`/mcp` status table** — failed rows append `(<source path>)` to the error detail
- **`whip mcp test <name>`** — prints `  config: <path>` after the failure

## How

- `ServerConfig` gains a `Source` field (`json:"-"` — display-only, never persisted), stamped by `LoadMergedFiltered` during discovery: `.mcp.json` for claude-style, `~/.codex/config.toml` for codex, `~/.whip/config.json` for whip's own `mcp` block
- `Manager.Statuses()` / `SetBlocked()` carry it through to the status snapshot
- No wording changes — the `mcp:` prefix and existing messages are untouched

## Tests

- `TestLoadMergedFilteredPolicy` — source attribution through discovery (merged + blocked)
- `TestManagerFromBlockedDiscovery` — blocked rows point at their source file
- `TestManagerStatusSource` (new) — the path survives `NewManager` into the `Statuses` snapshot
- `TestMCPFirstSettleNote` — the inline transcript line includes the path

`go build`, `go vet`, and the full `internal/mcp`, `internal/tui`, `cmd/whip` suites pass; verified end-to-end with a broken `.mcp.json`.