### PR TITLE
test: raise portable-set coverage 70.6% → 84.3%, ratchet floor to 80%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,14 @@ jobs:
             -coverprofile=cover.out -coverpkg="$(echo $PKGS | tr ' ' ',')" $PKGS
 
       # Self-contained coverage floor — no external service or token, so it
-      # works identically on fork PRs. Baseline today is ~70%; the gate fails
+      # works identically on fork PRs. Baseline today is ~84%; the gate fails
       # if total statement coverage drops below the floor. Ratchet the floor up
       # over time as coverage improves (don't lower it).
-      - name: coverage floor (70%)
+      - name: coverage floor (80%)
         run: |
           total=$(go tool cover -func=cover.out | awk '/^total:/ {gsub("%","",$3); print $3}')
           echo "total coverage: ${total}%"
-          awk -v t="$total" -v floor=70 'BEGIN { if (t+0 < floor) { printf "coverage %.1f%% is below the %d%% floor\n", t, floor; exit 1 } }'
+          awk -v t="$total" -v floor=80 'BEGIN { if (t+0 < floor) { printf "coverage %.1f%% is below the %d%% floor\n", t, floor; exit 1 } }'
 
       - name: go mod tidy is a no-op
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Two workflows gate pull requests: **ci** and **security**.
 - **go test -race -shuffle=on** — the portable package set (internal/browser
   and internal/tui need a Chromium sandbox / tty that hosted runners don't
   have; they stay local).
-- **coverage floor (70%)** — total statement coverage of the portable set must
+- **coverage floor (80%)** — total statement coverage of the portable set must
   stay at or above the floor. It's a self-contained `go tool cover` check (no
   external service), so it works identically on fork PRs. The floor is a
   ratchet: it only goes up as coverage improves. New code should come with

--- a/cmd/whip/auth_test.go
+++ b/cmd/whip/auth_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/context-labs/whip/internal/config"
@@ -143,6 +145,24 @@ func TestAuthCLIDispatch(t *testing.T) {
 	t.Setenv(config.OpenRouterEnvVar, "")
 	if err := authCLI([]string{"openrouter"}); err == nil {
 		t.Error("openrouter with no key should error, not hang or write config")
+	}
+}
+
+// Without a terminal (tests, pipes) offerShellExport prints the manual
+// export line and never touches the rc file — appending needs a confirmed
+// [y/N], which needs a TTY.
+func TestOfferShellExportNonTTY(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, shell := range []string{"/bin/zsh", "/bin/fish"} { // known rc target and none
+		t.Setenv("SHELL", shell)
+		out := captureStdout(t, func() { offerShellExport("sk-or-test") })
+		if !strings.Contains(out, "export "+config.OpenRouterEnvVar+"=sk-or-test") {
+			t.Errorf("SHELL=%s: manual export line missing:\n%s", shell, out)
+		}
+	}
+	if _, err := os.Stat(home + "/.zshrc"); !os.IsNotExist(err) {
+		t.Error("non-tty run must not create or modify the rc file")
 	}
 }
 

--- a/cmd/whip/browser_cli_test.go
+++ b/cmd/whip/browser_cli_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/browser/extrelay"
+)
+
+func TestBrowserCLIDispatch(t *testing.T) {
+	if err := browserCLI(nil); err == nil {
+		t.Error("bare `whip browser` should print usage")
+	}
+	if err := browserCLI([]string{"bogus"}); err == nil {
+		t.Error("unknown subcommand should error")
+	}
+}
+
+// install writes the unpacked extension and the relay state file into an
+// isolated HOME. PATH is emptied so the best-effort open of
+// chrome://extensions can never launch anything on the test machine.
+func TestBrowserInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // xdg-open/open not found: Start fails silently
+
+	var err error
+	out := captureStdout(t, func() { err = browserCLI([]string{"install"}) })
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	dir := extrelay.ExtensionDir(home)
+	entries, rerr := os.ReadDir(dir)
+	if rerr != nil || len(entries) == 0 {
+		t.Fatalf("extension dir not written: %v", rerr)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "manifest.json")); err != nil {
+		t.Errorf("manifest.json missing: %v", err)
+	}
+
+	// relay state: valid JSON with a non-empty token, private perms
+	statePath := extrelay.RelayStatePath(home)
+	info, serr := os.Stat(statePath)
+	if serr != nil {
+		t.Fatalf("relay state missing: %v", serr)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("relay state should be 0600, got %v", info.Mode().Perm())
+	}
+	data, _ := os.ReadFile(statePath)
+	var state struct{ Addr, Token string }
+	if err := json.Unmarshal(data, &state); err != nil || state.Token == "" || state.Addr == "" {
+		t.Errorf("relay state should carry addr+token: %v %q", err, data)
+	}
+
+	// the instructions name the folder the user must load
+	if !strings.Contains(out, dir) || !strings.Contains(out, "Load unpacked") {
+		t.Errorf("install output should walk through the manual load:\n%s", out)
+	}
+}

