### PR TITLE
tui: /context-doctor names where each skill comes from

### DIFF
--- a/internal/tui/context_doctor.go
+++ b/internal/tui/context_doctor.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -35,24 +37,31 @@ func (m *model) doctorReport() string {
 	// turn in prepareTurn).
 	rows = append(rows, ctxRow{"system prompt (base)", len(m.sysPrompt), ""})
 
-	// Skills: block total + the worst offenders.
-	sk := skills.Scan(skills.DefaultDirs()...)
+	// Skills: block total + the worst offenders, each named with the directory
+	// it was discovered from — "where does this skill come from?" should be
+	// answerable here, not by hunting ~/.whip/skills vs .agents/skills.
+	scan := m.skillScan
+	if scan == nil { // headless tests build models without the seam
+		scan = func() []skills.Skill { return skills.Scan(skills.DefaultDirs()...) }
+	}
+	sk := scan()
 	block := skills.PromptBlock(sk)
 	row := ctxRow{fmt.Sprintf("skills (%d loaded)", len(sk)), len(block), ""}
 	// Per-skill line cost in the block: "- name: desc (path)\n".
 	type sc struct {
 		name string
+		dir  string // the skills dir the SKILL.md lives under
 		n    int
 	}
 	var per []sc
 	for _, s := range sk {
 		n := len(s.Name) + min(len(s.Description), 300) + len(s.Path) + 8
-		per = append(per, sc{s.Name, n})
+		per = append(per, sc{s.Name, filepath.Dir(filepath.Dir(s.Path)), n})
 	}
 	sort.Slice(per, func(i, j int) bool { return per[i].n > per[j].n })
 	var top []string
 	for i := 0; i < len(per) && i < 5; i++ {
-		top = append(top, fmt.Sprintf("%s ~%dtok", per[i].name, (per[i].n+3)/4))
+		top = append(top, fmt.Sprintf("%s ~%dtok (%s)", per[i].name, (per[i].n+3)/4, shortSkillsDir(per[i].dir)))
 	}
 	if len(top) > 0 {
 		row.note = "biggest: " + strings.Join(top, ", ")
@@ -128,6 +137,30 @@ func (m *model) doctorReport() string {
 	fmt.Fprintf(&b, "  %-*s %7s\n", w, "TOTAL injected before you type", "~"+tok(total))
 	b.WriteString("\nTrim: /mcp <name> disable · remove a skill from .agents/skills · /context-doctor again")
 	return b.String()
+}
+
+// shortSkillsDir compacts a skills directory for the doctor's per-skill
+// attribution: home-relative ("~/.whip/skills") when under the user's home,
+// cwd-relative ("./.agents/skills") when under the working directory,
+// absolute otherwise.
+func shortSkillsDir(dir string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if rel, err := filepath.Rel(home, dir); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			if rel == "." {
+				return "~"
+			}
+			return "~" + string(filepath.Separator) + rel
+		}
+	}
+	if wd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(wd, dir); err == nil && !strings.HasPrefix(rel, "..") {
+			if rel == "." {
+				return "."
+			}
+			return "." + string(filepath.Separator) + rel
+		}
+	}
+	return dir
 }
 
 // tok renders a token count compactly (1.2k, 350).

