### PR TITLE
fix: make the bash global lock actually exclude path mutations

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -37,8 +37,13 @@ The buffer of 1 is the lock. First acquirer fills it and proceeds; later
 acquirers block on send until the holder receives. No explicit unlock, no
 registration race, no promise plumbing — the channel *is* the mutex, and the
 compiler checks direction. Two spellings of the same file share a lock via
-`filepath.Abs` + `filepath.Clean`. `bash` (side effects not attributable to a
-path) takes a single global channel.
+`filepath.Abs` + `filepath.Clean`.
+
+`bash`, whose side effects aren't attributable to a path, has to exclude every
+path mutation and not merely other `bash` calls, so the two gates are one
+`sync.RWMutex` rather than a second channel: a path mutation read-locks it for
+as long as it holds its path channel, `bash` write-locks it. Mutations still run
+in parallel with each other, because readers do.
 
 The batch itself is fanned out with a goroutine per call and a buffered results
 channel (`runTools` in `internal/agent/agent.go`); results land back in call

--- a/internal/agent/filelocks.go
+++ b/internal/agent/filelocks.go
@@ -14,22 +14,30 @@ import (
 //
 // Only write/edit take a per-path lock; reads don't. Bash takes the global
 // lock because a command can touch anything.
+//
+// The two gates are one lock, not two: a per-path channel alone would only
+// serialize mutations against each other, leaving bash free to run beside a
+// write it could clobber. So a path mutation holds gate.RLock for as long as it
+// holds its path channel, and bash holds gate.Lock, which is the exclusion the
+// comment above claims. Mutations still run in parallel with one another,
+// because readers do.
 type fileLocks struct {
-	mu     sync.Mutex
-	locks  map[string]chan struct{}
-	global chan struct{} // serializes bash (unknown side effects) with mutations
+	mu    sync.Mutex
+	locks map[string]chan struct{}
+	gate  sync.RWMutex // bash write-locks it; every path mutation read-locks it
 }
 
 func newFileLocks() *fileLocks {
-	return &fileLocks{
-		locks:  map[string]chan struct{}{},
-		global: make(chan struct{}, 1),
-	}
+	return &fileLocks{locks: map[string]chan struct{}{}}
 }
 
 // acquirePath blocks until the lock for path is held, returning a release func.
 // The 1-capacity channel means the first acquirer succeeds immediately and
 // later acquirers block on send until the holder receives.
+// The gate is taken before the path channel and released after it. Deadlock is
+// not the reason for that order: bash only ever takes the gate and never holds
+// a path channel, so no wait cycle exists either way. One fixed order is just
+// easier to reason about.
 func (f *fileLocks) acquirePath(path string) func() {
 	key := canonicalPathKey(path)
 	f.mu.Lock()
@@ -39,15 +47,19 @@ func (f *fileLocks) acquirePath(path string) func() {
 		f.locks[key] = ch
 	}
 	f.mu.Unlock()
-	ch <- struct{}{}       // acquire (blocks while held)
-	return func() { <-ch } // release
+	f.gate.RLock()
+	ch <- struct{}{} // acquire (blocks while held)
+	return func() {
+		<-ch // release
+		f.gate.RUnlock()
+	}
 }
 
 // acquireGlobal serializes a tool call against every other mutation — used by
 // bash, whose side effects can't be attributed to one path.
 func (f *fileLocks) acquireGlobal() func() {
-	f.global <- struct{}{}
-	return func() { <-f.global }
+	f.gate.Lock()
+	return func() { f.gate.Unlock() }
 }
 
 // canonicalPathKey normalizes a path so two spellings of the same file share

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -153,6 +154,90 @@ func TestBashExcludesPathMutations(t *testing.T) {
 
 	if maxConc.Load() != 1 {
 		t.Fatalf("bash must exclude path mutations (max concurrency 1), got %d", maxConc.Load())
+	}
+}
+
+// The gate bash write-locks is read-locked by every path mutation, so the
+// obvious wrong fix (an exclusive lock on both sides) would quietly serialize
+// every write in the batch. Different paths must still overlap.
+func TestDifferentPathWritesOverlap(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	var conc, maxConc atomic.Int32
+	ag.Tools = []tools.Tool{{
+		Def: llm.NewTool("write", "w", `{"type":"object","properties":{"path":{"type":"string"}}}`),
+		Run: func(ctx context.Context, args json.RawMessage) (string, error) {
+			n := conc.Add(1)
+			for {
+				m := maxConc.Load()
+				if n <= m || maxConc.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			time.Sleep(25 * time.Millisecond)
+			conc.Add(-1)
+			return "ok", nil
+		},
+	}}
+	mk := func(id, p string) llm.ToolCall {
+		return llm.ToolCall{ID: id, Function: struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{Name: "write", Arguments: fmt.Sprintf(`{"path":%q}`, p)}}
+	}
+	ag.runTools(context.Background(), []llm.ToolCall{
+		mk("1", "/tmp/a.go"), mk("2", "/tmp/b.go"), mk("3", "/tmp/c.go"),
+	}, Events{})
+	t.Logf("different-path max concurrency = %d", maxConc.Load())
+	if maxConc.Load() < 2 {
+		t.Fatalf("different-path writes no longer overlap: max concurrency %d", maxConc.Load())
+	}
+}
+
+// Go's RWMutex parks new readers once a writer is waiting, so a bash call
+// arriving mid-batch must still complete rather than starve behind a stream of
+// path mutations, and the batch must not deadlock when it is far larger than
+// the scheduler's parallelism.
+func TestBashCompletesUnderWriteLoad(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	var bashDone atomic.Bool
+	slow := func(name string, mark bool) tools.Tool {
+		return tools.Tool{
+			Def: llm.NewTool(name, name, `{"type":"object","properties":{"path":{"type":"string"},"command":{"type":"string"}}}`),
+			Run: func(ctx context.Context, args json.RawMessage) (string, error) {
+				time.Sleep(5 * time.Millisecond)
+				if mark {
+					bashDone.Store(true)
+				}
+				return "ok", nil
+			},
+		}
+	}
+	ag.Tools = []tools.Tool{slow("write", false), slow("bash", true)}
+	mk := func(id, name, args string) llm.ToolCall {
+		return llm.ToolCall{ID: id, Function: struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{Name: name, Arguments: args}}
+	}
+	var calls []llm.ToolCall
+	for i := range 60 {
+		calls = append(calls, mk(strconv.Itoa(i), "write", fmt.Sprintf(`{"path":"/tmp/w%d.go"}`, i)))
+	}
+	calls = append(calls, mk("bash", "bash", `{"command":"x"}`))
+	for i := 60; i < 120; i++ {
+		calls = append(calls, mk(strconv.Itoa(i), "write", fmt.Sprintf(`{"path":"/tmp/w%d.go"}`, i)))
+	}
+	done := make(chan struct{})
+	start := time.Now()
+	go func() { ag.runTools(context.Background(), calls, Events{}); close(done) }()
+	select {
+	case <-done:
+		t.Logf("121 calls finished in %v, bash ran = %v", time.Since(start), bashDone.Load())
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock or starvation: runTools did not finish")
+	}
+	if !bashDone.Load() {
+		t.Fatal("the bash call never ran")
 	}
 }
 

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -113,6 +113,49 @@ func TestSamePathEditsSerialize(t *testing.T) {
 	}
 }
 
+// Bash takes the global lock because a command can touch anything, so a bash
+// call and a path mutation must not overlap. The per-path lock and the global
+// lock are separate gates, so this is the one pairing that proves the global
+// lock excludes anything other than a second bash.
+func TestBashExcludesPathMutations(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+
+	var conc, maxConc atomic.Int32
+	instrumented := func(name string) tools.Tool {
+		return tools.Tool{
+			Def: llm.NewTool(name, name, `{"type":"object","properties":{"path":{"type":"string"},"command":{"type":"string"}}}`),
+			Run: func(ctx context.Context, args json.RawMessage) (string, error) {
+				n := conc.Add(1)
+				for {
+					m := maxConc.Load()
+					if n <= m || maxConc.CompareAndSwap(m, n) {
+						break
+					}
+				}
+				time.Sleep(25 * time.Millisecond)
+				conc.Add(-1)
+				return "ok", nil
+			},
+		}
+	}
+	ag.Tools = []tools.Tool{instrumented("bash"), instrumented("write")}
+
+	mk := func(id, name, args string) llm.ToolCall {
+		return llm.ToolCall{ID: id, Function: struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{Name: name, Arguments: args}}
+	}
+	ag.runTools(context.Background(), []llm.ToolCall{
+		mk("1", "bash", `{"command":"rm -rf /tmp/anything"}`),
+		mk("2", "write", `{"path":"/tmp/same.go"}`),
+	}, Events{})
+
+	if maxConc.Load() != 1 {
+		t.Fatalf("bash must exclude path mutations (max concurrency 1), got %d", maxConc.Load())
+	}
+}
+
 // Background tasks run concurrently with the parent and deliver their report
 // via the Done channel + a steered message.
 func TestBackgroundTaskDeliversReport(t *testing.T) {

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -353,6 +353,44 @@ func TestManagerAutoReconnect(t *testing.T) {
 	}
 }
 
+// Close must actually shut the manager down: the drop watcher it wakes must
+// not mark the server failed and must not kick an auto-reconnect. Without the
+// closed flag every closed-guard in this file is inert and the manager is back
+// to ready within a few dozen milliseconds of Close returning, holding a live
+// session nobody can reach.
+func TestManagerCloseStopsReconnect(t *testing.T) {
+	t.Setenv("WHIP_TEST_MCP_BACKOFF_MS", "0")
+
+	m := newTestManager(t, map[string]ServerConfig{"docs": testCfg("docs")})
+	m.Start(context.Background())
+	waitReady(t, m)
+	if st := m.Statuses(); st[0].Status != StatusReady {
+		t.Fatal("expected ready")
+	}
+
+	m.Close()
+
+	m.onChangeMu.Lock()
+	closed := m.closed
+	m.onChangeMu.Unlock()
+	if !closed {
+		t.Fatal("Close did not set closed, so every closed-guard is inert")
+	}
+
+	// Give the watcher and any reconnect it kicks time to act.
+	s := m.servers["docs"]
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		sess, status := s.sess, s.status
+		s.mu.Unlock()
+		if sess != nil {
+			t.Fatalf("reconnected after Close: status %v", status)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // TestManagerAutoReconnectGivesUp: a server that keeps failing exhausts
 // autoReconnectMax tries and stays failed (no flapping forever).
 func TestManagerAutoReconnectGivesUp(t *testing.T) {


### PR DESCRIPTION
Fixes #8.

Rebased onto main. The MCP half of this PR is gone: `03434cd` fixed `Manager.Close` upstream while this was open, with the same remedy, so all that survives of it here is a test.

**The bash global lock didn't exclude path mutations** (`f507fec`). `acquirePath` sent on a per-path channel and `acquireGlobal` sent on a separate one, so the only thing the global lock excluded was a second bash. A bash command and a write to a file ran concurrently, which is the case the lock exists for. Replaced the two channels with one `sync.RWMutex`: a path mutation holds `RLock` for as long as it holds its path channel, bash holds `Lock`. Mutations still run in parallel with each other because readers do.

`ed07d91` covers what the lock change itself could break rather than what it fixes: an exclusive lock on both sides would pass the bash-versus-write test while serializing every write in a batch, and Go parks new readers once a writer waits, which is a starvation shape nothing looked at.

`1ffa940` adds a test for your `Close` fix. `TestConnectDuringCloseDiscardsSession` sets `m.closed` by hand and never calls `Close`, so deleting those three lines from `Close` leaves the whole `internal/mcp` suite green. The new test calls the real `Close`, asserts the flag, and polls two seconds for a restored session, and it is red against that same revert.

`c2728e0` updates `docs/concurrency.md`, which still described `bash` taking the global channel this replaces.

What was measured:

| check | before | after |
|---|---|---|
| bash + write concurrency | 2 | 1 |
| bash + bash concurrency (control) | 1 | 1 |
| different-path writes | 3 | 3 |
| 121 calls with a bash mid-batch | n/a | finishes, bash runs |
| `internal/mcp` suite with the flag set removed from `Close` | green | red |

Swapping `acquirePath`'s `RLock` for `Lock` drops different-path concurrency from 3 to 1 and turns that test red, so it is not passing by construction.

One correction to the earlier version of this PR. I had claimed the acquisition order, gate before path channel, prevents a deadlock. It does not: bash only ever takes the gate and never holds a path channel, so no wait cycle exists either way, and the load test still passes with the order inverted. The code comment and commit message now say that instead.

Locally `gofmt -s -l`, `go vet`, `golangci-lint`, `go mod tidy` and the four cross-compile targets are clean, and the portable test set passes under `-race -shuffle=on`. `TestAuthInferenceNetBYOKNoKey` hangs on this machine for lack of network and does the same on an unmodified main, so I skipped it to measure; coverage with it skipped is 89.4% here against 89.3% for main.