--- a/cmd/whip/mcp_cli_test.go
+++ b/cmd/whip/mcp_cli_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/mcp"
+)
+
+func TestMCPCLIAddListRemove(t *testing.T) {
+	wd := importFixture(t, "") // codex fixture provides node_repl + paper
+	chdir(t, wd)
+
+	// dispatch and argument validation
+	if err := mcpCLI(nil, "v"); err == nil {
+		t.Error("bare `whip mcp` should print usage")
+	}
+	if err := mcpCLI([]string{"bogus"}, "v"); err == nil {
+		t.Error("unknown subcommand should error")
+	}
+	if err := mcpCLI([]string{"add"}, "v"); err == nil {
+		t.Error("add without a name should error")
+	}
+	if err := mcpCLI([]string{"add", "x", "oops"}, "v"); err == nil {
+		t.Error("add without -- or --url should error")
+	}
+	if err := mcpCLI([]string{"add", "bad", "--url", "ftp://x"}, "v"); err == nil {
+		t.Error("a non-http url is an invalid server")
+	}
+
+	// add a stdio server and a remote server
+	var err error
+	out := captureStdout(t, func() { err = mcpCLI([]string{"add", "local", "--", "echo", "hi"}, "v") })
+	if err != nil || !strings.Contains(out, `added mcp server "local"`) {
+		t.Fatalf("add stdio: %v %q", err, out)
+	}
+	if err := mcpCLI([]string{"add", "remote", "--url", "http://127.0.0.1:9/mcp"}, "v"); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+
+	// list shows both new servers, the imported ones, and their sources
+	out = captureStdout(t, func() { err = mcpCLI([]string{"list"}, "v") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"local", "echo hi", "remote", "http://127.0.0.1:9/mcp", "paper", "whip config", "codex config"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list missing %q:\n%s", want, out)
+		}
+	}
+
+	// remove: own entry works, imported and unknown names explain themselves
+	if err := mcpCLI([]string{"remove", "local"}, "v"); err != nil {
+		t.Fatalf("remove own server: %v", err)
+	}
+	out = captureStdout(t, func() { _ = mcpCLI([]string{"list"}, "v") })
+	if strings.Contains(out, "local") {
+		t.Errorf("removed server still listed:\n%s", out)
+	}
+	if err := mcpCLI([]string{"remove", "paper"}, "v"); err == nil || !strings.Contains(err.Error(), "edit that file") {
+		t.Errorf("removing an imported server should point at its source file, got %v", err)
+	}
+	if err := mcpCLI([]string{"remove", "nosuch"}, "v"); err == nil || !strings.Contains(err.Error(), "no mcp server") {
+		t.Errorf("removing an unknown server: %v", err)
+	}
+	if err := mcpCLI([]string{"remove"}, "v"); err == nil {
+		t.Error("remove without a name should error")
+	}
+}
+
+func TestMCPCLIBlockedServer(t *testing.T) {
+	wd := importFixture(t, `, "mcpImport": { "codex": { "exclude": ["node_repl"] } }`)
+	chdir(t, wd)
+
+	out := captureStdout(t, func() { _ = mcpCLI([]string{"list"}, "v") })
+	if !strings.Contains(out, "node_repl") || !strings.Contains(out, "blocked") {
+		t.Errorf("list should mark the excluded server blocked:\n%s", out)
+	}
+	if err := mcpCLI([]string{"remove", "node_repl"}, "v"); err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("removing a blocked server should explain the policy, got %v", err)
+	}
+	var err error
+	_ = captureStdout(t, func() { err = mcpTestCLI("node_repl") })
+	if err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("testing a blocked server should explain the policy, got %v", err)
+	}
+}
+
+func TestMCPTestCLIUnknownAndDisabled(t *testing.T) {
+	whipHome := t.TempDir()
+	t.Setenv("WHIP_HOME", whipHome)
+	chdir(t, t.TempDir()) // no .mcp.json in the working directory
+	orig := mcp.CodexPath
+	mcp.CodexPath = func() string { return filepath.Join(whipHome, "no-codex.toml") }
+	t.Cleanup(func() { mcp.CodexPath = orig })
+
+	cfg := `{
+  "defaultModel": "m1",
+  "providers": { "a": { "baseUrl": "https://a", "api": "openai-completions" } },
+  "models": { "m1": { "providers": ["a"] } },
+  "mcp": { "off": { "command": ["true"], "enabled": false } }
+}`
+	if err := os.WriteFile(filepath.Join(whipHome, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mcpCLI([]string{"test"}, "v"); err == nil {
+		t.Error("`mcp test` without a name should print usage")
+	}
+	var err error
+	_ = captureStdout(t, func() { err = mcpTestCLI("nosuch") })
+	if err == nil || !strings.Contains(err.Error(), "no mcp server named") {
+		t.Errorf("unknown server: %v", err)
+	}
+	// a disabled server reports without ever launching the command
+	out := captureStdout(t, func() { err = mcpTestCLI("off") })
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("disabled server should error: %v", err)
+	}
+	if !strings.Contains(out, "disabled") {
+		t.Errorf("disabled status not printed:\n%s", out)
+	}
+	// list marks it disabled too
+	out = captureStdout(t, func() { _ = mcpCLI([]string{"list"}, "v") })
+	if !strings.Contains(out, "off") || !strings.Contains(out, "disabled") {
+		t.Errorf("list should show the disabled server:\n%s", out)
+	}
+}

--- a/cmd/whip/update_test.go
+++ b/cmd/whip/update_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stubShell puts a fake `sh` first (and only) in PATH so updateCLI can never
+// reach the network or run the real installer. The stub records its args and
+// exits with the given code.
+func stubShell(t *testing.T, exitCode string) (argsFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	argsFile = filepath.Join(dir, "args.txt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\nexit " + exitCode + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "sh"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	return argsFile
+}
+
+func TestUpdateCLIRunsInstaller(t *testing.T) {
+	argsFile := stubShell(t, "0")
+
+	var err error
+	out := captureStdout(t, func() { err = updateCLI() })
+	if err != nil {
+		t.Fatalf("update with a succeeding installer: %v", err)
+	}
+	if !strings.Contains(out, "whip updated") {
+		t.Errorf("success message missing:\n%s", out)
+	}
+	args, rerr := os.ReadFile(argsFile)
+	if rerr != nil {
+		t.Fatalf("stub sh never ran: %v", rerr)
+	}
+	if !strings.Contains(string(args), installURL) {
+		t.Errorf("installer command should pipe %s, got %q", installURL, args)
+	}
+}
+
+func TestUpdateCLIInstallerFails(t *testing.T) {
+	stubShell(t, "3")
+
+	var err error
+	out := captureStdout(t, func() { err = updateCLI() })
+	if err == nil || !strings.Contains(err.Error(), "update failed") {
+		t.Fatalf("a failing installer should surface as an update error, got %v", err)
+	}
+	if strings.Contains(out, "whip updated") {
+		t.Errorf("failure must not claim success:\n%s", out)
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -687,6 +687,178 @@ func TestCompactKeepsToolCallPair(t *testing.T) {
 	}
 }
 
+// SteerImages queues a multimodal user message: the turn continues past it
+// and the injected message carries both the text and the image parts.
+func TestSteerImagesInjectsParts(t *testing.T) {
+	srv := textServer(t, func(n int, req llm.Request) string {
+		if n == 2 {
+			return "ok2"
+		}
+		return "ok1"
+	})
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.SteerImages("see the screenshot", []llm.ContentPart{llm.ImagePart("png", []byte("img-bytes"))})
+	final, err := ag.Turn(context.Background(), "go", Events{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final != "ok2" {
+		t.Fatalf("turn should continue after the steered images, got %q", final)
+	}
+	var steered *llm.Message
+	for i := range ag.Messages {
+		if ag.Messages[i].Role == "user" && ag.Messages[i].Content == "see the screenshot" {
+			steered = &ag.Messages[i]
+		}
+	}
+	if steered == nil {
+		t.Fatal("steered message not in the conversation")
+	}
+	if len(steered.Parts) != 1 || steered.Parts[0].Type != "image_url" {
+		t.Fatalf("steered message should carry the image part: %+v", steered.Parts)
+	}
+}
+
+// AppendUser adds an unauthored user message outside a turn (the `!` shell
+// escape path).
+func TestAppendUser(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag.AppendUser("shell output: ok")
+	last := ag.Messages[len(ag.Messages)-1]
+	if last.Role != "user" || last.Content != "shell output: ok" {
+		t.Fatalf("appended message: %+v", last)
+	}
+	if last.Authored {
+		t.Error("shared shell output is not an authored message")
+	}
+}
+
+// SetUsage seeds a resumed session's totals so AddUsage keeps counting from
+// there; ResetUsage zeroes them for /clear.
+func TestSetAndResetUsage(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag.SetUsage(llm.Usage{PromptTokens: 11, CompletionTokens: 7})
+	ag.AddUsage(llm.Usage{PromptTokens: 4, CompletionTokens: 1})
+	if u := ag.Usage(); u.PromptTokens != 15 || u.CompletionTokens != 8 {
+		t.Fatalf("seeded totals should keep counting: %+v", u)
+	}
+	ag.ResetUsage()
+	if u := ag.Usage(); u.PromptTokens != 0 || u.CompletionTokens != 0 || u.Cached() != 0 {
+		t.Fatalf("reset should zero the totals: %+v", u)
+	}
+}
+
+// TurnWithImages is an authored submission carrying vision parts.
+func TestTurnWithImagesMarksAuthoredAndCarriesParts(t *testing.T) {
+	srv := textServer(t, func(n int, req llm.Request) string { return "done" })
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	parts := []llm.ContentPart{llm.ImagePart("png", []byte("shot"))}
+	final, err := ag.TurnWithImages(context.Background(), "what's in this image?", parts, Events{})
+	if err != nil || final != "done" {
+		t.Fatalf("%q %v", final, err)
+	}
+	user := ag.Messages[1]
+	if !user.Authored || user.SentAt == nil {
+		t.Errorf("an image submission is authored and timestamped: %+v", user)
+	}
+	if len(user.Parts) != 1 || user.Parts[0].Type != "image_url" {
+		t.Errorf("image parts lost: %+v", user.Parts)
+	}
+}
+
+// SetMCPTools makes the MCP set visible via AllTools and installs the
+// tools.Suggester, so a typo'd mcp__ call gets a "did you mean?" nudge.
+func TestSetMCPToolsInstallsSuggester(t *testing.T) {
+	orig := tools.Suggester
+	tools.Suggester = nil
+	t.Cleanup(func() { tools.Suggester = orig })
+
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	mt := tools.Tool{Def: llm.NewTool("mcp__srv__hello", "h", `{"type":"object"}`)}
+	ag.SetMCPTools([]tools.Tool{mt})
+
+	var found bool
+	for _, tl := range ag.AllTools() {
+		if tl.Def.Function.Name == "mcp__srv__hello" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("MCP tool missing from AllTools")
+	}
+	if tools.Suggester == nil {
+		t.Fatal("SetMCPTools should install the suggester")
+	}
+	// a near-miss call self-corrects through Execute's unknown-tool path
+	out := tools.Execute(context.Background(), ag.AllTools(), "mcp__srv__helo", json.RawMessage(`{}`))
+	if !strings.Contains(out, "did you mean") || !strings.Contains(out, "mcp__srv__hello") {
+		t.Fatalf("typo'd MCP call should suggest the live name, got %q", out)
+	}
+}
+
+// GoalFromContextMessages windows the conversation tail, never including the
+// system prompt, defaulting and clamping n.
+func TestGoalFromContextMessages(t *testing.T) {
+	if _, err := GoalFromContextMessages(nil, 0); err == nil {
+		t.Error("empty history should error")
+	}
+	sys := llm.Message{Role: "system", Content: "sys"}
+	if _, err := GoalFromContextMessages([]llm.Message{sys, {Role: "user", Content: "u"}}, 0); err == nil {
+		t.Error("a single message is not enough context")
+	}
+
+	msgs := []llm.Message{sys}
+	for i := range 12 {
+		msgs = append(msgs, llm.Message{Role: "user", Content: fmt.Sprintf("m%d", i)})
+	}
+	tail, err := GoalFromContextMessages(msgs, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tail) != GoalFromContextDefaultWindow || tail[0].Content != "m4" || tail[len(tail)-1].Content != "m11" {
+		t.Fatalf("default window wrong: %+v", tail)
+	}
+	if tail, _ = GoalFromContextMessages(msgs, 3); len(tail) != 3 || tail[0].Content != "m9" {
+		t.Fatalf("explicit window wrong: %+v", tail)
+	}
+	tail, err = GoalFromContextMessages(msgs, 100)
+	if err != nil || len(tail) != 12 {
+		t.Fatalf("oversized n should clamp to the conversation: %d %v", len(tail), err)
+	}
+	if tail[0].Role == "system" {
+		t.Error("the system prompt must never be in the goal window")
+	}
+}
+
+// BuildGoalFromContextPrompt renders the tail as a transcript inside the
+// goal-formulation instructions.
+func TestBuildGoalFromContextPrompt(t *testing.T) {
+	var tc llm.ToolCall
+	tc.Function.Name = "bash"
+	tc.Function.Arguments = `{"command":"go test"}`
+	tail := []llm.Message{
+		{Role: "user", Content: "fix the flaky test"},
+		{Role: "assistant", Content: "working on internal/foo", ToolCalls: []llm.ToolCall{tc}},
+		{Role: "tool", Content: "exit 1"},
+	}
+	p := BuildGoalFromContextPrompt(tail)
+	for _, want := range []string{
+		"user: fix the flaky test",
+		"assistant: working on internal/foo",
+		"assistant called bash(",
+		"tool result: exit 1",
+		"Write the goal now.",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("goal prompt missing %q:\n%s", want, p)
+		}
+	}
+}
+
 func TestManualCompactFiresEvent(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"choices":[{"message":{"content":"sim"}}]}`))

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools"
+)
+
+// SetSessionID gates the session memory scope: before it, remember(scope:
+// session) errors; after it, entries land in the per-session markdown file.
+func TestMemoryToolsSessionScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ctx := context.Background()
+
+	out := tools.Execute(ctx, ag.Tools, "remember", json.RawMessage(`{"text":"x","scope":"session"}`))
+	if !strings.Contains(out, "no session yet") {
+		t.Fatalf("session scope without a session id should refuse: %q", out)
+	}
+	out = tools.Execute(ctx, ag.Tools, "remember", json.RawMessage(`{"text":"x","scope":"bogus"}`))
+	if !strings.Contains(out, "scope must be") {
+		t.Fatalf("unknown scope should refuse: %q", out)
+	}
+
+	ag.SetSessionID("sess1")
+	out = tools.Execute(ctx, ag.Tools, "remember", json.RawMessage(`{"text":"always pnpm, never npm","scope":"session"}`))
+	if out != "Remembered (session memory)." {
+		t.Fatalf("remember after SetSessionID: %q", out)
+	}
+	path := filepath.Join(home, "sessions", "sess1.memory.md")
+	data, err := os.ReadFile(path)
+	if err != nil || !strings.Contains(string(data), "always pnpm, never npm") {
+		t.Fatalf("session memory file should hold the entry: %v %q", err, data)
+	}
+
+	// forget strikes the entry ("- [x]") instead of deleting it
+	out = tools.Execute(ctx, ag.Tools, "forget", json.RawMessage(`{"n":1,"scope":"session"}`))
+	if !strings.Contains(out, "Forgot entry 1") {
+		t.Fatalf("forget: %q", out)
+	}
+	data, _ = os.ReadFile(path)
+	if !strings.Contains(string(data), "- [x]") || !strings.Contains(string(data), "always pnpm") {
+		t.Fatalf("forget should strike, not delete: %q", data)
+	}
+
+	// default scope is installation, independent of the session id
+	out = tools.Execute(ctx, ag.Tools, "remember", json.RawMessage(`{"text":"likes go"}`))
+	if out != "Remembered (installation memory)." {
+		t.Fatalf("default scope: %q", out)
+	}
+	data, err = os.ReadFile(filepath.Join(home, "memory.md"))
+	if err != nil || !strings.Contains(string(data), "likes go") {
+		t.Fatalf("installation memory file: %v %q", err, data)
+	}
+}

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -266,6 +266,57 @@ func TestClearSettledKeepsRunning(t *testing.T) {
 	}
 }
 
+// The global lock (bash) admits one holder at a time: a second acquire
+// blocks until the first releases.
+func TestAcquireGlobalSerializes(t *testing.T) {
+	f := newFileLocks()
+	release := f.acquireGlobal()
+
+	acquired := make(chan struct{})
+	go func() {
+		r2 := f.acquireGlobal()
+		close(acquired)
+		r2()
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("second global acquire should block while the first holds it")
+	case <-time.After(50 * time.Millisecond):
+	}
+	release()
+	select {
+	case <-acquired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("release never unblocked the waiter")
+	}
+}
+
+// SetSessionID publishes (and clears) the session tasks record against, and
+// settle hands that id to OnRecord.
+func TestRegistrySessionID(t *testing.T) {
+	r := newTaskRegistry()
+	if got := r.recordSession(); got != "" {
+		t.Fatalf("fresh registry session: %q", got)
+	}
+	r.SetSessionID("s1")
+	if got := r.recordSession(); got != "s1" {
+		t.Fatalf("after set: %q", got)
+	}
+	r.SetSessionID("") // /clear and /fork
+	if got := r.recordSession(); got != "" {
+		t.Fatalf("after clear: %q", got)
+	}
+
+	var recorded string
+	r.OnRecord = func(id string, _ *BackgroundTask) { recorded = id }
+	r.SetSessionID("s2")
+	r.tasks["task-1"] = &BackgroundTask{ID: "task-1", Status: TaskRunning, Done: make(chan struct{})}
+	r.settle("task-1", TaskDone, "report")
+	if recorded != "s2" {
+		t.Fatalf("settle should record against the published session, got %q", recorded)
+	}
+}
+
 func TestCanonicalPathKey(t *testing.T) {
 	a := canonicalPathKey("foo/../bar/baz.go")
 	b := canonicalPathKey("bar/baz.go")

--- a/internal/computer/computer_test.go
+++ b/internal/computer/computer_test.go
@@ -65,3 +65,71 @@ func TestChromeTabsParse(t *testing.T) {
 		t.Fatalf("separator parse: %v", f)
 	}
 }
+
+// On non-macOS every osascript-tier entry point must fail with
+// ErrUnsupportedPlatform (the platform gate fires before any exec).
+func TestUnsupportedPlatform(t *testing.T) {
+	if Available() {
+		t.Skip("darwin: osascript tier would drive the real desktop")
+	}
+	if _, err := osascript(`return "x"`); !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Errorf("osascript: %v", err)
+	}
+	if _, err := Tell("Finder", "activate"); !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Errorf("Tell: %v", err)
+	}
+	calls := map[string]error{}
+	_, _, calls["ChromeActive"] = ChromeActive()
+	_, calls["ChromeTabs"] = ChromeTabs()
+	calls["ChromeGoto"] = ChromeGoto("https://example.com")
+	calls["ChromeNewTab"] = ChromeNewTab("https://example.com")
+	calls["ChromeActivateTab"] = ChromeActivateTab(1, 2)
+	calls["ChromeCloseTab"] = ChromeCloseTab(1, 2)
+	calls["ChromeBack"] = ChromeBack()
+	calls["ChromeReload"] = ChromeReload()
+	_, calls["ChromeFindTab"] = ChromeFindTab("example")
+	_, calls["ChromeState"] = ChromeState()
+	for name, err := range calls {
+		if !errors.Is(err, ErrUnsupportedPlatform) {
+			t.Errorf("%s: want ErrUnsupportedPlatform, got %v", name, err)
+		}
+	}
+	// The platform error must NOT be rewritten to the Chrome-toggle guidance.
+	if _, err := ChromeJS("1+1"); !errors.Is(err, ErrUnsupportedPlatform) || errors.Is(err, ErrJSFromAppleEvents) {
+		t.Errorf("ChromeJS: %v", err)
+	}
+	if _, err := ensureHelperBinary(); !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Errorf("ensureHelperBinary: %v", err)
+	}
+}
+
+func TestPolicyDenyAndSummary(t *testing.T) {
+	p := NewPolicy([]string{"Google Chrome"}, nil, false)
+	if got := p.Summary(); got != "google chrome" {
+		t.Errorf("Summary: %q", got)
+	}
+	p.Approve("Safari")
+	if got := p.Summary(); !strings.Contains(got, "google chrome") || !strings.Contains(got, "safari (session)") {
+		t.Errorf("Summary with session approval: %q", got)
+	}
+	// Deny blocks for the session and revokes a session approval.
+	p.Deny("Safari")
+	if err := p.Check("Safari"); err == nil || !strings.Contains(err.Error(), "policy") {
+		t.Errorf("session-denied app must fail: %v", err)
+	}
+	// Approve clears a session deny again.
+	p.Approve("Safari")
+	if err := p.Check("Safari"); err != nil {
+		t.Errorf("re-approval must unblock: %v", err)
+	}
+	if got := NewPolicy(nil, nil, true).Summary(); got != "none" {
+		t.Errorf("empty Summary: %q", got)
+	}
+}
+
+func TestApprovalNeededError(t *testing.T) {
+	e := &ApprovalNeeded{App: "Safari"}
+	if !strings.Contains(e.Error(), `"Safari"`) || !strings.Contains(e.Error(), "computer.allow") {
+		t.Errorf("ApprovalNeeded.Error: %q", e.Error())
+	}
+}

--- a/internal/computer/helper_test.go
+++ b/internal/computer/helper_test.go
@@ -179,3 +179,67 @@ func TestCrashRestart(t *testing.T) {
 		t.Fatalf("post-restart call: %v", err)
 	}
 }
+
+func TestSharedSpawnCacheAndReset(t *testing.T) {
+	// fakeHelper builds the fake and points WHIP_COMPUTER_BIN at it.
+	fakeHelper(t, "").kill()
+	ResetShared()
+	t.Cleanup(ResetShared)
+	h1, err := Shared()
+	if err != nil {
+		t.Fatalf("Shared: %v", err)
+	}
+	h2, err := Shared()
+	if err != nil || h2 != h1 {
+		t.Fatalf("Shared must cache the helper: %v %p %p", err, h1, h2)
+	}
+	var out map[string]any
+	if err := h1.Call(context.Background(), "ping", nil, &out); err != nil {
+		t.Fatalf("shared helper call: %v", err)
+	}
+	ResetShared()
+	h3, err := Shared()
+	if err != nil {
+		t.Fatalf("Shared after reset: %v", err)
+	}
+	if h3 == h1 {
+		t.Fatal("ResetShared must drop the cached helper")
+	}
+}
+
+func TestSharedCachesSpawnError(t *testing.T) {
+	t.Setenv("WHIP_COMPUTER_BIN", filepath.Join(t.TempDir(), "does-not-exist"))
+	ResetShared()
+	t.Cleanup(ResetShared)
+	_, err1 := Shared()
+	if err1 == nil {
+		t.Fatal("Shared must fail for a missing binary")
+	}
+	_, err2 := Shared()
+	if !errors.Is(err2, err1) {
+		t.Fatalf("spawn error must be cached, got %v then %v", err1, err2)
+	}
+}
+
+func TestScreenshotDecode(t *testing.T) {
+	var nilShot *Screenshot
+	if b, err := nilShot.Decode(); b != nil || err != nil {
+		t.Errorf("nil screenshot: %v %v", b, err)
+	}
+	if b, err := (&Screenshot{}).Decode(); b != nil || err != nil {
+		t.Errorf("empty screenshot: %v %v", b, err)
+	}
+	b, err := (&Screenshot{JPEGBase64: "aGVsbG8="}).Decode()
+	if err != nil || string(b) != "hello" {
+		t.Errorf("decode: %q %v", b, err)
+	}
+	if _, err := (&Screenshot{JPEGBase64: "!!!"}).Decode(); err == nil {
+		t.Error("bad base64 must error")
+	}
+}
+
+func TestStaleErrorMessage(t *testing.T) {
+	if got := (&StaleError{Msg: "state changed"}).Error(); got != "state changed" {
+		t.Errorf("StaleError.Error: %q", got)
+	}
+}

--- a/internal/config/catalog_test.go
+++ b/internal/config/catalog_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestCatalogPricing(t *testing.T) {
 	cat := Catalog{Models: []ModelInfoLite{
@@ -31,5 +34,39 @@ func TestCatalogPricingRoundTrip(t *testing.T) {
 	in, out, cr, ok := got["p"].Pricing("m")
 	if !ok || in != 1e-6 || out != 5e-6 || cr != 1e-7 {
 		t.Fatalf("round-trip: %v %v %v ok=%v", in, out, cr, ok)
+	}
+}
+
+func TestCatalogStale(t *testing.T) {
+	if (Catalog{FetchedAt: time.Now()}).Stale() {
+		t.Fatal("just-fetched catalog must be fresh")
+	}
+	if !(Catalog{FetchedAt: time.Now().Add(-25 * time.Hour)}).Stale() {
+		t.Fatal("day-old catalog must be stale")
+	}
+	if !(Catalog{}).Stale() {
+		t.Fatal("zero-value catalog must be stale")
+	}
+}
+
+func TestCatalogSupportsVision(t *testing.T) {
+	cat := Catalog{Models: []ModelInfoLite{
+		{ID: "vision", InputModalities: []string{"text", "image"}},
+		{ID: "textonly", InputModalities: []string{"text"}},
+		{ID: "unadvertised"},
+	}}
+	cases := []struct {
+		id            string
+		vision, found bool
+	}{
+		{"vision", true, true},
+		{"textonly", false, true},
+		{"unadvertised", false, false}, // no modalities -> caller falls back
+		{"missing", false, false},
+	}
+	for _, c := range cases {
+		if v, f := cat.SupportsVision(c.id); v != c.vision || f != c.found {
+			t.Errorf("SupportsVision(%q) = %v,%v; want %v,%v", c.id, v, f, c.vision, c.found)
+		}
 	}
 }

--- a/internal/config/jsonc_test.go
+++ b/internal/config/jsonc_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestReadWriteJSONRoundTrip(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	type state struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	if err := WriteJSON("state.json", state{Name: "abe", Count: 3}); err != nil {
+		t.Fatal(err)
+	}
+	var got state
+	if err := ReadJSON("state.json", &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "abe" || got.Count != 3 {
+		t.Fatalf("round-trip = %+v", got)
+	}
+}
+
+func TestReadJSONMissingFileErrors(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	var v map[string]any
+	if err := ReadJSON("nope.json", &v); err == nil {
+		t.Fatal("missing file should be an error the caller treats as empty")
+	}
+}

--- a/internal/config/trust_test.go
+++ b/internal/config/trust_test.go
@@ -32,3 +32,33 @@ func TestTrustRoundTrip(t *testing.T) {
 		t.Fatalf("trusted.json missing: %v", err)
 	}
 }
+
+func TestTrustMergesIntoExistingFile(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := Trust("/first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Trust("/second"); err != nil { // must merge, not clobber
+		t.Fatal(err)
+	}
+	if !Trusted("/first") || !Trusted("/second") {
+		t.Fatal("both paths should stay trusted")
+	}
+}
+
+func TestTrustRecoversFromNullPaths(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	home, err := Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "trusted.json"), []byte(`{"paths":null}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Trust("/rescued"); err != nil {
+		t.Fatal(err)
+	}
+	if !Trusted("/rescued") {
+		t.Fatal("trust over a null paths map should still record")
+	}
+}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,7 +1,9 @@
 package llm
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -367,5 +369,88 @@ func TestSessionCost(t *testing.T) {
 		if got := SessionCost(c.u, c.in, c.out, c.cacheRead); math.Abs(got-c.want) > 1e-12 {
 			t.Errorf("%s: SessionCost = %v, want %v", c.name, got, c.want)
 		}
+	}
+}
+
+func TestImagePart(t *testing.T) {
+	data := []byte{0x89, 'P', 'N', 'G'}
+	p := ImagePart("png", data)
+	if p.Type != "image_url" || p.ImageURL == nil {
+		t.Fatalf("part = %+v", p)
+	}
+	wantPrefix := "data:image/png;base64,"
+	if !strings.HasPrefix(p.ImageURL.URL, wantPrefix) {
+		t.Fatalf("URL = %q", p.ImageURL.URL)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(p.ImageURL.URL, wantPrefix))
+	if err != nil || !bytes.Equal(decoded, data) {
+		t.Fatalf("payload round-trip = %q, %v", decoded, err)
+	}
+	// jpg must be normalized to the real MIME type
+	if jp := ImagePart("jpg", data); !strings.HasPrefix(jp.ImageURL.URL, "data:image/jpeg;base64,") {
+		t.Fatalf("jpg URL = %q", jp.ImageURL.URL)
+	}
+}
+
+func TestModelInfoSupportsVision(t *testing.T) {
+	if !(ModelInfo{InputModalities: []string{"text", "image"}}).SupportsVision() {
+		t.Error("image modality should report vision")
+	}
+	if (ModelInfo{InputModalities: []string{"text"}}).SupportsVision() {
+		t.Error("text-only model should not report vision")
+	}
+	if (ModelInfo{}).SupportsVision() {
+		t.Error("nil modalities should not report vision")
+	}
+}
+
+func TestMessageJSONMultimodalRoundTrip(t *testing.T) {
+	m := Message{Role: "user", Content: "look at this", Parts: []ContentPart{ImagePart("png", []byte("img"))}}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// wire form: content array with the text part first, then the image
+	var wire struct {
+		Content []ContentPart `json:"content"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if len(wire.Content) != 2 || wire.Content[0].Type != "text" || wire.Content[0].Text != "look at this" || wire.Content[1].Type != "image_url" {
+		t.Fatalf("wire content = %+v", wire.Content)
+	}
+
+	var back Message
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Content != "look at this" || len(back.Parts) != 1 || back.Parts[0].ImageURL.URL != m.Parts[0].ImageURL.URL {
+		t.Fatalf("round-trip = %+v", back)
+	}
+	if back.TextContent() != "look at this" {
+		t.Fatalf("TextContent = %q", back.TextContent())
+	}
+}
+
+func TestMessageUnmarshalPlainString(t *testing.T) {
+	var m Message
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"hi","model":"m @ p"}`), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.Role != "assistant" || m.Content != "hi" || m.Model != "m @ p" {
+		t.Fatalf("m = %+v", m)
+	}
+	// null / absent content is fine (tool-call-only assistant messages)
+	var empty Message
+	if err := json.Unmarshal([]byte(`{"role":"assistant"}`), &empty); err != nil {
+		t.Fatal(err)
+	}
+	if empty.Content != "" {
+		t.Fatalf("empty content = %q", empty.Content)
+	}
+	// malformed content shape must error, not vanish silently
+	if err := json.Unmarshal([]byte(`{"role":"user","content":42}`), &m); err == nil {
+		t.Fatal("numeric content should error")
 	}
 }

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -106,3 +106,10 @@ func TestServerRequestsGetNullAck(t *testing.T) {
 		t.Fatal("no ack for server request")
 	}
 }
+
+func TestRPCErrorMessage(t *testing.T) {
+	err := &rpcError{Code: -32601, Message: "method not found"}
+	if got := err.Error(); got != "rpc error -32601: method not found" {
+		t.Fatalf("Error() = %q", got)
+	}
+}

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -440,3 +440,23 @@ func TestValidAndDefaults(t *testing.T) {
 		t.Error("command+url should be invalid")
 	}
 }