--- a/internal/tui/context_doctor_test.go
+++ b/internal/tui/context_doctor_test.go
@@ -1,10 +1,13 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/context-labs/whip/internal/mcp"
+	"github.com/context-labs/whip/internal/skills"
 )
 
 func TestDoctorFreshSession(t *testing.T) {
@@ -46,6 +49,63 @@ func TestDoctorCommandWired(t *testing.T) {
 		t.Error("/doctor should not exist as a shorthand")
 	}
 	_ = before
+}
+
+// TestDoctorSkillSources pins the attribution: each skill named in "biggest:"
+// carries the directory it was discovered from, home-relative for ~/.whip
+// and ./-relative for the project dir — answering "where does this skill come
+// from?" without leaving the report.
+func TestDoctorSkillSources(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	proj := t.TempDir()
+	t.Chdir(proj)
+
+	writeSkill := func(dir, name, desc string) {
+		t.Helper()
+		sd := filepath.Join(dir, name)
+		if err := os.MkdirAll(sd, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nname: " + name + "\ndescription: " + desc + "\n---\n"
+		if err := os.WriteFile(filepath.Join(sd, "SKILL.md"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeSkill(filepath.Join(proj, ".agents", "skills"), "proj-skill", "from the project")
+	writeSkill(filepath.Join(home, ".whip", "skills"), "user-skill", "from the user dir")
+
+	m := tasksModel("http://unused")
+	m.skillScan = func() []skills.Skill { return skills.Scan(skills.DefaultDirs()...) }
+	out := m.doctorReport()
+	if !strings.Contains(out, "proj-skill") || !strings.Contains(out, "user-skill") {
+		t.Fatalf("both skills should be named:\n%s", out)
+	}
+	if !strings.Contains(out, "proj-skill ~") || !strings.Contains(out, "(./.agents/skills)") {
+		t.Errorf("project skill should point at ./.agents/skills:\n%s", out)
+	}
+	if !strings.Contains(out, "(~/.whip/skills)") {
+		t.Errorf("user skill should point at ~/.whip/skills:\n%s", out)
+	}
+}
+
+// TestShortSkillsDir pins the compaction rules: home → ~, cwd → ./, anything
+// else stays absolute.
+func TestShortSkillsDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+	cases := map[string]string{
+		filepath.Join(home, ".whip", "skills"):                     "~/.whip/skills",
+		filepath.Join(wd, ".agents", "skills"):                     "./.agents/skills",
+		filepath.Join(string(filepath.Separator), "opt", "skills"): "/opt/skills",
+	}
+	for dir, want := range cases {
+		if got := shortSkillsDir(dir); got != want {
+			t.Errorf("shortSkillsDir(%q) = %q, want %q", dir, got, want)
+		}
+	}
 }
 
 func TestTok(t *testing.T) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -170,6 +170,10 @@ type model struct {
 	mcpMgr       *mcp.Manager              // MCP server connections; nil when none configured
 	mcpSeen      map[string]bool           // servers whose first settle was announced
 	lspMgr       *lsp.Manager              // LSP diagnostics source for write/edit tool output
+	// skillScan is the skills discovery seam (skills.Scan over DefaultDirs in
+	// the real model): a field so the context doctor can be tested against
+	// temp-dir skills instead of whatever the test machine happens to have.
+	skillScan func() []skills.Skill
 
 	irunner *interactiveRunner // installed on tools.InteractiveBash at startup
 	iactive *interactive       // in-flight interactive command; nil when idle
@@ -271,6 +275,7 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string) (s
 		input: ti, spin: spinner.New(spinner.WithSpinner(spinner.Dot)), follow: true, saved: 1,
 		catalogs: config.LoadCatalogs(), mouseOn: mouseOn, now: time.Now, showThinking: showThinking,
 		compactModel: cfg.CompactModel, compactProv: cfg.CompactProvider,
+		skillScan: func() []skills.Skill { return skills.Scan(skills.DefaultDirs()...) },
 	}
 	m.applyCompactModel()
 	m.agent.CompactThreshold = compactThresholdFor(cfg)


### PR DESCRIPTION
## What

The `/context-doctor` skills row named the biggest offenders but not their origin — auditing a bloated fresh-session context meant hunting `~/.whip/skills` vs `.agents/skills` by hand. Now each named skill carries the directory it was discovered from, compacted home-relative or cwd-relative:

```
  skills (42 loaded)        ~10.2k  biggest: ponytail ~120tok (~/.whip/skills), my-skill ~45tok (./.agents/skills), …
```

## How

- `model.skillScan` is the discovery seam (`skills.Scan(skills.DefaultDirs()...)` in the real model): a field so the doctor can be tested against temp-dir skills instead of whatever the test machine happens to have installed
- `shortSkillsDir` compacts directories: `~` for anything under the user's home, `./` for anything under the working directory, absolute otherwise
- No format change to the rest of the report — only the `biggest:` entries gain `(<dir>)` suffixes

## Tests

- `TestDoctorSkillSources` — a project skill and a user skill are both named with their respective source dirs
- `TestShortSkillsDir` — the `~` / `./` / absolute compaction rules
- Existing doctor tests (`TestDoctorFreshSession`, `TestDoctorCommandWired`) unchanged and passing

`go build`, `go vet`, and the full `internal/tui`, `internal/skills`, `internal/mcp`, `cmd/whip` suites pass. (The `internal/browser` E2E failures on this machine are environment-dependent — no local Chrome with remote debugging — and reproduce on clean `main`.)