+
+func TestDefaultCodexPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if got, want := defaultCodexPath(), filepath.Join(home, ".codex", "config.toml"); got != want {
+		t.Fatalf("defaultCodexPath() = %q, want %q", got, want)
+	}
+}
+
+func TestToInt(t *testing.T) {
+	if n, ok := toInt(int64(7)); !ok || n != 7 {
+		t.Errorf("toInt(int64) = %d, %v", n, ok)
+	}
+	if n, ok := toInt(float64(30)); !ok || n != 30 {
+		t.Errorf("toInt(float64) = %d, %v", n, ok)
+	}
+	if _, ok := toInt("30"); ok {
+		t.Error("toInt(string) should be !ok")
+	}
+}

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -494,7 +494,10 @@ func TestServerInstructions(t *testing.T) {
 	deadline = time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		s.mu.Lock()
-		terminal := s.status == StatusReady || (s.status == StatusFailed && s.autoTries >= autoReconnectMax)
+		// Ready is only terminal with a live session: the drop watcher clears
+		// sess/instr under s.mu before it flips status to Failed, so a bare
+		// Ready can be a transient pre-Failed window.
+		terminal := (s.status == StatusReady && s.sess != nil) || (s.status == StatusFailed && s.autoTries >= autoReconnectMax)
 		s.mu.Unlock()
 		if terminal {
 			break
@@ -540,5 +543,32 @@ func TestProbe(t *testing.T) {
 	}
 	if res.Elapsed > 15*time.Second {
 		t.Errorf("probe blew far past the startup timeout: %s", res.Elapsed)
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	want := map[Status]string{
+		StatusDisabled:   "disabled",
+		StatusConnecting: "connecting",
+		StatusReady:      "ready",
+		StatusFailed:     "failed",
+		Status(99):       "unknown",
+	}
+	for s, w := range want {
+		if got := s.String(); got != w {
+			t.Errorf("Status(%d).String() = %q, want %q", s, got, w)
+		}
+	}
+}
+
+func TestSetOnChange(t *testing.T) {
+	m := NewManager(nil)
+	m.FireOnChangeForTest() // nil callback must be a no-op, not a panic
+	fired := 0
+	m.SetOnChange(func() { fired++ })
+	m.FireOnChangeForTest()
+	m.FireOnChangeForTest()
+	if fired != 2 {
+		t.Fatalf("callback fired %d times, want 2", fired)
 	}
 }

--- a/internal/mcp/serve_test.go
+++ b/internal/mcp/serve_test.go
@@ -1,0 +1,90 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestServeInProcess drives Serve without a subprocess: Serve's
+// StdioTransport is hardwired to os.Stdin/os.Stdout, so the test swaps both
+// for pipes and speaks MCP through them with the SDK client. The
+// WHIP_TEST_SELFHOST-gated tests cover the real-subprocess path; this one
+// keeps Serve covered in plain CI.
+func TestServeInProcess(t *testing.T) {
+	inR, inW, err := os.Pipe() // server stdin
+	if err != nil {
+		t.Fatal(err)
+	}
+	outR, outW, err := os.Pipe() // server stdout
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldIn, oldOut := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = inR, outW
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- Serve(ctx, "test") }()
+
+	// Restore stdio only after Serve has returned, so the swap can't race
+	// the server's reads under -race.
+	t.Cleanup(func() {
+		cancel()
+		_ = inW.Close()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("Serve did not return after stdin close + cancel")
+		}
+		os.Stdin, os.Stdout = oldIn, oldOut
+	})
+
+	cli := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := cli.Connect(ctx, &sdkmcp.IOTransport{Reader: outR, Writer: inW}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	list, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tool := range list.Tools {
+		names[tool.Name] = true
+	}
+	if len(list.Tools) != 4 || !names["read"] || names["task"] {
+		t.Fatalf("served tools = %v (want whip's 4, task excluded)", names)
+	}
+
+	res, err := cs.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      "read",
+		Arguments: map[string]any{"path": "serve.go", "limit": 3},
+	})
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	txt, ok := res.Content[0].(*sdkmcp.TextContent)
+	if !ok || !strings.Contains(txt.Text, "package mcp") {
+		t.Fatalf("read via MCP = %#v", res.Content)
+	}
+
+	// Tool errors must come back as tool output, not protocol failures.
+	res, err = cs.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      "read",
+		Arguments: map[string]any{"path": "does-not-exist.xyz"},
+	})
+	if err != nil {
+		t.Fatalf("failing tool call should not be a protocol error: %v", err)
+	}
+	txt, ok = res.Content[0].(*sdkmcp.TextContent)
+	if !ok || !strings.HasPrefix(txt.Text, "Error: ") {
+		t.Fatalf("tool error surfaced as %#v", res.Content)
+	}
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -94,3 +94,47 @@ func TestForgetPreservesUserProse(t *testing.T) {
 		t.Fatalf("hand-written prose must survive:\n%s", data)
 	}
 }
+
+// Scope constructors resolve under the whip home (WHIP_HOME overrides it).
+func TestScopeConstructors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+
+	inst := Installation()
+	if inst.Path != filepath.Join(home, "memory.md") || inst.Name != "installation" {
+		t.Fatalf("Installation() = %+v", inst)
+	}
+	sess := Session("abcd1234")
+	if sess.Path != filepath.Join(home, "sessions", "abcd1234.memory.md") || sess.Name != "session" {
+		t.Fatalf("Session() = %+v", sess)
+	}
+	// no session id yet → the zero scope, which rejects writes and reads empty
+	zero := Session("")
+	if zero != (Scope{}) {
+		t.Fatalf("Session(\"\") = %+v, want zero scope", zero)
+	}
+	if got := zero.Entries(); got != nil {
+		t.Fatalf("zero scope should read empty, got %v", got)
+	}
+	if err := zero.Remember("x"); err == nil {
+		t.Fatal("remember on the zero scope should error")
+	}
+	if err := zero.Forget(1); err == nil {
+		t.Fatal("forget on the zero scope should error")
+	}
+	// constructors and the round-trip compose: remember lands in WHIP_HOME
+	if err := inst.Remember("a fact"); err != nil {
+		t.Fatal(err)
+	}
+	if es := Installation().Entries(); len(es) != 1 || es[0].Text != "a fact" {
+		t.Fatalf("entries via constructor: %+v", es)
+	}
+}
+
+// Forget with no file yet reports "no memories" instead of failing oddly.
+func TestForgetMissingFile(t *testing.T) {
+	s := Scope{Path: filepath.Join(t.TempDir(), "none.md"), Name: "session"}
+	if err := s.Forget(1); err == nil {
+		t.Fatal("forget with no file should error")
+	}
+}

--- a/internal/schedule/schedule_test.go
+++ b/internal/schedule/schedule_test.go
@@ -65,3 +65,13 @@ func TestOneShot(t *testing.T) {
 		t.Fatal("a fired one-shot is done")
 	}
 }
+
+func TestStringAt(t *testing.T) {
+	s, err := Parse("@at 2026-07-26T17:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.String(); got != "@at 2026-07-26T17:00:00Z" {
+		t.Fatalf("String() = %q", got)
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -462,3 +462,188 @@ func TestCompactionEvent(t *testing.T) {
 		t.Fatalf("after deleting the event, raw history should load: %+v", got)
 	}
 }
+
+func TestTodosAndUsagePersistence(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	id, _ := st.Create("/tmp", "m", "p")
+	st.Save(id, 1, []llm.Message{{Role: "system"}, {Role: "user", Content: "q"}}, "m", "p")
+
+	if got := st.Todos(id); got != "" {
+		t.Fatalf("fresh session should have no todos, got %q", got)
+	}
+	plan := `[{"content":"write tests","status":"in_progress"}]`
+	if err := st.SetTodos(id, plan); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.Todos(id); got != plan {
+		t.Fatalf("todos did not round-trip: %q", got)
+	}
+	// whole-list overwrite, and "" clears
+	if err := st.SetTodos(id, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.Todos(id); got != "" {
+		t.Fatalf("todos not cleared: %q", got)
+	}
+	// unknown session reads as empty, never an error
+	if got := st.Todos("nope"); got != "" {
+		t.Fatalf("unknown session todos: %q", got)
+	}
+
+	// usage totals are absolute and survive a reload
+	if err := st.SetUsage(id, 100, 40, 7); err != nil {
+		t.Fatal(err)
+	}
+	meta, _, err := st.Load(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.UsageIn != 100 || meta.UsageCached != 40 || meta.UsageOut != 7 {
+		t.Fatalf("usage did not round-trip: %+v", meta)
+	}
+}
+
+func TestClearMessages(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	id, _ := st.Create("/tmp", "m", "p")
+	st.Save(id, 0, []llm.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q"},
+		{Role: "assistant", Content: "a"},
+	}, "m", "p")
+
+	if err := st.ClearMessages(id); err != nil {
+		t.Fatal(err)
+	}
+	if raw := st.RawMessages(id); len(raw) != 0 {
+		t.Fatalf("messages should be gone, got %d", len(raw))
+	}
+	// the session row survives: Load resolves it, with no messages
+	meta, msgs, err := st.Load(id)
+	if err != nil || meta.ID != id || len(msgs) != 0 {
+		t.Fatalf("session row must survive ClearMessages: %+v %d %v", meta, len(msgs), err)
+	}
+}
+
+func TestSnapshotRoundTrip(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	id, _ := st.Create("/tmp", "m", "p")
+
+	if got := st.Snapshots(id); len(got) != 0 {
+		t.Fatalf("fresh session should have no snapshots, got %v", got)
+	}
+	if err := st.SetSnapshot(id, 1, "stash@{0}"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetSnapshot(id, 3, "stash@{1}"); err != nil {
+		t.Fatal(err)
+	}
+	// same seq replaces
+	if err := st.SetSnapshot(id, 1, "stash@{9}"); err != nil {
+		t.Fatal(err)
+	}
+	got := st.Snapshots(id)
+	if len(got) != 2 || got[1] != "stash@{9}" || got[3] != "stash@{1}" {
+		t.Fatalf("snapshots: %v", got)
+	}
+	// "" deletes one turn's ref
+	if err := st.SetSnapshot(id, 3, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got = st.Snapshots(id); len(got) != 1 || got[1] != "stash@{9}" {
+		t.Fatalf("after delete: %v", got)
+	}
+
+	// DeleteFrom trims snapshots along with messages
+	st.SetSnapshot(id, 5, "stash@{2}")
+	if err := st.DeleteFrom(id, 5); err != nil {
+		t.Fatal(err)
+	}
+	if got = st.Snapshots(id); len(got) != 1 || got[1] != "stash@{9}" {
+		t.Fatalf("DeleteFrom should trim snapshots too: %v", got)
+	}
+
+	// ClearSnapshots drops the rest
+	if err := st.ClearSnapshots(id); err != nil {
+		t.Fatal(err)
+	}
+	if got = st.Snapshots(id); len(got) != 0 {
+		t.Fatalf("ClearSnapshots left rows: %v", got)
+	}
+}
+
+func TestScheduleRoundTrip(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	id, _ := st.Create("/tmp", "m", "p")
+
+	if got := st.Schedules(id); len(got) != 0 {
+		t.Fatalf("fresh session should have no schedules, got %v", got)
+	}
+	anchor := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	id1, err := st.AddSchedule(id, "@every 10m", "check the build", anchor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := st.AddSchedule(id, "@at 2026-01-03T00:00:00Z", "one shot", anchor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id1 != 1 || id2 != 2 {
+		t.Fatalf("ids should increment per session: %d %d", id1, id2)
+	}
+	// ids are per-session: another session starts at 1 again
+	other, _ := st.Create("/tmp", "m", "p")
+	if oid, _ := st.AddSchedule(other, "@every 1h", "p", anchor); oid != 1 {
+		t.Fatalf("other session's first schedule id: %d", oid)
+	}
+
+	scs := st.Schedules(id)
+	if len(scs) != 2 {
+		t.Fatalf("schedules: %+v", scs)
+	}
+	if scs[0].ID != 1 || scs[0].Schedule != "@every 10m" || scs[0].Prompt != "check the build" {
+		t.Fatalf("schedule 1: %+v", scs[0])
+	}
+	if !scs[0].Anchor.Equal(anchor) {
+		t.Fatalf("anchor did not round-trip: %v", scs[0].Anchor)
+	}
+	if !scs[0].LastFire.IsZero() {
+		t.Fatalf("never-fired task should have zero LastFire: %v", scs[0].LastFire)
+	}
+
+	fired := anchor.Add(10 * time.Minute)
+	if err := st.MarkFired(id, id1, fired); err != nil {
+		t.Fatal(err)
+	}
+	scs = st.Schedules(id)
+	if !scs[0].LastFire.Equal(fired) {
+		t.Fatalf("MarkFired did not stamp: %v", scs[0].LastFire)
+	}
+	if !scs[1].LastFire.IsZero() {
+		t.Fatalf("MarkFired touched the wrong row: %+v", scs[1])
+	}
+
+	if err := st.DeleteSchedule(id, id1); err != nil {
+		t.Fatal(err)
+	}
+	scs = st.Schedules(id)
+	if len(scs) != 1 || scs[0].ID != id2 {
+		t.Fatalf("after delete: %+v", scs)
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -51,3 +51,22 @@ func TestScanAndPromptBlock(t *testing.T) {
 		t.Fatalf("spec-legal description must not be truncated")
 	}
 }
+
+// DefaultDirs: project .agents/skills (from the cwd) then user ~/.whip/skills.
+func TestDefaultDirs(t *testing.T) {
+	wd := t.TempDir()
+	home := t.TempDir()
+	t.Chdir(wd)
+	t.Setenv("HOME", home)
+
+	dirs := DefaultDirs()
+	if len(dirs) != 2 {
+		t.Fatalf("DefaultDirs() = %v", dirs)
+	}
+	if dirs[0] != filepath.Join(wd, ".agents", "skills") {
+		t.Fatalf("project dir: %q", dirs[0])
+	}
+	if dirs[1] != filepath.Join(home, ".whip", "skills") {
+		t.Fatalf("user dir: %q", dirs[1])
+	}
+}

--- a/internal/tools/bashrun/bashrun_test.go
+++ b/internal/tools/bashrun/bashrun_test.go
@@ -192,3 +192,24 @@ func TestUserShellResolution(t *testing.T) {
 		t.Fatalf("run via user shell: %+v", res)
 	}
 }
+
+func TestKeyBytes(t *testing.T) {
+	cases := map[string]string{
+		"enter":     KeyEnter,
+		"esc":       KeyEsc,
+		"tab":       KeyTab,
+		"backspace": KeyBS,
+		"delete":    KeyBS,
+		"up":        KeyUp,
+		"down":      KeyDown,
+		"right":     KeyRight,
+		"left":      KeyLeft,
+		"bogus":     "",
+		"":          "",
+	}
+	for name, want := range cases {
+		if got := KeyBytes(name); got != want {
+			t.Errorf("KeyBytes(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/internal/tools/browser_lang_test.go
+++ b/internal/tools/browser_lang_test.go
@@ -85,3 +85,13 @@ func TestBrowserExecNoManager(t *testing.T) {
 		t.Fatalf("want error string, got %q", out)
 	}
 }
+
+func TestHelperStmtString(t *testing.T) {
+	prog, err := parseHelperProgram(`goto("https://example.com")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := prog[0].String(); got != `goto("https://example.com")` {
+		t.Errorf("String must return the raw statement text: %q", got)
+	}
+}

--- a/internal/tools/computer_test.go
+++ b/internal/tools/computer_test.go
@@ -1,6 +1,10 @@
 package tools
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -48,5 +52,298 @@ func TestGateApp(t *testing.T) {
 	ComputerApprover = nil
 	if err := gateApp("Safari"); err != nil {
 		t.Errorf("approval must persist for the session: %v", err)
+	}
+}
+
+func TestIsStale(t *testing.T) {
+	if !IsStale(&computer.StaleError{Msg: "state changed"}) {
+		t.Error("StaleError must be stale")
+	}
+	if IsStale(errors.New("other")) || IsStale(nil) {
+		t.Error("non-stale errors must not be stale")
+	}
+}
+
+func TestShorten(t *testing.T) {
+	if got := shorten("short", 10); got != "short" {
+		t.Errorf("shorten under limit: %q", got)
+	}
+	if got := shorten("abcdefghij", 5); got != "abcd…" {
+		t.Errorf("shorten over limit: %q", got)
+	}
+}
+
+func TestGenerations(t *testing.T) {
+	noteGeneration("GenApp", &computer.AppState{Generation: 7})
+	if got := genFor("genapp"); got != 7 { // case-insensitive
+		t.Errorf("genFor: %d", got)
+	}
+	noteGeneration("GenApp", nil) // nil state is a no-op
+	if got := genFor("GenApp"); got != 7 {
+		t.Errorf("genFor after nil note: %d", got)
+	}
+	if got := genFor("NeverSeen"); got != 0 {
+		t.Errorf("unknown app gen: %d", got)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	st := &computer.AppState{
+		Generation: 3,
+		App:        "TextEdit",
+		Elements: []computer.AXElement{{
+			Index: 0, Role: "AXButton", Title: "OK", Value: "v", Desc: "d",
+			Position: []float64{10, 20}, Size: []float64{30, 40}, Focused: true,
+		}},
+		Screenshot: &computer.Screenshot{Bytes: 123},
+	}
+	out := summarize(st)
+	for _, want := range []string{
+		"app=TextEdit generation=3 elements=1",
+		"screenshot: 123 bytes jpeg attached",
+		`[0] AXButton title="OK" value="v" desc="d" at(10,20 30x40) focused`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summarize missing %q in:\n%s", want, out)
+		}
+	}
+	st.Screenshot = &computer.Screenshot{Err: "no grant"}
+	if out := summarize(st); !strings.Contains(out, "screenshot: unavailable (no grant)") {
+		t.Errorf("summarize screenshot error: %s", out)
+	}
+}
+
+// withComputerPolicy swaps in a policy for the test.
+func withComputerPolicy(t *testing.T, p *computer.Policy) {
+	t.Helper()
+	oldP, oldA := ComputerPolicy, ComputerApprover
+	t.Cleanup(func() { ComputerPolicy, ComputerApprover = oldP, oldA })
+	ComputerPolicy, ComputerApprover = p, nil
+}
+
+// runComputerCode error and gate paths that are portable (no osascript, no
+// helper needed — they fail before touching the platform).
+func TestRunComputerCodePortablePaths(t *testing.T) {
+	withComputerPolicy(t, computer.NewPolicy([]string{"Google Chrome"}, []string{"Finder"}, true))
+	ctx := t.Context()
+
+	if out, err := runComputerCode(ctx, "# label\nprint(\"hi\")"); err != nil || out != "hi\n" {
+		t.Errorf("print: %q %v", out, err)
+	}
+	if out, err := runComputerCode(ctx, `print(42)`); err != nil || out != "42\n" {
+		t.Errorf("print number: %q %v", out, err)
+	}
+	if _, err := runComputerCode(ctx, `frobnicate("x")`); err == nil || !strings.Contains(err.Error(), "unknown helper") {
+		t.Errorf("unknown helper: %v", err)
+	}
+	if _, err := runComputerCode(ctx, `goto("x" `); err == nil {
+		t.Error("parse error must surface")
+	}
+	// Policy: denied app blocks tell() before any AppleScript runs.
+	if _, err := runComputerCode(ctx, `tell("Finder", "activate")`); err == nil || !strings.Contains(err.Error(), "policy") {
+		t.Errorf("denied app: %v", err)
+	}
+	// SSRF floor: chrome_goto to a metadata endpoint is blocked pre-navigation.
+	if _, err := runComputerCode(ctx, `chrome_goto("http://169.254.169.254/latest")`); err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("ssrf block: %v", err)
+	}
+	// Arg validation fires before gates or platform calls.
+	if _, err := runComputerCode(ctx, `chrome_js()`); err == nil || !strings.Contains(err.Error(), "missing arg") {
+		t.Errorf("missing arg: %v", err)
+	}
+	if _, err := runComputerCode(ctx, `click("Google Chrome")`); err == nil || !strings.Contains(err.Error(), "click needs") {
+		t.Errorf("click arity: %v", err)
+	}
+	if _, err := runComputerCode(ctx, `chrome_activate("w", 1)`); err == nil || !strings.Contains(err.Error(), "must be a number") {
+		t.Errorf("argNum type check: %v", err)
+	}
+}
+
+// The osascript tier propagates the platform error on non-macOS.
+func TestRunComputerCodeOsascriptTierUnsupported(t *testing.T) {
+	if computer.Available() {
+		t.Skip("darwin: would drive the real Chrome")
+	}
+	withComputerPolicy(t, computer.NewPolicy([]string{"Google Chrome"}, nil, true))
+	ctx := t.Context()
+	for _, code := range []string{
+		`chrome_state()`, `chrome_tabs()`, `chrome_back()`, `chrome_reload()`,
+		`chrome_js("1+1")`, `chrome_find("example")`,
+		`chrome_activate(1, 2)`, `chrome_close(1, 2)`,
+		`chrome_new_tab("http://93.184.216.34/")`, `chrome_goto("http://93.184.216.34/")`,
+		`tell("Google Chrome", "activate")`,
+	} {
+		if _, err := runComputerCode(ctx, code); err == nil || !errors.Is(err, computer.ErrUnsupportedPlatform) {
+			t.Errorf("%s: want ErrUnsupportedPlatform, got %v", code, err)
+		}
+	}
+}
+
+// Without a helper binary, native helpers fail with enable-the-driver guidance.
+func TestHelperUnavailable(t *testing.T) {
+	if computer.Available() {
+		t.Skip("darwin: an embedded helper may exist")
+	}
+	t.Setenv("WHIP_COMPUTER_BIN", "")
+	computer.ResetShared()
+	t.Cleanup(computer.ResetShared)
+	if _, err := helper(); err == nil || !strings.Contains(err.Error(), "whip-computer driver") {
+		t.Errorf("helper: %v", err)
+	}
+	withComputerPolicy(t, computer.NewPolicy([]string{"TestApp"}, nil, true))
+	if _, err := runComputerCode(t.Context(), `apps()`); err == nil || !strings.Contains(err.Error(), "whip-computer driver") {
+		t.Errorf("apps without helper: %v", err)
+	}
+}
+
+// fakeNativeHelper builds a stub whip-computer binary (Go, stdlib-only) that
+// speaks the stdio JSON-RPC protocol with canned responses, and points
+// WHIP_COMPUTER_BIN at it — the same seam internal/computer's tests use.
+func fakeNativeHelper(t *testing.T) {
+	t.Helper()
+	const src = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func reply(enc *json.Encoder, id, result any) {
+	_ = enc.Encode(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+func main() {
+	fmt.Println("whip-computer/1")
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	enc := json.NewEncoder(os.Stdout)
+	state := map[string]any{
+		"generation": 2, "app": "TestApp",
+		"elements": []map[string]any{{"index": 0, "role": "AXButton", "title": "OK", "enabled": true}},
+		"screenshot": map[string]any{"jpegBase64": "aGVsbG8=", "bytes": 5},
+	}
+	for sc.Scan() {
+		var req map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+			continue
+		}
+		id := req["id"]
+		params, _ := req["params"].(map[string]any)
+		switch req["method"] {
+		case "handshake":
+			reply(enc, id, map[string]any{"version": "whip-computer/1"})
+		case "apps":
+			reply(enc, id, []map[string]any{{"name": "Finder", "bundleId": "com.apple.finder", "pid": 1, "active": true}})
+		case "permissions.request":
+			reply(enc, id, map[string]any{"accessibility": true, "screenRecording": true})
+		case "state", "ax":
+			reply(enc, id, state)
+		case "click":
+			// The tool must pass back the generation from the last state read.
+			if g, _ := params["gen"].(float64); g != 2 {
+				_ = enc.Encode(map[string]any{"jsonrpc": "2.0", "id": id, "error": map[string]any{"code": 4, "message": "state changed since generation"}})
+				continue
+			}
+			next := map[string]any{}
+			for k, v := range state {
+				next[k] = v
+			}
+			next["generation"] = 3
+			reply(enc, id, next)
+		case "type":
+			reply(enc, id, map[string]any{"action": "typed", "stateUnavailable": "no AX grant", "hint": "grant it"})
+		case "screenshot":
+			reply(enc, id, map[string]any{"jpegBase64": "aGVsbG8=", "bytes": 5})
+		default:
+			_ = enc.Encode(map[string]any{"jsonrpc": "2.0", "id": id, "error": map[string]any{"code": -32601, "message": "unknown method"}})
+		}
+	}
+}
+`
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-computer")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fakecomputer\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goBin := "go"
+	if out, err := exec.CommandContext(t.Context(), "go", "env", "GOROOT").Output(); err == nil {
+		if cand := filepath.Join(strings.TrimSpace(string(out)), "bin", "go"); fileExists(cand) {
+			goBin = cand
+		}
+	}
+	cmd := exec.CommandContext(t.Context(), goBin, "build", "-o", bin, ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake helper: %v\n%s", err, out)
+	}
+	t.Setenv("WHIP_COMPUTER_BIN", bin)
+	computer.ResetShared()
+	t.Cleanup(computer.ResetShared)
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// The native tier end to end against the fake helper: apps/state read,
+// generation-guarded mutation with folded-in state, the acknowledgement
+// path, screenshots reaching the sink, and the stale-generation error.
+func TestNativeTierWithFakeHelper(t *testing.T) {
+	fakeNativeHelper(t)
+	withComputerPolicy(t, computer.NewPolicy([]string{"TestApp"}, nil, true))
+	var sunk [][]byte
+	oldSink := ScreenshotSink
+	ScreenshotSink = func(jpegs [][]byte) { sunk = jpegs }
+	t.Cleanup(func() { ScreenshotSink = oldSink })
+	ctx := t.Context()
+
+	out, err := runComputerCode(ctx, `print(apps())`)
+	if err != nil || !strings.Contains(out, "com.apple.finder") {
+		t.Fatalf("apps: %q %v", out, err)
+	}
+	out, err = runComputerCode(ctx, `print(permissions())`)
+	if err != nil || !strings.Contains(out, `"accessibility":true`) {
+		t.Fatalf("permissions: %q %v", out, err)
+	}
+
+	// A mutation before any state() read has no generation: the fake rejects
+	// it as stale, and the error surfaces as a StaleError.
+	delete(appGenerations, "testapp")
+	if _, err := runComputerCode(ctx, `click("TestApp", 0)`); !IsStale(err) {
+		t.Fatalf("pre-state click: want stale error, got %v", err)
+	}
+
+	// state() then click(): the tool passes gen=2, gets generation 3 back,
+	// and both calls attach their screenshots.
+	out, err = runComputerCode(ctx, "state(\"TestApp\")\nclick(\"TestApp\", 0)")
+	if err != nil {
+		t.Fatalf("state+click: %v", err)
+	}
+	if !strings.Contains(out, "generation=2") || !strings.Contains(out, "generation=3") {
+		t.Errorf("want fresh state folded into the mutation:\n%s", out)
+	}
+	if !strings.Contains(out, "2 screenshot(s) attached") || len(sunk) != 2 || string(sunk[0]) != "hello" {
+		t.Errorf("screenshot sink: %q, %d shots", out, len(sunk))
+	}
+	if g := genFor("TestApp"); g != 3 {
+		t.Errorf("generation after mutation: %d", g)
+	}
+
+	// Acknowledgement path: the helper can't re-read state, the action's
+	// outcome surfaces verbatim instead of a summary.
+	out, err = runComputerCode(ctx, `type("TestApp", "hi")`)
+	if err != nil || !strings.Contains(out, "typed") || !strings.Contains(out, "no AX grant") {
+		t.Fatalf("ack path: %q %v", out, err)
+	}
+
+	out, err = runComputerCode(ctx, `screenshot("TestApp")`)
+	if err != nil || !strings.Contains(out, "screenshot captured: 5 bytes") {
+		t.Fatalf("screenshot: %q %v", out, err)
 	}
 }

--- a/internal/tools/permission_test.go
+++ b/internal/tools/permission_test.go
@@ -1,0 +1,28 @@
+package tools
+
+import "testing"
+
+func TestCommandRule(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"ls -la", "ls"},
+		{"git checkout main", "git checkout"},
+		{"git", "git"},
+		{"npm run build --watch", "npm run build"},
+		{"docker compose up -d", "docker compose up"},
+		{"git submodule update --init", "git submodule update"},
+		// only the first command of a chain/pipeline is the rule
+		{"git checkout main && rm -rf /", "git checkout"},
+		{"cat foo | grep bar", "cat"},
+		{"echo hi > out.txt", "echo"},
+		{"ls; rm -rf /", "ls"},
+		// leading env assignments are stripped
+		{"FOO=1 BAR=2 git status", "git status"},
+		{"  ", ""},
+		{"FOO=1", ""},
+	}
+	for _, c := range cases {
+		if got := CommandRule(c.in); got != c.want {
+			t.Errorf("CommandRule(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

#13 merged with the coverage gate red. This PR brings the portable package set from **70.6% → 84.3%** total statement coverage (the exact metric CI computes) and ratchets the floor 70% → 80%, per the floor's documented ratchet policy.

## What changed

**Test-only** — no production code is touched. 27 files, all `_test.go` except the floor bump in `ci.yml`/`CONTRIBUTING.md`. All 79 fully-uncovered functions in the portable set are now exercised:

| Package | Before | After |
|---|---|---|
| cmd/whip | 39.7% | 71.7% |
| internal/computer | 47.3% | 78.2% |
| internal/tools | 43.2% | 68.8% |
| internal/session | 73.9% | 87.9% |
| internal/agent | 76.5% | 90.6% |
| internal/memory | 77.6% | 92.1% |
| internal/llm | 82.4% | 93.3% |
| internal/config | 83.5% | 88.6% |
| internal/mcp | 87.0% | 89.6% |
| internal/tools/bashrun | 85.9% | 89.4% |
| internal/lsp | 89.1% | 89.7% |
| internal/schedule | 92.3% | 96.2% |
| internal/skills | 90.5% | 97.6% |

Highlights:
- **session**: snapshot/schedule/todo/usage round-trips through the real SQLite store, including DeleteFrom trimming and per-session schedule id increments.
- **computer + tools**: the native tier runs end-to-end against a fake `whip-computer` binary (existing `WHIP_COMPUTER_BIN` seam), including the generation/staleness guard and screenshot decode; policy deny/re-approval; SSRF block on `chrome_goto`.
- **cmd/whip**: `mcp` add/list/remove/test dispatch, `browser install` into a temp HOME with PATH emptied, `update` through a PATH-stubbed `sh` that records the pipeline — nothing is ever downloaded.
- **mcp**: `Serve` driven in-process over piped stdio with the real SDK client (4 tools, `task` excluded, tool errors as output not protocol failures).
- **agent**: image steering, goal-from-context window/clamp cases, suggest via the did-you-mean path — all over the existing httptest SSE fakes.

Also fixes a **pre-existing shuffle flake**: `TestServerInstructions` treated `StatusReady` as terminal, but the session-drop watcher clears the session before flipping status, so `Ready && instr==""` is a real transient window; the poll now also waits for a live session.

## What stays uncovered, deliberately

Unreachable without adding production seams: darwin-only osascript/Chrome paths behind `runtime.GOOS` gates (CI is linux), `main()` and TTY-gated prompts, `mcpTestCLI`'s real-handshake branches, and DB/`UserHomeDir` fault-injection arms. Each is noted in the test files where relevant.

## Verification

- `go test -race -shuffle=on` with the CI coverage recipe: pass, total 84.3%
- `golangci-lint run ./...`: 0 issues; `gofmt -s -l .`: clean
- Tests are deterministic and portable: no network, tty, Chromium, or macOS APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)