### PR TITLE
test: raise portable-set coverage 84.3% → 93.7%, ratchet floor to 90%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,14 @@ jobs:
             -coverprofile=cover.out -coverpkg="$(echo $PKGS | tr ' ' ',')" $PKGS
 
       # Self-contained coverage floor — no external service or token, so it
-      # works identically on fork PRs. Baseline today is ~84%; the gate fails
+      # works identically on fork PRs. Baseline today is ~93.7%; the gate fails
       # if total statement coverage drops below the floor. Ratchet the floor up
       # over time as coverage improves (don't lower it).
-      - name: coverage floor (80%)
+      - name: coverage floor (90%)
         run: |
           total=$(go tool cover -func=cover.out | awk '/^total:/ {gsub("%","",$3); print $3}')
           echo "total coverage: ${total}%"
-          awk -v t="$total" -v floor=80 'BEGIN { if (t+0 < floor) { printf "coverage %.1f%% is below the %d%% floor\n", t, floor; exit 1 } }'
+          awk -v t="$total" -v floor=90 'BEGIN { if (t+0 < floor) { printf "coverage %.1f%% is below the %d%% floor\n", t, floor; exit 1 } }'
 
       - name: go mod tidy is a no-op
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Two workflows gate pull requests: **ci** and **security**.
 - **go test -race -shuffle=on** — the portable package set (internal/browser
   and internal/tui need a Chromium sandbox / tty that hosted runners don't
   have; they stay local).
-- **coverage floor (80%)** — total statement coverage of the portable set must
+- **coverage floor (90%)** — total statement coverage of the portable set must
   stay at or above the floor. It's a self-contained `go tool cover` check (no
   external service), so it works identically on fork PRs. The floor is a
   ratchet: it only goes up as coverage improves. New code should come with

--- a/cmd/whip/auth_test.go
+++ b/cmd/whip/auth_test.go
@@ -181,4 +181,77 @@ func TestShellRC(t *testing.T) {
 			t.Errorf("SHELL=%q: got %q, want %q", c.shell, got, c.want)
 		}
 	}
+
+	// no home directory: nothing to append to, whatever the shell is
+	t.Setenv("HOME", "")
+	t.Setenv("SHELL", "/bin/zsh")
+	if got := shellRC(); got != "" {
+		t.Errorf("without a home directory shellRC should be empty, got %q", got)
+	}
+}
+
+// withStdin replaces os.Stdin with a pipe holding data for the test.
+func withStdin(t *testing.T, data string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = old; r.Close() })
+}
+
+// An unparseable flag fails before anything is read or written, and an empty
+// answer at the prompt reports the missing key rather than calling the API.
+func TestAuthOpenRouterCLIArgs(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	t.Setenv(config.OpenRouterEnvVar, "")
+
+	if err := authOpenRouterCLI([]string{"-nosuchflag"}); err == nil {
+		t.Error("an unknown flag should error")
+	}
+
+	withStdin(t, "\n") // prompt answered with a bare newline
+	err := authCLI([]string{"openrouter"})
+	if err == nil || !strings.Contains(err.Error(), "no API key provided") {
+		t.Errorf("an empty key should be reported, got %v", err)
+	}
+	if cfg, lerr := config.Load(); lerr == nil {
+		if _, ok := cfg.Providers["openrouter"]; ok {
+			t.Error("an empty key must not write a provider entry")
+		}
+	}
+}
+
+// A valid key still fails cleanly when the config can't be read, and nothing
+// is written.
+func TestAuthOpenRouterUnreadableConfig(t *testing.T) {
+	srv := fakeOpenRouter(t, "sk-or-good")
+	defer srv.Close()
+	unusableHome(t)
+
+	if err := authOpenRouter(srv.URL, "sk-or-good", false); err == nil {
+		t.Error("an unusable config dir should surface as an error")
+	}
+}
+
+// A validated key that can't be persisted is an error, not a silent no-op.
+func TestAuthOpenRouterUnwritableConfig(t *testing.T) {
+	srv := fakeOpenRouter(t, "sk-or-good")
+	defer srv.Close()
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+	if _, err := config.Load(); err != nil { // materialize the default config
+		t.Fatal(err)
+	}
+	freezeHome(t, home)
+
+	if err := authOpenRouter(srv.URL, "sk-or-good", false); err == nil {
+		t.Error("an unwritable config dir should surface as an error")
+	}
 }

--- a/cmd/whip/browser_cli_test.go
+++ b/cmd/whip/browser_cli_test.go
@@ -62,3 +62,44 @@ func TestBrowserInstall(t *testing.T) {
 		t.Errorf("install output should walk through the manual load:\n%s", out)
 	}
 }
+
+// install can't proceed without a home directory, and reports the write
+// failure (rather than a partial install) when the whip dir can't be made.
+func TestBrowserInstallHomeErrors(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	t.Setenv("HOME", "")
+	if err := browserCLI([]string{"install"}); err == nil {
+		t.Error("install without a home directory should error")
+	}
+
+	file := filepath.Join(t.TempDir(), "home-is-a-file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", file)
+	err := browserCLI([]string{"install"})
+	if err == nil || !strings.Contains(err.Error(), "write extension") {
+		t.Errorf("an unwritable home should fail on the extension write, got %v", err)
+	}
+}
+
+// The relay state file is part of the install: if it can't be written, the
+// install fails loudly rather than leaving an extension with no token.
+func TestBrowserInstallRelayStateError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	// occupy the state path with a directory, which os.WriteFile can't replace
+	state := extrelay.RelayStatePath(home)
+	if err := os.MkdirAll(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	_ = captureStdout(t, func() { err = browserCLI([]string{"install"}) })
+	if err == nil || !strings.Contains(err.Error(), "write relay state") {
+		t.Errorf("an unwritable relay state should fail the install, got %v", err)
+	}
+}

--- a/cmd/whip/mcp_cli_test.go
+++ b/cmd/whip/mcp_cli_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,5 +128,205 @@ func TestMCPTestCLIUnknownAndDisabled(t *testing.T) {
 	out = captureStdout(t, func() { _ = mcpCLI([]string{"list"}, "v") })
 	if !strings.Contains(out, "off") || !strings.Contains(out, "disabled") {
 		t.Errorf("list should show the disabled server:\n%s", out)
+	}
+}
+
+// mcpHome isolates WHIP_HOME (with the given "mcp" block appended to a
+// healthy config), an empty working directory, and a missing codex file.
+func mcpHome(t *testing.T, mcpBlock string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+	chdir(t, t.TempDir())
+	orig := mcp.CodexPath
+	mcp.CodexPath = func() string { return filepath.Join(home, "no-codex.toml") }
+	t.Cleanup(func() { mcp.CodexPath = orig })
+
+	cfg := `{
+  "defaultModel": "m1",
+  "providers": { "a": { "baseUrl": "https://a", "api": "openai-completions" } },
+  "models": { "m1": { "providers": ["a"] } }` + mcpBlock + `
+}`
+	if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// With nothing configured anywhere, list says so instead of printing nothing.
+func TestMCPCLIListEmpty(t *testing.T) {
+	mcpHome(t, "")
+	var err error
+	out := captureStdout(t, func() { err = mcpCLI([]string{"list"}, "v") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no MCP servers configured") {
+		t.Fatalf("empty list should say so, got %q", out)
+	}
+}
+
+// mcpCLI routes `test` and `import` to their handlers (and validates their
+// arguments) rather than falling through to the unknown-subcommand error.
+func TestMCPCLIRoutesTestAndImport(t *testing.T) {
+	mcpHome(t, "")
+
+	var err error
+	_ = captureStdout(t, func() { err = mcpCLI([]string{"test", "nosuch"}, "v") })
+	if err == nil || !strings.Contains(err.Error(), "no mcp server named") {
+		t.Errorf("`mcp test <name>` should reach the doctor, got %v", err)
+	}
+
+	out := captureStdout(t, func() { err = mcpCLI([]string{"import", "--dry-run"}, "v") })
+	if err != nil || !strings.Contains(out, "nothing to import") {
+		t.Errorf("`mcp import --dry-run` should reach the importer, got %v %q", err, out)
+	}
+	if err := mcpImportCLI([]string{"--bogus"}); err == nil {
+		t.Error("an unknown import flag should error")
+	}
+}
+
+// A server that is neither stdio nor remote fails at birth: the doctor
+// reports the failure with its note and the file to fix, without launching
+// anything or waiting for a connect timeout.
+func TestMCPTestCLIInvalidServerFails(t *testing.T) {
+	mcpHome(t, `,
+  "mcp": { "broken": { "note": "imported without a command" } }`)
+
+	var err error
+	out := captureStdout(t, func() { err = mcpTestCLI("broken") })
+	if err == nil || !strings.Contains(err.Error(), "failed") {
+		t.Fatalf("an invalid server should fail, got %v", err)
+	}
+	for _, want := range []string{"✗ failed", "neither command nor url", "note: imported without a command", "config:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("doctor output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// Every subcommand that needs the config reports a broken one instead of
+// panicking on a nil config.
+func TestMCPCLIUnreadableConfig(t *testing.T) {
+	unusableHome(t)
+	chdir(t, t.TempDir())
+
+	if err := mcpCLI([]string{"list"}, "v"); err == nil {
+		t.Error("list with an unreadable config should error")
+	}
+	if err := mcpTestCLI("any"); err == nil {
+		t.Error("test with an unreadable config should error")
+	}
+	if err := mcpImportCLI(nil); err == nil {
+		t.Error("import with an unreadable config should error")
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected and returns what it wrote.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+	fn()
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+// A project .mcp.json that doesn't parse is reported on stderr and never
+// aborts the listing of the servers that do parse.
+func TestMCPCLIListReportsBrokenProjectFile(t *testing.T) {
+	mcpHome(t, `,
+  "mcp": { "ok": { "command": ["true"] } }`)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, ".mcp.json"), []byte("{ not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out string
+	errOut := captureStderr(t, func() {
+		out = captureStdout(t, func() {
+			if err := mcpCLI([]string{"list"}, "v"); err != nil {
+				t.Error(err)
+			}
+		})
+	})
+	if !strings.Contains(errOut, ".mcp.json") {
+		t.Errorf("a broken project file should be reported on stderr, got %q", errOut)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Errorf("the working servers should still be listed:\n%s", out)
+	}
+}
+
+// TestMCPServeHelperProcess is not a test: re-executed as a child process it
+// is a real `whip mcp serve` stdio server for the doctor to talk to.
+func TestMCPServeHelperProcess(t *testing.T) {
+	if os.Getenv("WHIP_MCP_SERVE_HELPER") != "1" {
+		t.Skip("helper process, run only by TestMCPTestCLIReady")
+	}
+	if err := mcpCLI([]string{"serve"}, "helper"); err != nil {
+		fmt.Fprintln(os.Stderr, "serve:", err)
+	}
+}
+
+// The doctor's happy path: connect to a real stdio MCP server (this test
+// binary re-executed as `whip mcp serve`), report the timing and the tools.
+func TestMCPTestCLIReady(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skip("no test binary path")
+	}
+	mcpHome(t, fmt.Sprintf(`,
+  "mcp": { "self": { "command": [%q, "-test.run=^TestMCPServeHelperProcess$"], "env": { "WHIP_MCP_SERVE_HELPER": "1" }, "startupTimeout": 20 } }`, self))
+
+	out := captureStdout(t, func() {
+		if terr := mcpTestCLI("self"); terr != nil {
+			t.Errorf("a live server should probe clean: %v", terr)
+		}
+	})
+	if !strings.Contains(out, "✓ connected") {
+		t.Fatalf("doctor should report the connection:\n%s", out)
+	}
+	if !strings.Contains(out, "tools:") || !strings.Contains(out, "read") {
+		t.Errorf("doctor should list the served tools:\n%s", out)
+	}
+}
+
+// When the config can't be written back, add/remove/import all report the
+// failure instead of claiming success.
+func TestMCPCLISaveFailures(t *testing.T) {
+	home := mcpHome(t, `,
+  "mcp": { "mine": { "command": ["true"] } }`)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// an importable project server, so import has something to write
+	if werr := os.WriteFile(filepath.Join(wd, ".mcp.json"),
+		[]byte(`{"mcpServers":{"proj":{"command":"true"}}}`), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	freezeHome(t, home)
+
+	if err := mcpCLI([]string{"add", "new", "--", "true"}, "v"); err == nil {
+		t.Error("add should report an unwritable config")
+	}
+	if err := mcpCLI([]string{"remove", "mine"}, "v"); err == nil {
+		t.Error("remove should report an unwritable config")
+	}
+	if err := mcpImportCLI(nil); err == nil {
+		t.Error("import should report an unwritable config")
 	}
 }

--- a/cmd/whip/run_test.go
+++ b/cmd/whip/run_test.go
@@ -296,3 +296,113 @@ func TestRunQuietJSON(t *testing.T) {
 func configDir() (string, error) { return os.Getenv("WHIP_HOME"), nil }
 
 func sessionOpen(dir string) (*session.Store, error) { return session.Open(dir + "/sessions.db") }
+
+// Bad flags, an unknown --format, and a missing prompt all fail before any
+// provider is contacted.
+func TestRunArgValidation(t *testing.T) {
+	runFixture(t, "never used", nil)
+
+	for _, c := range []struct {
+		name, want string
+		args       []string
+	}{
+		{"unknown flag", "not defined", []string{"-nosuchflag"}},
+		{"bad format", "unknown --format", []string{"--format", "xml", "hi"}},
+		{"no prompt", "no prompt given", nil},
+	} {
+		_, err := runCapture(t, "", c.args...)
+		if err == nil || !strings.Contains(err.Error(), c.want) {
+			t.Errorf("%s: got %v, want an error containing %q", c.name, err, c.want)
+		}
+	}
+}
+
+// Routing and system-prompt failures are reported before the turn starts.
+func TestRunResolveErrors(t *testing.T) {
+	runFixture(t, "never used", nil)
+
+	if _, err := runCapture(t, "", "-m", "nosuchmodel", "hi"); err == nil {
+		t.Error("an unroutable model should error")
+	}
+	missing := filepath.Join(t.TempDir(), "absent.md")
+	_, err := runCapture(t, "", "-system-file", missing, "hi")
+	if err == nil || !strings.Contains(err.Error(), "-system-file") {
+		t.Errorf("a missing -system-file should name the flag, got %v", err)
+	}
+
+	// a provider with no key at all: nothing to authenticate with
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+	cfg := `{
+		"defaultModel": "test",
+		"providers": {"testprov": {"baseUrl": "https://example.invalid", "api": "openai-completions"}},
+		"models": {"test": {"providers": ["testprov"], "maxOut": 100}}
+	}`
+	if werr := os.WriteFile(filepath.Join(home, "config.json"), []byte(cfg), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	if _, err := runCapture(t, "", "hi"); err == nil || !strings.Contains(err.Error(), "no API key") {
+		t.Errorf("a keyless provider should error, got %v", err)
+	}
+}
+
+// An unreadable config dir fails the run instead of falling back to defaults
+// that would reach the network.
+func TestRunUnreadableConfig(t *testing.T) {
+	unusableHome(t)
+	if _, err := runCapture(t, "", "hi"); err == nil {
+		t.Error("an unusable WHIP_HOME should error")
+	}
+}
+
+// In --format json the tool calls are events too, and a failed run ends with
+// an error event rather than a done event.
+func TestRunJSONToolEvents(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(target, []byte("file body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// a server that always answers with a read tool call: only -max-turns ends it
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		args, _ := json.Marshal(map[string]string{"path": target})
+		call, _ := json.Marshal(string(args))
+		fmt.Fprintf(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"read","arguments":%s}}]}}]}`+"\n\n", call)
+		fmt.Fprint(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+	cfg := fmt.Sprintf(`{
+		"defaultModel": "test",
+		"providers": {"testprov": {"baseUrl": %q, "api": "openai-completions", "apiKey": "k"}},
+		"models": {"test": {"providers": ["testprov"], "maxOut": 100}}
+	}`, srv.URL)
+	if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCapture(t, "", "-format", "json", "-max-turns", "2", "-quiet", "-no-session", "read it")
+	if err == nil {
+		t.Fatal("a capped run should error")
+	}
+	seen := map[string]string{}
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		var ev map[string]string
+		if uerr := json.Unmarshal([]byte(line), &ev); uerr != nil {
+			t.Fatalf("stdout should be NDJSON, got %q: %v", line, uerr)
+		}
+		seen[ev["type"]] = ev["name"] + ev["result"] + ev["error"]
+	}
+	if seen["tool_start"] != "read" {
+		t.Errorf("a tool call should emit tool_start for the tool, got %q", seen["tool_start"])
+	}
+	if !strings.Contains(seen["tool_end"], "file body") {
+		t.Errorf("tool_end should carry the tool result, got %q", seen["tool_end"])
+	}
+	if !strings.Contains(seen["error"], "max turns") {
+		t.Errorf("a failed run should end with an error event, got %q", seen["error"])
+	}
+}

--- a/cmd/whip/sessions_test.go
+++ b/cmd/whip/sessions_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +10,17 @@ import (
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/session"
 )
+
+// unusableHome points WHIP_HOME at a path nested inside a regular file, so
+// every config.Dir/config.Load call fails the way a broken install does.
+func unusableHome(t *testing.T) {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WHIP_HOME", filepath.Join(f, "whip"))
+}
 
 // whip sessions lists stored sessions newest-first with id, title, model, age.
 func TestSessionsCLI(t *testing.T) {
@@ -34,4 +46,127 @@ func TestSessionsCLI(t *testing.T) {
 	if !strings.Contains(out, "just now") && !strings.Contains(out, time.Now().Format("2006-01-02")) {
 		t.Fatalf("age column should render, got:\n%s", out)
 	}
+}
+
+// An empty store says so instead of printing an empty table, and a session
+// with no first user message yet renders as "(untitled)".
+func TestSessionsCLIEmptyAndUntitled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("WHIP_HOME", dir)
+
+	out := captureStdout(t, func() {
+		if err := sessionsCLI(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "no sessions yet") {
+		t.Fatalf("an empty store should say so, got %q", out)
+	}
+
+	st, err := session.Open(filepath.Join(dir, "sessions.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := st.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// no authored user message yet: the session has no title to show
+	if err := st.Save(id, 0, []llm.Message{{Role: "assistant", Content: "hi"}}, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+
+	out = captureStdout(t, func() {
+		if err := sessionsCLI(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "(untitled)") {
+		t.Fatalf("a titleless session should render as (untitled), got %q", out)
+	}
+}
+
+// A long title is truncated to the column width with an ellipsis.
+func TestSessionsCLITruncatesTitle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("WHIP_HOME", dir)
+
+	st, err := session.Open(filepath.Join(dir, "sessions.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := st.Create("/tmp", "m", "p")
+	long := strings.Repeat("q", 80)
+	if err := st.Save(id, 0, []llm.Message{{Role: "user", Content: long, Authored: true}}, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+
+	out := captureStdout(t, func() {
+		if err := sessionsCLI(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "…") || strings.Contains(out, long) {
+		t.Fatalf("a long title should be truncated with an ellipsis, got %q", out)
+	}
+}
+
+// A broken config dir and an unopenable store both surface as errors rather
+// than a panic or a silently empty listing.
+func TestSessionsCLIStoreErrors(t *testing.T) {
+	unusableHome(t)
+	if err := sessionsCLI(); err == nil {
+		t.Error("an unusable WHIP_HOME should error")
+	}
+
+	dir := t.TempDir()
+	t.Setenv("WHIP_HOME", dir)
+	if err := os.Mkdir(filepath.Join(dir, "sessions.db"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessionsCLI(); err == nil {
+		t.Error("a sessions.db that is a directory should error")
+	}
+}
+
+func TestTruncAndAgo(t *testing.T) {
+	if got := trunc("short", 10); got != "short" {
+		t.Errorf("trunc should leave a short string alone, got %q", got)
+	}
+	if got := trunc("0123456789abc", 10); got != "012345678…" {
+		t.Errorf("trunc(…, 10) = %q", got)
+	}
+
+	now := time.Now()
+	for _, c := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{10 * time.Second, "just now"},
+		{5 * time.Minute, "5m ago"},
+		{3 * time.Hour, "3h ago"},
+	} {
+		if got := ago(now.Add(-c.d)); got != c.want {
+			t.Errorf("ago(-%s) = %q, want %q", c.d, got, c.want)
+		}
+	}
+	old := now.Add(-72 * time.Hour)
+	if got := ago(old); got != old.Format("2006-01-02") {
+		t.Errorf("anything older than a day should show the date, got %q", got)
+	}
+}
+
+// freezeHome makes the config directory read-only for the rest of the test,
+// so every config write-back fails the way a locked-down install does.
+func freezeHome(t *testing.T, home string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("root writes through a read-only directory")
+	}
+	if err := os.Chmod(home, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(home, 0o700) })
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -872,10 +872,48 @@ func TestManualCompactFiresEvent(t *testing.T) {
 		)
 	}
 	var fired bool
-	if err := ag.ManualCompact(context.Background(), Events{OnCompact: func(took, kept int) { fired = true }}); err != nil {
+	var gotSummary string
+	ev := Events{
+		OnCompact:   func(took, kept int) { fired = true },
+		OnCompacted: func(summary string, cutoff int) { gotSummary = summary },
+	}
+	if err := ag.ManualCompact(context.Background(), ev); err != nil {
 		t.Fatalf("manual compact: %v", err)
 	}
 	if !fired {
 		t.Fatal("OnCompact should fire for ManualCompact")
+	}
+	if gotSummary != "sim" {
+		t.Fatalf("OnCompacted summary = %q", gotSummary)
+	}
+
+	// Too little history: the error surfaces instead of a silent no-op.
+	empty := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	if err := empty.ManualCompact(context.Background(), Events{}); err == nil {
+		t.Fatal("ManualCompact on a fresh agent should report too little history")
+	}
+}
+
+// MessagesSnapshot hands out a copy — mutating it must not touch the agent's
+// transcript (the TUI reads it while a turn runs).
+func TestMessagesSnapshotIsACopy(t *testing.T) {
+	ag := New(nil, "m", 0, "sys")
+	ag.AppendUser("hello")
+	snap := ag.MessagesSnapshot()
+	if len(snap) != len(ag.Messages) {
+		t.Fatalf("snapshot len %d, agent %d", len(snap), len(ag.Messages))
+	}
+	snap[0].Content = "clobbered"
+	if ag.Messages[0].Content == "clobbered" {
+		t.Fatal("snapshot must not alias the agent's messages")
+	}
+}
+
+func TestTruncateField(t *testing.T) {
+	if got := truncateField("  a\nb  ", 10); got != "a b" {
+		t.Errorf("newlines/trim: %q", got)
+	}
+	if got := truncateField("abcdefghij", 5); got != "abcd…" {
+		t.Errorf("truncation: %q", got)
 	}
 }

--- a/internal/agent/events_test.go
+++ b/internal/agent/events_test.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/context-labs/whip/internal/llm"
+)
+
+// recorder is an Events that appends every callback it receives.
+func recorder(mu *sync.Mutex, got *[]string) Events {
+	add := func(s string) {
+		mu.Lock()
+		*got = append(*got, s)
+		mu.Unlock()
+	}
+	return Events{
+		OnText:      func(s string) { add("text:" + s) },
+		OnThink:     func(s string) { add("think:" + s) },
+		OnToolStart: func(id, name, args string) { add("start:" + id + name + args) },
+		OnToolEnd:   func(id, name, res string) { add("end:" + id + name + res) },
+		OnSteer:     func(s string) { add("steer:" + s) },
+		OnCompact:   func(took, kept int) { add("compact") },
+		OnUsage:     func(u llm.Usage) { add("usage") },
+	}
+}
+
+// fire invokes every callback on ev that is non-nil.
+func fire(ev Events) {
+	ev.OnText("t")
+	ev.OnThink("k")
+	ev.OnToolStart("i", "n", "a")
+	ev.OnToolEnd("i", "n", "r")
+	ev.OnSteer("s")
+	ev.OnCompact(1, 2)
+	if ev.OnUsage != nil {
+		ev.OnUsage(llm.Usage{})
+	}
+}
+
+// FanIn delivers every callback to every source, and tolerates sources that
+// implement none of them.
+func TestFanInAllCallbacks(t *testing.T) {
+	var mu sync.Mutex
+	var a, b []string
+	fire(FanIn(recorder(&mu, &a), Events{}, recorder(&mu, &b)))
+
+	want := []string{"text:t", "think:k", "start:ina", "end:inr", "steer:s", "compact", "usage"}
+	for _, got := range [][]string{a, b} {
+		if len(got) != len(want) {
+			t.Fatalf("fan-in delivered %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("event %d = %q, want %q", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// The registry's emitter forwards a task's events to every live subscriber,
+// and drops them once the task has settled.
+func TestEmitterBroadcastsToSubscribers(t *testing.T) {
+	r := newTaskRegistry()
+	task := &BackgroundTask{ID: "task-1", Status: TaskRunning, Done: make(chan struct{}), cancel: func() {}}
+	r.tasks[task.ID] = task
+
+	var mu sync.Mutex
+	var a, b []string
+	if !r.Subscribe(task.ID, recorder(&mu, &a)) || !r.Subscribe(task.ID, recorder(&mu, &b)) {
+		t.Fatal("Subscribe on a running task must succeed")
+	}
+	if r.Subscribe("task-nope", Events{}) {
+		t.Error("Subscribe on an unknown task must fail")
+	}
+
+	fire(r.emitter(task.ID)) // emitter has no OnUsage — fire skips it
+	mu.Lock()
+	if len(a) != 6 || len(b) != 6 || a[0] != "text:t" || a[5] != "compact" {
+		t.Errorf("subscribers saw %v / %v", a, b)
+	}
+	mu.Unlock()
+
+	// Events for an unknown task go nowhere rather than panicking.
+	fire(r.emitter("task-nope"))
+
+	r.settle(task.ID, TaskDone, "report")
+	if r.Subscribe(task.ID, Events{}) {
+		t.Error("Subscribe on a settled task must fail")
+	}
+}
+
+// Registry lookups on unknown or settled ids are no-ops rather than panics,
+// and List sorts same-instant tasks by their monotonic id.
+func TestTaskRegistryUnknownIDsAndOrder(t *testing.T) {
+	r := newTaskRegistry()
+	if _, ok := r.Get("task-nope"); ok {
+		t.Error("Get on an unknown task must report false")
+	}
+	if r.Cancel("task-nope") {
+		t.Error("Cancel on an unknown task must report false")
+	}
+	r.settle("task-nope", TaskDone, "ignored") // must not panic
+
+	now := time.Now()
+	for _, id := range []string{"task-10", "task-2", "task-1"} {
+		r.tasks[id] = &BackgroundTask{ID: id, Status: TaskDone, StartedAt: now, Done: make(chan struct{}), cancel: func() {}}
+	}
+	r.tasks["task-3"] = &BackgroundTask{ID: "task-3", Status: TaskRunning, StartedAt: now.Add(time.Second), Done: make(chan struct{}), cancel: func() {}}
+	got := r.List()
+	want := []string{"task-1", "task-2", "task-10", "task-3"}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("List order = %v, want %v", got, want)
+		}
+	}
+
+	if n := r.ClearSettled(); n != 3 {
+		t.Errorf("ClearSettled cleared %d, want 3", n)
+	}
+	if list := r.List(); len(list) != 1 || list[0].ID != "task-3" {
+		t.Errorf("running task must survive ClearSettled: %v", list)
+	}
+	if r.Cancel("task-1") {
+		t.Error("Cancel on a cleared task must report false")
+	}
+}
+
+// Tasks() creates the registry lazily so a zero-value-ish agent still works.
+func TestTasksLazyRegistry(t *testing.T) {
+	a := New(nil, "m", 0, "sys")
+	a.bg = nil
+	r := a.Tasks()
+	if r == nil || a.Tasks() != r {
+		t.Fatal("Tasks must create once and return the same registry")
+	}
+}

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -60,3 +60,24 @@ func TestMemoryToolsSessionScope(t *testing.T) {
 		t.Fatalf("installation memory file: %v %q", err, data)
 	}
 }
+
+// Bad arguments and store-level failures surface as tool errors, never as a
+// false "Remembered".
+func TestMemoryToolErrors(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ctx := context.Background()
+
+	for _, tc := range []struct{ tool, args, want string }{
+		{"remember", `{"text":`, "unexpected end"},             // malformed arguments
+		{"remember", `{"text":"   "}`, "text is required"},     // store rejects it
+		{"forget", `{"n":`, "unexpected end"},                  // malformed arguments
+		{"forget", `{"n":1,"scope":"bogus"}`, "scope must be"}, // bad scope
+		{"forget", `{"n":99}`, "no memor"},                     // nothing to forget
+	} {
+		out := tools.Execute(ctx, ag.Tools, tc.tool, json.RawMessage(tc.args))
+		if !strings.HasPrefix(out, "Error") || !strings.Contains(out, tc.want) {
+			t.Errorf("%s %s: want error containing %q, got %q", tc.tool, tc.args, tc.want, out)
+		}
+	}
+}

--- a/internal/agent/todo_test.go
+++ b/internal/agent/todo_test.go
@@ -66,6 +66,35 @@ func TestTodowriteValidation(t *testing.T) {
 	}
 }
 
+// An oversized list, malformed arguments, and the clear-the-plan call.
+func TestTodowriteEdges(t *testing.T) {
+	a := New(nil, "m", 0, "sys")
+
+	var big strings.Builder
+	big.WriteString(`{"todos":[`)
+	for i := range maxTodos + 1 {
+		if i > 0 {
+			big.WriteString(",")
+		}
+		big.WriteString(`{"content":"step","status":"pending"}`)
+	}
+	big.WriteString(`]}`)
+	if out := callTodowrite(t, a, big.String()); !strings.Contains(out, "consolidate steps") {
+		t.Errorf("oversized list: %q", out)
+	}
+	if out := callTodowrite(t, a, `{"todos":`); !strings.HasPrefix(out, "Error:") {
+		t.Errorf("malformed args: %q", out)
+	}
+
+	callTodowrite(t, a, `{"todos":[{"content":"do it","status":"pending"}]}`)
+	if out := callTodowrite(t, a, `{"todos":[]}`); out != "Plan cleared." {
+		t.Errorf("clear: %q", out)
+	}
+	if a.todoBlock() != "" || a.TodosJSON() != "" {
+		t.Error("cleared plan should inject and serialize nothing")
+	}
+}
+
 // End-to-end: a plan set via the tool reaches the model request as an
 // ephemeral system message each round, and a.Messages stays clean.
 func TestTodowriteEndToEnd(t *testing.T) {

--- a/internal/config/failure_test.go
+++ b/internal/config/failure_test.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// unusableHome points WHIP_HOME at a path under a regular file, so Dir()'s
+// MkdirAll always fails and every caller sees the "no config dir" error path.
+func unusableHome(t *testing.T) {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WHIP_HOME", filepath.Join(f, "whip"))
+}
+
+// blockedPath makes name unwritable in WHIP_HOME in the requested way, without
+// relying on file permissions (which root ignores):
+//
+//	"tmp"    – the "<name>.tmp" staging path is a directory, so the write fails
+//	"target" – "<name>" itself is a non-empty directory, so the rename fails
+func blockedPath(t *testing.T, name, how string) {
+	t.Helper()
+	dir, err := Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if how == "tmp" {
+		p += ".tmp"
+	}
+	if err := os.MkdirAll(filepath.Join(p, "occupied"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestNoConfigDirIsNotFatal: when the whip home can't be created, readers
+// degrade to empty/false and writers return the error — nothing panics.
+func TestNoConfigDirIsNotFatal(t *testing.T) {
+	unusableHome(t)
+
+	if Trusted("/some/dir") {
+		t.Error("Trusted should be false when the config dir is unusable")
+	}
+	if err := Trust("/some/dir"); err == nil {
+		t.Error("Trust should report the unusable config dir")
+	}
+	if n := ProjectGoalMaxRounds("/some/dir"); n != 0 {
+		t.Errorf("ProjectGoalMaxRounds = %d, want 0", n)
+	}
+	if err := SetProjectGoalMaxRounds("/some/dir", 5); err == nil {
+		t.Error("SetProjectGoalMaxRounds should report the unusable config dir")
+	}
+	if cats := LoadCatalogs(); len(cats) != 0 {
+		t.Errorf("LoadCatalogs = %v, want empty", cats)
+	}
+	if err := SaveCatalogs(map[string]Catalog{"p": {}}); err == nil {
+		t.Error("SaveCatalogs should report the unusable config dir")
+	}
+	var v map[string]any
+	if err := ReadJSON("state.json", &v); err == nil {
+		t.Error("ReadJSON should report the unusable config dir")
+	}
+	if err := WriteJSON("state.json", map[string]int{}); err == nil {
+		t.Error("WriteJSON should report the unusable config dir")
+	}
+	if _, err := Load(); err == nil {
+		t.Error("Load should report the unusable config dir")
+	}
+	if err := Default().Save(); err == nil {
+		t.Error("Save should report the unusable config dir")
+	}
+}
+
+// TestTrustedRejectsCorruptFile: an unparseable trusted.json means "not
+// trusted" — failing open would grant trust the user never gave.
+func TestTrustedRejectsCorruptFile(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	dir, _ := Dir()
+	if err := os.WriteFile(filepath.Join(dir, "trusted.json"), []byte("{ not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if Trusted("/x") {
+		t.Fatal("a corrupt trusted.json must not grant trust")
+	}
+	// and a fresh grant repairs it
+	if err := Trust("/x"); err != nil {
+		t.Fatal(err)
+	}
+	if !Trusted("/x") {
+		t.Fatal("Trust should overwrite the corrupt file")
+	}
+}
+
+// TestTrustReportsWriteFailures: a trust grant that can't reach disk must
+// return an error — silently dropping it would re-prompt forever (or worse,
+// look granted in-session).
+func TestTrustReportsWriteFailures(t *testing.T) {
+	t.Run("staging write", func(t *testing.T) {
+		t.Setenv("WHIP_HOME", t.TempDir())
+		blockedPath(t, "trusted.json", "tmp")
+		if err := Trust("/x"); err == nil {
+			t.Fatal("Trust should report the failed staging write")
+		}
+	})
+	t.Run("rename", func(t *testing.T) {
+		t.Setenv("WHIP_HOME", t.TempDir())
+		blockedPath(t, "trusted.json", "target")
+		if err := Trust("/x"); err == nil {
+			t.Fatal("Trust should report the failed rename")
+		}
+		dir, _ := Dir()
+		if _, err := os.Stat(filepath.Join(dir, "trusted.json.tmp")); !os.IsNotExist(err) {
+			t.Fatal("a failed rename must clean up its staging file")
+		}
+	})
+}
+
+// TestProjectsReportWriteFailures is the same contract for projects.json.
+func TestProjectsReportWriteFailures(t *testing.T) {
+	t.Run("staging write", func(t *testing.T) {
+		t.Setenv("WHIP_HOME", t.TempDir())
+		blockedPath(t, "projects.json", "tmp")
+		if err := SetProjectGoalMaxRounds("/x", 7); err == nil {
+			t.Fatal("SetProjectGoalMaxRounds should report the failed staging write")
+		}
+	})
+	t.Run("rename", func(t *testing.T) {
+		t.Setenv("WHIP_HOME", t.TempDir())
+		blockedPath(t, "projects.json", "target")
+		if err := SetProjectGoalMaxRounds("/x", 7); err == nil {
+			t.Fatal("SetProjectGoalMaxRounds should report the failed rename")
+		}
+		dir, _ := Dir()
+		if _, err := os.Stat(filepath.Join(dir, "projects.json.tmp")); !os.IsNotExist(err) {
+			t.Fatal("a failed rename must clean up its staging file")
+		}
+	})
+}
+
+// TestConfigSaveReportsWriteFailures: the atomic write's two failure points
+// must both surface, and the staging file must not be left behind.
+func TestConfigSaveReportsWriteFailures(t *testing.T) {
+	t.Run("staging write", func(t *testing.T) {
+		t.Setenv("WHIP_HOME", t.TempDir())
+		blockedPath(t, "config.json", "tmp")
+		if err := Default().Save(); err == nil {
+			t.Fatal("Save should report the failed staging write")
+		}
+	})
+	t.Run("rename", func(t *testing.T) {
+		t.Setenv("WHIP_HOME", t.TempDir())
+		blockedPath(t, "config.json", "target")
+		if err := Default().Save(); err == nil {
+			t.Fatal("Save should report the failed rename")
+		}
+		dir, _ := Dir()
+		if _, err := os.Stat(filepath.Join(dir, "config.json.tmp")); !os.IsNotExist(err) {
+			t.Fatal("a failed rename must clean up its staging file")
+		}
+	})
+}
+
+// TestSaveOverUnparseableConfig: an existing config that doesn't parse is
+// still backed up and replaced (the log notes it, the write proceeds).
+func TestSaveOverUnparseableConfig(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	dir, _ := Dir()
+	p := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(p, []byte("{ this is not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Default().Save(); err != nil {
+		t.Fatal(err)
+	}
+	bak, err := os.ReadFile(p + ".bak")
+	if err != nil {
+		t.Fatalf("the unparseable file should be backed up: %v", err)
+	}
+	if string(bak) != "{ this is not json" {
+		t.Fatalf("backup content: %q", bak)
+	}
+	cfg, err := Load()
+	if err != nil || cfg.DefaultModel != Default().DefaultModel {
+		t.Fatalf("the replacement config should load: %v %+v", err, cfg)
+	}
+}
+
+// TestLoadReportsUnreadableConfig: a config path that exists but can't be read
+// is an error, not a silent regeneration (regenerating would clobber it).
+func TestLoadReportsUnreadableConfig(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	dir, _ := Dir()
+	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); err == nil {
+		t.Fatal("Load should report an unreadable config file")
+	}
+}
+
+// TestLoadKeepsMCPServersWhenRestoringBackup: recovering a clobbered config
+// from .bak must not drop MCP servers the user configured in the meantime.
+func TestLoadKeepsMCPServersWhenRestoringBackup(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	dir, _ := Dir()
+	p := filepath.Join(dir, "config.json")
+	// healthy backup (no mcp block) + clobbered live file that has one
+	if err := os.WriteFile(p+".bak", []byte(`{"defaultModel":"kimi-k3","providers":{"inference":{"baseUrl":"u","api":"openai-completions"}},"models":{"kimi-k3":{"providers":["inference"]}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"mcp":{"fs":{"command":["srv"]}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Providers) != 1 || cfg.DefaultModel != "kimi-k3" {
+		t.Fatalf("should have restored from .bak: %+v", cfg)
+	}
+	if _, ok := cfg.MCPServers["fs"]; !ok {
+		t.Fatalf("the mcp block must survive the restore: %+v", cfg.MCPServers)
+	}
+}
+
+// TestCatalogMissesReturnZero covers the not-found fallbacks callers rely on.
+func TestCatalogMissesReturnZero(t *testing.T) {
+	c := Catalog{Models: []ModelInfoLite{{ID: "known", ContextLength: 10}}}
+	if got := c.ContextLength("unknown"); got != 0 {
+		t.Errorf("ContextLength(unknown) = %d, want 0", got)
+	}
+	if got := c.Find("unknown"); got != nil {
+		t.Errorf("Find(unknown) = %+v, want nil", got)
+	}
+}
+
+// TestLoadCatalogsRejectsGarbage: a corrupt models.json yields an empty,
+// writable map rather than a nil one callers would panic writing into.
+func TestLoadCatalogsRejectsGarbage(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	dir, _ := Dir()
+	if err := os.WriteFile(filepath.Join(dir, "models.json"), []byte("null"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cats := LoadCatalogs()
+	if cats == nil {
+		t.Fatal("LoadCatalogs must never return nil")
+	}
+	cats["p"] = Catalog{} // must not panic
+	if err := os.WriteFile(filepath.Join(dir, "models.json"), []byte("[1,2]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadCatalogs(); got == nil || len(got) != 0 {
+		t.Fatalf("a non-object models.json should yield an empty map, got %v", got)
+	}
+}
+
+// TestWriteJSONReportsUnmarshalableValue: WriteJSON takes any, so a value JSON
+// can't render must come back as an error rather than truncating the file.
+func TestWriteJSONReportsUnmarshalableValue(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := WriteJSON("state.json", make(chan int)); err == nil {
+		t.Fatal("an unmarshalable value should be an error")
+	}
+	dir, _ := Dir()
+	if _, err := os.Stat(filepath.Join(dir, "state.json")); !os.IsNotExist(err) {
+		t.Fatal("nothing should have been written")
+	}
+}

--- a/internal/config/jsonc_test.go
+++ b/internal/config/jsonc_test.go
@@ -22,6 +22,55 @@ func TestReadWriteJSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestParseJSONCEdgeCases pins the stripper's tricky cases: comment markers
+// and commas inside string literals must survive, escapes must not end a
+// string early, and malformed sources must be reported rather than silently
+// producing broken JSON.
+func TestParseJSONCEdgeCases(t *testing.T) {
+	ok := []struct {
+		name, src, want string
+	}{
+		{"escaped quote", `{"a": "say \"hi\", ok"}`, `say "hi", ok`},
+		{"escaped backslash", `{"a": "c:\\path\\"}`, `c:\path\`},
+		{"comment marker in string", `{"a": "http://x/y"}`, "http://x/y"},
+		{"division-like slash", `{"a": "1"} // 2/3`, "1"},
+		{"block comment", `{/* skip */ "a": "1"}`, "1"},
+		{"trailing comma", `{"a": "1",}`, "1"},
+		{"comma inside string", `{"a": ", }"}`, ", }"},
+	}
+	for _, c := range ok {
+		t.Run(c.name, func(t *testing.T) {
+			var v struct {
+				A string `json:"a"`
+			}
+			if err := parseJSONC([]byte(c.src), &v); err != nil {
+				t.Fatalf("parse %s: %v", c.src, err)
+			}
+			if v.A != c.want {
+				t.Fatalf("got %q, want %q", v.A, c.want)
+			}
+		})
+	}
+
+	// a lone slash that starts neither comment form is left alone
+	if got, err := stripJSONC([]byte(`{"a":"1"}/`)); err != nil || string(got) != `{"a":"1"}/` {
+		t.Fatalf("bare slash: %q %v", got, err)
+	}
+
+	bad := map[string]string{
+		"unterminated block comment": `{"a": 1} /* nope`,
+		"unterminated string":        `{"a": "nope}`,
+	}
+	for name, src := range bad {
+		t.Run(name, func(t *testing.T) {
+			var v map[string]any
+			if err := parseJSONC([]byte(src), &v); err == nil {
+				t.Fatalf("%s should be an error", name)
+			}
+		})
+	}
+}
+
 func TestReadJSONMissingFileErrors(t *testing.T) {
 	t.Setenv("WHIP_HOME", t.TempDir())
 	var v map[string]any

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -105,6 +106,103 @@ func TestServerRequestsGetNullAck(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("no ack for server request")
 	}
+}
+
+// An error response is routed back to the waiting request, and a malformed
+// frame is skipped instead of killing the read loop.
+func TestErrorResponseAndGarbageFrame(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	defer inW.Close()
+	defer outW.Close()
+	c := newClient(inW, outR, nil)
+	defer c.shutdown()
+
+	go func() {
+		br := bufio.NewReader(inR)
+		body, err := readFrame(br)
+		if err != nil {
+			return
+		}
+		var msg rpcMessage
+		_ = json.Unmarshal(body, &msg)
+		// Garbage first: the loop must survive it and still answer.
+		_, _ = fmt.Fprint(outW, "Content-Length: 5\r\n\r\n{no:}")
+		resp, _ := json.Marshal(rpcMessage{ID: msg.ID, Error: &rpcError{Code: -32602, Message: "bad params"}})
+		_, _ = fmt.Fprintf(outW, "Content-Length: %d\r\n\r\n%s", len(resp), resp)
+	}()
+
+	err := c.request(context.Background(), "test/method", nil, nil)
+	var rpcErr *rpcError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != -32602 {
+		t.Fatalf("want rpc error, got %v", err)
+	}
+}
+
+// Unmarshalable params never reach the wire — send/request/notify bail out
+// rather than framing a broken message.
+func TestUnmarshalableParams(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	defer inW.Close()
+	defer outW.Close()
+	c := newClient(inW, outR, nil)
+	defer c.shutdown()
+
+	if err := c.request(context.Background(), "test/method", make(chan int), nil); err == nil {
+		t.Error("unmarshalable request params must error")
+	}
+	c.notify("test/note", make(chan int)) // must not panic or block
+	c.send(rpcMessage{Method: "test/bad", Params: json.RawMessage("{not json")})
+
+	// Nothing was written: the server side sees no frame before we tear down.
+	got := make(chan struct{})
+	go func() {
+		if _, err := readFrame(bufio.NewReader(inR)); err == nil {
+			close(got)
+		}
+	}()
+	select {
+	case <-got:
+		t.Error("a broken message reached the wire")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// Once the client is dead, sends drop and in-flight requests unblock with a
+// connection-closed error instead of hanging on the tool ctx.
+func TestRequestAfterShutdown(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	defer inW.Close()
+	defer outW.Close()
+	c := newClient(inW, outR, nil)
+	go func() { // drain stdin so the writer pump never blocks
+		br := bufio.NewReader(inR)
+		for {
+			if _, err := readFrame(br); err != nil {
+				return
+			}
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- c.request(context.Background(), "test/never", nil, nil) }()
+	time.Sleep(50 * time.Millisecond)
+	c.shutdown()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "connection closed") {
+			t.Fatalf("in-flight request after shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not unblock on shutdown")
+	}
+
+	if err := c.request(context.Background(), "test/after", nil, nil); err == nil {
+		t.Error("request on a dead client must error")
+	}
+	c.send(rpcMessage{Method: "test/after"}) // drops on c.dead, must not block
 }
 
 func TestRPCErrorMessage(t *testing.T) {

--- a/internal/lsp/diagnostic_test.go
+++ b/internal/lsp/diagnostic_test.go
@@ -1,0 +1,111 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatSeverities(t *testing.T) {
+	for _, tc := range []struct {
+		sev  int
+		want string
+	}{
+		{SeverityError, "ERROR [3:7] boom"},
+		{SeverityWarning, "WARN [3:7] boom"},
+		{SeverityInfo, "INFO [3:7] boom"},
+		{SeverityHint, "HINT [3:7] boom"},
+		{0, "ERROR [3:7] boom"}, // unset severity defaults to error
+	} {
+		if got := format(Diagnostic{Line: 3, Col: 7, Severity: tc.sev, Message: "boom"}); got != tc.want {
+			t.Errorf("severity %d: %q", tc.sev, got)
+		}
+	}
+	// Long messages are truncated with an ellipsis (rust-analyzer emits KBs).
+	long := strings.Repeat("x", maxMsgLen+50)
+	got := format(Diagnostic{Line: 1, Col: 1, Severity: SeverityError, Message: long})
+	if !strings.HasSuffix(got, "…") || len(got) != len("ERROR [1:1] ")+maxMsgLen+len("…") {
+		t.Errorf("truncation: len=%d suffix=%q", len(got), got[len(got)-4:])
+	}
+}
+
+func TestBlockFiltersAndCaps(t *testing.T) {
+	// Info/hint diagnostics are dropped entirely — no block at all.
+	if got := block("a.go", []Diagnostic{{Severity: SeverityInfo}, {Severity: SeverityHint}}); got != "" {
+		t.Errorf("info-only block: %q", got)
+	}
+	if got := block("a.go", nil); got != "" {
+		t.Errorf("empty block: %q", got)
+	}
+
+	var many []Diagnostic
+	for i := range maxPerFile + 3 {
+		many = append(many, Diagnostic{Line: i + 1, Col: 1, Severity: SeverityError, Message: "e"})
+	}
+	many = append(many, Diagnostic{Severity: SeverityHint, Message: "ignored"})
+	got := block("a.go", many)
+	if !strings.HasPrefix(got, "\n\n<diagnostics file=\"a.go\">\n") || !strings.HasSuffix(got, "</diagnostics>") {
+		t.Errorf("block wrapper: %q", got)
+	}
+	if n := strings.Count(got, "ERROR "); n != maxPerFile {
+		t.Errorf("kept %d diagnostics, want %d", n, maxPerFile)
+	}
+	if !strings.Contains(got, "... and 3 more") || strings.Contains(got, "ignored") {
+		t.Errorf("overflow line / hint filter: %q", got)
+	}
+}
+
+func TestReportSiblings(t *testing.T) {
+	edited := "/w/a.go"
+	editedDiags := []Diagnostic{{Line: 1, Col: 1, Severity: SeverityError, Message: "undefined: foo"}}
+
+	// No siblings: just the edited file's block.
+	got := Report(edited, editedDiags, nil)
+	if !strings.Contains(got, "undefined: foo") || strings.Contains(got, "other") {
+		t.Errorf("no siblings: %q", got)
+	}
+
+	// Warning-only siblings and the edited file itself are not counted.
+	sib := map[string][]Diagnostic{
+		edited:    editedDiags,
+		"/w/b.go": {{Severity: SeverityWarning, Message: "warn only"}},
+	}
+	if got := Report(edited, editedDiags, sib); strings.Contains(got, "introduced errors") {
+		t.Errorf("warning-only sibling must not be reported: %q", got)
+	}
+
+	// One erroring sibling: singular wording, block included.
+	sib["/w/b.go"] = []Diagnostic{{Line: 2, Col: 3, Severity: SeverityError, Message: "b broke"}}
+	got = Report(edited, editedDiags, sib)
+	if !strings.Contains(got, `<diagnostics file="/w/b.go">`) || !strings.Contains(got, "errors in file; fix them too") {
+		t.Errorf("single sibling: %q", got)
+	}
+
+	// More siblings than the cap: plural wording, sorted, capped.
+	for _, p := range []string{"/w/c.go", "/w/d.go", "/w/e.go", "/w/f.go", "/w/g.go"} {
+		sib[p] = []Diagnostic{{Line: 1, Col: 1, Severity: SeverityError, Message: "broke " + p}}
+	}
+	got = Report(edited, editedDiags, sib)
+	if !strings.Contains(got, "introduced errors in 6 other files, 5 shown") {
+		t.Errorf("overflow wording: %q", got)
+	}
+	if n := strings.Count(got, "<diagnostics file="); n != maxSiblingFiles+1 {
+		t.Errorf("blocks rendered: %d", n)
+	}
+	// Sorted by path: b..f shown, g dropped.
+	if strings.Contains(got, "/w/g.go") {
+		t.Errorf("siblings must be sorted and capped: %q", got)
+	}
+}
+
+func TestSiblingErrorsSameDirOnly(t *testing.T) {
+	all := map[string][]Diagnostic{
+		"/w/a.go":     {{Severity: SeverityError}},
+		"/w/b.go":     {{Severity: SeverityError}},
+		"/w/c.go":     {{Severity: SeverityWarning}},
+		"/w/sub/d.go": {{Severity: SeverityError}},
+	}
+	out := siblingErrors("/w/a.go", all)
+	if len(out) != 1 || out["/w/b.go"] == nil {
+		t.Errorf("siblingErrors = %v", out)
+	}
+}

--- a/internal/mcp/codextoml_test.go
+++ b/internal/mcp/codextoml_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestParseTOMLValue pins the value grammar directly: escapes, literal vs
+// basic strings, arrays, nested inline tables, numbers and booleans. The
+// hand-written reader is the risky half of codex import, so it gets a table.
+func TestParseTOMLValue(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want any
+	}{
+		{`true`, true},
+		{`false`, false},
+		{`42`, int64(42)},
+		{`-7`, int64(-7)},
+		{`1.5`, 1.5},
+		{`"plain"`, "plain"},
+		{`""`, ""},
+		{`"a\nb\tc\rd\\e\"f"`, "a\nb\tc\rd\\e\"f"},
+		{`'lit\nno-escape'`, `lit\nno-escape`}, // literal strings keep backslashes
+		{`''`, ""},
+		{`[]`, []string(nil)},
+		{`["a", "b"]`, []string{"a", "b"}},
+		{`["a, b"]`, []string{"a, b"}}, // comma inside quotes is not a separator
+		{`{}`, map[string]any{}},
+		{`{ a = "1", b = 2, c = true }`, map[string]any{"a": "1", "b": int64(2), "c": true}},
+		{`{outer = {inner = "x"}, after = "y"}`, map[string]any{"outer": map[string]any{"inner": "x"}, "after": "y"}},
+		{`{"quoted key" = "v"}`, map[string]any{"quoted key": "v"}},
+	} {
+		got, err := parseTOMLValue(tc.in)
+		if err != nil {
+			t.Errorf("parseTOMLValue(%s) error: %v", tc.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("parseTOMLValue(%s) = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseTOMLValueErrors: malformed input must fail loudly, never parse
+// wrong — each case names the construct it rejects.
+func TestParseTOMLValueErrors(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{``, "unsupported value"},
+		{`nope`, "unsupported value"},
+		{`"`, "unterminated string"},
+		{`'`, "unterminated string"},
+		{`'abc`, "unterminated string"},
+		{`"abc`, "unterminated string"},
+		{`"a"b"`, "trailing data after string"},
+		{`"a\`, "unterminated escape"},
+		{`"a\q"`, `unsupported escape \q`},
+		{`[1, 2`, "unterminated array"},
+		{`[nope]`, "unsupported value"},
+		{`[["x"]]`, "array elements must be strings"},
+		{`{a = "1"`, "unterminated inline table"},
+		{`{a}`, "expected key = value in inline table"},
+		{`{a = nope}`, "unsupported value"},
+	} {
+		got, err := parseTOMLValue(tc.in)
+		if err == nil {
+			t.Errorf("parseTOMLValue(%s) = %#v, want error %q", tc.in, got, tc.want)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("parseTOMLValue(%s) error = %q, want it to contain %q", tc.in, err, tc.want)
+		}
+	}
+}
+
+// TestParseCodexScalarKeys: the keys that map onto ServerConfig scalars,
+// including the _ms → seconds round-up.
+func TestParseCodexScalarKeys(t *testing.T) {
+	cfgs, err := ParseCodex([]byte(`
+[mcp_servers.x]
+command = "srv"
+cwd = "/srv/root"
+enabled = true
+startup_timeout_ms = 1500
+tool_timeout_sec = 90
+unknown_codex_key = "ignored"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	x := cfgs["x"]
+	if x.Cwd != "/srv/root" {
+		t.Errorf("cwd = %q", x.Cwd)
+	}
+	if x.Enabled == nil || !*x.Enabled || x.Disabled() {
+		t.Errorf("enabled = %v", x.Enabled)
+	}
+	if x.StartupTimeout != 2 { // 1500ms rounds up to 2s
+		t.Errorf("startup_timeout_ms 1500 → %ds, want 2s", x.StartupTimeout)
+	}
+	if x.ToolTimeout != 90 {
+		t.Errorf("tool_timeout_sec = %d", x.ToolTimeout)
+	}
+}
+
+// TestParseCodexTypeErrors: a well-formed value of the wrong type names the
+// table and the key, so a user can fix their config.toml.
+func TestParseCodexTypeErrors(t *testing.T) {
+	for _, tc := range []struct{ doc, want string }{
+		{"[mcp_servers.x]\nargs = \"notanarray\"\n", "args must be an array of strings"},
+		{"[mcp_servers.x]\nenv = \"notatable\"\n", "env must be an inline table"},
+		{"[mcp_servers.x]\nenvironment = 3\n", "environment must be an inline table"},
+		{"[mcp_servers.x]\nheaders = 3\n", "headers must be an inline table"},
+		{"[mcp_servers.x]\nurl = 3\n", "url must be a string"},
+		{"[mcp_servers.x]\ncwd = 3\n", "cwd must be a string"},
+		{"[mcp_servers.x]\nstartup_timeout_sec = \"soon\"\n", "startup_timeout_sec must be an integer"},
+		{"[mcp_servers.x]\nstartup_timeout_ms = \"soon\"\n", "startup_timeout_ms must be an integer"},
+		{"[mcp_servers.x]\ntool_timeout_sec = true\n", "tool_timeout_sec must be an integer"},
+		{"[mcp_servers.x]\njust-a-bare-key\n", "expected key = value"},
+		{"[mcp_servers.x]\ncommand = \"a\nargs = [\"b\"]\n", "unterminated string"},
+	} {
+		cfgs, err := ParseCodex([]byte(tc.doc))
+		if err == nil {
+			t.Errorf("ParseCodex(%q) = %v, want error %q", tc.doc, cfgs, tc.want)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("ParseCodex(%q) error = %q, want it to contain %q", tc.doc, err, tc.want)
+		}
+	}
+}
+
+func TestLoadCodex(t *testing.T) {
+	// An unset path is the "no codex config" signal in the discovery flow.
+	if _, err := LoadCodex(""); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("LoadCodex(\"\") = %v, want os.ErrNotExist", err)
+	}
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[mcp_servers.d]\ncommand = \"srv\"\nargs = ['--stdio']\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgs, err := LoadCodex(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cfgs["d"].Command, []string{"srv", "--stdio"}) {
+		t.Errorf("d command = %v", cfgs["d"].Command)
+	}
+	if _, err := LoadCodex(filepath.Join(t.TempDir(), "missing.toml")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("missing file = %v, want os.ErrNotExist", err)
+	}
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -87,7 +87,16 @@ type server struct {
 
 	autoTries int // auto-reconnect attempts since the last successful connect
 
-	mu sync.Mutex // guards status/err/defs/sess
+	mu sync.Mutex // guards status/err/defs/sess/cfg.Enabled
+}
+
+// disabled reports the server's current enable state. Enable/Disable flip
+// cfg.Enabled while the run and auto-reconnect goroutines read it, so the
+// read takes mu like any other mutable server field.
+func (s *server) disabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfg.Disabled()
 }
 
 // autoReconnect caps the background reconnect attempts after an unexpected
@@ -114,7 +123,7 @@ func (s *server) kickAutoReconnect(m *Manager) {
 	s.mu.Lock()
 	tries := s.autoTries
 	s.mu.Unlock()
-	if closing || s.cfg.Disabled() || tries >= autoReconnectMax {
+	if closing || s.disabled() || tries >= autoReconnectMax {
 		return
 	}
 	go func() {
@@ -125,7 +134,7 @@ func (s *server) kickAutoReconnect(m *Manager) {
 		s.mu.Lock()
 		gave := s.status == StatusReady || s.autoTries != tries // someone else recovered/retried
 		s.mu.Unlock()
-		if closing || gave || s.cfg.Disabled() {
+		if closing || gave || s.disabled() {
 			return
 		}
 		s.mu.Lock()
@@ -234,7 +243,7 @@ func (m *Manager) Start(ctx context.Context) {
 func (s *server) run(ctx context.Context, m *Manager) {
 	s.connect(ctx, m)
 	for range s.reconnect {
-		if s.cfg.Disabled() {
+		if s.disabled() {
 			s.setState(m, StatusDisabled, "")
 			continue
 		}
@@ -536,8 +545,8 @@ func (m *Manager) Disable(name string) bool {
 	if !ok {
 		return false
 	}
-	s.cfg.Enabled = new(false)
 	s.mu.Lock()
+	s.cfg.Enabled = new(false)
 	old := s.sess
 	s.sess, s.defs = nil, nil
 	s.gen++
@@ -555,7 +564,9 @@ func (m *Manager) Enable(name string) bool {
 	if !ok {
 		return false
 	}
+	s.mu.Lock()
 	s.cfg.Enabled = nil
+	s.mu.Unlock()
 	return m.Reconnect(name)
 }
 
@@ -690,6 +701,9 @@ func (m *Manager) Reconnect(name string) bool {
 // children get their own process group at spawn (defaultTransport) so whip's
 // exit path can also group-kill strays via the bashrun registry pattern.
 func (m *Manager) Close() {
+	m.onChangeMu.Lock()
+	m.closed = true
+	m.onChangeMu.Unlock()
 	for _, s := range m.servers {
 		s.mu.Lock()
 		sess := s.sess

--- a/internal/mcp/manager_more_test.go
+++ b/internal/mcp/manager_more_test.go
@@ -1,0 +1,598 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/context-labs/whip/internal/tools"
+)
+
+func TestEnvPairs(t *testing.T) {
+	got := envPairs(map[string]string{"A": "1", "B": "2"})
+	slices.Sort(got)
+	if !reflect.DeepEqual(got, []string{"A=1", "B=2"}) {
+		t.Errorf("envPairs = %v", got)
+	}
+	if got := envPairs(nil); len(got) != 0 {
+		t.Errorf("envPairs(nil) = %v", got)
+	}
+}
+
+// TestDefaultTransportStdio: the stdio branch builds a command in its own
+// process group, with whip's env plus the server's vars, and a cwd.
+func TestDefaultTransportStdio(t *testing.T) {
+	dir := t.TempDir()
+	stderr := newRingBuffer(64)
+	tr, err := defaultTransport(context.Background(), ServerConfig{
+		Command: []string{"srv", "--stdio"},
+		Cwd:     dir,
+		Env:     map[string]string{"WHIP_MCP_TRANSPORT_TEST": "yes"},
+	}, stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct, ok := tr.(*sdkmcp.CommandTransport)
+	if !ok {
+		t.Fatalf("transport type %T, want *sdkmcp.CommandTransport", tr)
+	}
+	cmd := ct.Command
+	if cmd.Dir != dir {
+		t.Errorf("cwd = %q, want %q", cmd.Dir, dir)
+	}
+	if !slices.Contains(cmd.Env, "WHIP_MCP_TRANSPORT_TEST=yes") {
+		t.Error("server env var not layered onto the inherited environment")
+	}
+	if len(cmd.Env) < 2 {
+		t.Errorf("environment not inherited: %v", cmd.Env)
+	}
+	if cmd.Stderr != stderr {
+		t.Error("stderr ring buffer not wired to the child")
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Error("child must get its own process group")
+	}
+	if !strings.HasSuffix(cmd.Path, "srv") || !reflect.DeepEqual(cmd.Args[1:], []string{"--stdio"}) {
+		t.Errorf("command = %v (%q)", cmd.Args, cmd.Path)
+	}
+}
+
+func TestFlattenResultEdges(t *testing.T) {
+	multi := flattenResult(&sdkmcp.CallToolResult{Content: []sdkmcp.Content{
+		&sdkmcp.TextContent{Text: "one"},
+		&sdkmcp.TextContent{Text: "two"},
+	}})
+	if multi != "one\ntwo" {
+		t.Errorf("two text parts = %q", multi)
+	}
+	if got := flattenResult(&sdkmcp.CallToolResult{}); got != "(no output)" {
+		t.Errorf("empty result = %q", got)
+	}
+	if got := flattenResult(&sdkmcp.CallToolResult{IsError: true}); got != "Error: (no output)" {
+		t.Errorf("empty error result = %q", got)
+	}
+	// A resource part with no contents contributes nothing rather than a
+	// half-rendered placeholder.
+	got := flattenResult(&sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.EmbeddedResource{}}})
+	if got != "(no output)" {
+		t.Errorf("empty embedded resource = %q", got)
+	}
+}
+
+// TestNormalizeSchemaUnmarshalable: a schema JSON can't encode falls back to
+// the empty object shape instead of emitting broken JSON to the provider.
+func TestNormalizeSchemaUnmarshalable(t *testing.T) {
+	got := normalizeSchema(map[string]any{"properties": map[string]any{}, "bad": make(chan int)})
+	if got != `{"type":"object","properties":{}}` {
+		t.Errorf("unmarshalable schema = %s", got)
+	}
+}
+
+// TestBridgeTitleFallback: a tool with only a Title uses it as the
+// description, so the model isn't handed "[MCP x] ".
+func TestBridgeTitleFallback(t *testing.T) {
+	s := &server{name: "docs"}
+	tool := s.bridge(&sdkmcp.Tool{Name: "search", Title: "Search the docs"})
+	if tool.Def.Function.Name != "mcp__docs__search" {
+		t.Errorf("name = %q", tool.Def.Function.Name)
+	}
+	if tool.Def.Function.Description != "[MCP docs] Search the docs" {
+		t.Errorf("description = %q", tool.Def.Function.Description)
+	}
+	// An explicit description wins over the title.
+	tool = s.bridge(&sdkmcp.Tool{Name: "search", Title: "Search the docs", Description: "real description"})
+	if tool.Def.Function.Description != "[MCP docs] real description" {
+		t.Errorf("description = %q", tool.Def.Function.Description)
+	}
+}
+
+func TestSetBlockedAndBlockedByPolicy(t *testing.T) {
+	m := NewManager(nil)
+	if m.BlockedByPolicy("anything") {
+		t.Error("nothing is blocked yet")
+	}
+	m.SetBlocked(map[string]ServerConfig{
+		"zeta":  {Note: "blocked by mcpImport", Source: "~/.codex/config.toml"},
+		"alpha": {Note: "blocked by mcpImport", Source: ".mcp.json"},
+	})
+	b := m.Blocked()
+	if len(b) != 2 || b[0].Name != "alpha" || b[1].Name != "zeta" {
+		t.Fatalf("blocked = %+v, want name-sorted alpha,zeta", b)
+	}
+	if b[0].Status != StatusDisabled || b[0].Note != "blocked by mcpImport" || b[0].Source != ".mcp.json" {
+		t.Errorf("blocked[0] = %+v", b[0])
+	}
+	if !m.BlockedByPolicy("zeta") || !m.BlockedByPolicy("alpha") {
+		t.Error("blocked servers must report true")
+	}
+	if m.BlockedByPolicy("never-configured") {
+		t.Error("unknown name must report false")
+	}
+}
+
+// TestInstructionsBlockSortedAndEmpty: no instructions → no block; several →
+// name-sorted sections.
+func TestInstructionsBlockSortedAndEmpty(t *testing.T) {
+	if got := NewManager(nil).InstructionsBlock(); got != "" {
+		t.Errorf("no servers → %q, want empty", got)
+	}
+
+	mk := func(name, instr string) *sdkmcp.Server {
+		srv := sdkmcp.NewServer(&sdkmcp.Implementation{Name: name}, &sdkmcp.ServerOptions{Instructions: instr})
+		sdkmcp.AddTool(srv, &sdkmcp.Tool{Name: "ping", InputSchema: map[string]any{"type": "object"}},
+			func(ctx context.Context, req *sdkmcp.CallToolRequest, in struct{}) (*sdkmcp.CallToolResult, any, error) {
+				return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "pong"}}}, nil, nil
+			})
+		return srv
+	}
+	srvs := map[string]*sdkmcp.Server{"zeta": mk("zeta", "zeta rules"), "alpha": mk("alpha", "alpha rules")}
+
+	m := NewManager(map[string]ServerConfig{"zeta": testCfg("zeta"), "alpha": testCfg("alpha")})
+	m.connectTransport = func(_ context.Context, cfg ServerConfig, _ *ringBuffer) (sdkmcp.Transport, error) {
+		ct, st := sdkmcp.NewInMemoryTransports()
+		ss, err := srvs[cfg.Command[0]].Connect(context.Background(), st, nil)
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(func() { ss.Close() })
+		return ct, nil
+	}
+	t.Cleanup(m.Close)
+	m.Start(context.Background())
+	waitReady(t, m)
+
+	block := m.InstructionsBlock()
+	ai, zi := strings.Index(block, "alpha rules"), strings.Index(block, "zeta rules")
+	if ai < 0 || zi < 0 || ai > zi {
+		t.Errorf("instructions must be name-sorted:\n%s", block)
+	}
+}
+
+// TestCallUnavailableVariants: the sess==nil branches speak in the user's
+// terms — construct the states directly, since a real server can't be held
+// in "settled but connecting" on demand.
+func TestCallUnavailableVariants(t *testing.T) {
+	settled := func(st Status, errMsg string) *server {
+		s := &server{name: "svc", settled: true, status: st, err: errMsg, ready: make(chan struct{}), calling: make(chan struct{}, 1)}
+		close(s.ready)
+		return s
+	}
+	for _, tc := range []struct {
+		s    *server
+		want string
+	}{
+		{settled(StatusFailed, ""), `mcp server "svc" unavailable (/mcp svc reconnect)`},
+		{settled(StatusFailed, "spawn failed"), `mcp server "svc" unavailable: spawn failed (/mcp svc reconnect)`},
+		{settled(StatusDisabled, ""), `mcp server "svc" is disabled (/mcp svc enable)`},
+		{settled(StatusConnecting, ""), `mcp server "svc" is connecting`},
+	} {
+		_, err := tc.s.call(context.Background(), "anything", nil)
+		if err == nil || err.Error() != tc.want {
+			t.Errorf("call err = %v, want %q", err, tc.want)
+		}
+	}
+}
+
+// TestCallLiveErrorPaths: bad arguments, an unknown tool, a cancelled context
+// while another call holds the per-server slot, and a tool that outruns the
+// configured tool timeout.
+func TestCallLiveErrorPaths(t *testing.T) {
+	m := newTestManager(t, map[string]ServerConfig{"docs": testCfg("docs")})
+	m.Start(context.Background())
+	waitReady(t, m)
+	s := m.servers["docs"]
+
+	if _, err := s.call(context.Background(), "greet", json.RawMessage("{not json")); err == nil ||
+		!strings.Contains(err.Error(), "invalid tool arguments") {
+		t.Errorf("bad args err = %v", err)
+	}
+	if _, err := s.call(context.Background(), "no-such-tool", nil); err == nil {
+		t.Error("unknown tool should surface the server's error")
+	}
+
+	// The per-server slot is taken: a cancelled caller gives up rather than
+	// queueing behind it.
+	s.calling <- struct{}{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := s.call(ctx, "greet", nil); !errors.Is(err, context.Canceled) {
+		t.Errorf("contended call err = %v, want context.Canceled", err)
+	}
+	<-s.calling
+}
+
+// TestCallToolTimeout: a tool that never returns is cut off at the configured
+// tool timeout with a message naming the tool.
+func TestCallToolTimeout(t *testing.T) {
+	srv := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "slow"}, nil)
+	sdkmcp.AddTool(srv, &sdkmcp.Tool{Name: "wedge", InputSchema: map[string]any{"type": "object"}},
+		func(ctx context.Context, req *sdkmcp.CallToolRequest, in struct{}) (*sdkmcp.CallToolResult, any, error) {
+			<-ctx.Done()
+			return nil, nil, ctx.Err()
+		})
+
+	m := NewManager(map[string]ServerConfig{"slow": {Command: []string{"slow"}, StartupTimeout: 5, ToolTimeout: 1}})
+	m.connectTransport = func(_ context.Context, _ ServerConfig, _ *ringBuffer) (sdkmcp.Transport, error) {
+		ct, st := sdkmcp.NewInMemoryTransports()
+		ss, err := srv.Connect(context.Background(), st, nil)
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(func() { ss.Close() })
+		return ct, nil
+	}
+	t.Cleanup(m.Close)
+	m.Start(context.Background())
+	waitReady(t, m)
+
+	_, err := m.servers["slow"].call(context.Background(), "wedge", nil)
+	if err == nil || !strings.Contains(err.Error(), "mcp tool wedge timed out after 1s") {
+		t.Errorf("timed-out call err = %v", err)
+	}
+}
+
+// TestCallWaitsForLateConnect: a call that arrives before the first connect
+// settles parks on s.ready and runs once the server lands.
+func TestCallWaitsForLateConnect(t *testing.T) {
+	release := make(chan struct{})
+	m := NewManager(map[string]ServerConfig{"late": testCfg("late")})
+	m.connectTransport = func(_ context.Context, _ ServerConfig, _ *ringBuffer) (sdkmcp.Transport, error) {
+		<-release
+		return serveTestServer(t, "late"), nil
+	}
+	t.Cleanup(m.Close)
+	m.Start(context.Background())
+
+	type result struct {
+		out string
+		err error
+	}
+	done := make(chan result, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		out, err := m.servers["late"].call(context.Background(), "greet", json.RawMessage(`{"name":"late"}`))
+		done <- result{out, err}
+	}()
+	<-started
+	time.Sleep(50 * time.Millisecond) // let the call park on s.ready (well inside connectGrace)
+	close(release)
+
+	select {
+	case r := <-done:
+		if r.err != nil || r.out != "hi late" {
+			t.Errorf("late call = %q, %v", r.out, r.err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("call never returned after the server connected")
+	}
+}
+
+// TestConnectSurfacesStderrTail: whatever the child wrote to stderr before
+// dying is appended to the failure message — the whole point of the ring
+// buffer.
+func TestConnectSurfacesStderrTail(t *testing.T) {
+	m := NewManager(map[string]ServerConfig{"noisy": testCfg("noisy")})
+	m.connectTransport = func(_ context.Context, _ ServerConfig, stderr *ringBuffer) (sdkmcp.Transport, error) {
+		stderr.Write([]byte("  panic: missing API key\n  "))
+		return nil, errors.New("spawn failed")
+	}
+	t.Cleanup(m.Close)
+	m.Start(context.Background())
+	waitReady(t, m)
+
+	st := m.Statuses()[0]
+	if st.Status != StatusFailed || st.Err != "spawn failed — stderr: panic: missing API key" {
+		t.Errorf("status = %+v", st)
+	}
+}
+
+// TestConnectListToolsFailureClosesSession: a server that connects but
+// refuses tools/list is failed, not half-registered.
+func TestConnectListToolsFailureClosesSession(t *testing.T) {
+	srv := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "grump"}, nil)
+	sdkmcp.AddTool(srv, &sdkmcp.Tool{Name: "ping", InputSchema: map[string]any{"type": "object"}},
+		func(ctx context.Context, req *sdkmcp.CallToolRequest, in struct{}) (*sdkmcp.CallToolResult, any, error) {
+			return &sdkmcp.CallToolResult{}, nil, nil
+		})
+	srv.AddReceivingMiddleware(func(next sdkmcp.MethodHandler) sdkmcp.MethodHandler {
+		return func(ctx context.Context, method string, req sdkmcp.Request) (sdkmcp.Result, error) {
+			if method == "tools/list" {
+				return nil, errors.New("list refused")
+			}
+			return next(ctx, method, req)
+		}
+	})
+
+	m := NewManager(map[string]ServerConfig{"grump": testCfg("grump")})
+	m.connectTransport = func(_ context.Context, _ ServerConfig, _ *ringBuffer) (sdkmcp.Transport, error) {
+		ct, st := sdkmcp.NewInMemoryTransports()
+		ss, err := srv.Connect(context.Background(), st, nil)
+		if err != nil {
+			return nil, err
+		}
+		t.Cleanup(func() { ss.Close() })
+		return ct, nil
+	}
+	t.Cleanup(m.Close)
+	m.Start(context.Background())
+	waitReady(t, m)
+
+	st := m.Statuses()[0]
+	if st.Status != StatusFailed || !strings.Contains(st.Err, "list refused") {
+		t.Fatalf("status = %+v", st)
+	}
+	if len(m.Tools()) != 0 {
+		t.Error("a server that never listed tools must contribute none")
+	}
+}
+
+// TestConnectDuringCloseDiscardsSession: a connect that lands after the
+// manager is closing throws the session away instead of storing it.
+func TestConnectDuringCloseDiscardsSession(t *testing.T) {
+	m := newTestManager(t, map[string]ServerConfig{"docs": testCfg("docs")})
+	m.onChangeMu.Lock()
+	m.closed = true
+	m.onChangeMu.Unlock()
+
+	s := m.servers["docs"]
+	s.connect(context.Background(), m) // synchronous: no lifecycle goroutine started
+	s.mu.Lock()
+	sess, status := s.sess, s.status
+	s.mu.Unlock()
+	if sess != nil {
+		t.Error("a closing manager must not store the session")
+	}
+	if status == StatusReady {
+		t.Errorf("status = %v, want not ready", status)
+	}
+	if len(m.Tools()) != 0 {
+		t.Error("discarded session must contribute no tools")
+	}
+}
+
+// TestRunDropsRedundantReconnect: a reconnect request that lands while the
+// server is already ready is dropped — the caller wanted a fresh connection
+// and already has one, so the live session must survive untouched.
+func TestRunDropsRedundantReconnect(t *testing.T) {
+	var connects atomic.Int64
+	m := NewManager(map[string]ServerConfig{"docs": testCfg("docs")})
+	m.connectTransport = func(_ context.Context, _ ServerConfig, _ *ringBuffer) (sdkmcp.Transport, error) {
+		connects.Add(1)
+		return serveTestServer(t, "docs"), nil
+	}
+	t.Cleanup(m.Close)
+	m.Start(context.Background())
+	waitReady(t, m)
+
+	s := m.servers["docs"]
+	s.mu.Lock()
+	gen := s.gen
+	s.mu.Unlock()
+
+	s.reconnect <- struct{}{} // queued directly: the session stays live
+	waitDrained(t, s)
+	time.Sleep(50 * time.Millisecond) // a redial, if any, would have happened by now
+
+	if got := connects.Load(); got != 1 {
+		t.Errorf("redundant reconnect redialed: %d connects, want 1", got)
+	}
+	s.mu.Lock()
+	gen2, live := s.gen, s.sess != nil
+	s.mu.Unlock()
+	if gen2 != gen || !live {
+		t.Errorf("live session disturbed: gen %d→%d, live=%v", gen, gen2, live)
+	}
+	out := tools.Execute(context.Background(), m.Tools(), "mcp__docs__greet", json.RawMessage(`{"name":"still here"}`))
+	if out != "hi still here" {
+		t.Errorf("greet after redundant reconnect = %q", out)
+	}
+}
+
+// TestRunRefusesReconnectWhenDisabled: /mcp reconnect on a disabled server
+// re-asserts disabled instead of resurrecting it behind the user's back.
+func TestRunRefusesReconnectWhenDisabled(t *testing.T) {
+	var connects, changes atomic.Int64
+	m := NewManager(map[string]ServerConfig{"dead": testCfg("dead")})
+	m.connectTransport = func(_ context.Context, _ ServerConfig, _ *ringBuffer) (sdkmcp.Transport, error) {
+		connects.Add(1)
+		return nil, errors.New("spawn failed")
+	}
+	t.Cleanup(m.Close)
+	m.SetOnChange(func() { changes.Add(1) })
+	m.Start(context.Background())
+	waitReady(t, m) // settles failed; no live session, so nothing races the disable
+
+	if !m.Disable("dead") {
+		t.Fatal("disable returned false")
+	}
+	before := changes.Load()
+	if !m.Reconnect("dead") {
+		t.Fatal("reconnect returned false")
+	}
+	waitDrained(t, m.servers["dead"])
+	deadline := probeDeadline()
+	for changes.Load() == before && !deadline.Done() {
+		deadline.Sleep()
+	}
+	if changes.Load() == before {
+		t.Fatal("run() never handled the reconnect for the disabled server")
+	}
+	if st := m.Statuses()[0]; st.Status != StatusDisabled {
+		t.Errorf("status after reconnecting a disabled server = %+v", st)
+	}
+	if got := connects.Load(); got != 1 {
+		t.Errorf("disabled server dialed %d times, want only the initial attempt", got)
+	}
+}
+
+// TestReconnectDropsLiveSession: /mcp reconnect on a healthy server tears the
+// session down and the server comes back on its own.
+func TestReconnectDropsLiveSession(t *testing.T) {
+	t.Setenv("WHIP_TEST_MCP_BACKOFF_MS", "20")
+	m := newTestManager(t, map[string]ServerConfig{"docs": testCfg("docs")})
+	m.Start(context.Background())
+	waitReady(t, m)
+
+	srv := m.servers["docs"]
+	srv.mu.Lock()
+	gen := srv.gen
+	srv.mu.Unlock()
+
+	if !m.Reconnect("docs") {
+		t.Fatal("reconnect returned false")
+	}
+	deadline := probeDeadline()
+	for !deadline.Done() {
+		srv.mu.Lock()
+		back := srv.status == StatusReady && srv.sess != nil && srv.gen > gen
+		srv.mu.Unlock()
+		if back {
+			break
+		}
+		deadline.Sleep()
+	}
+	srv.mu.Lock()
+	status, live, gen2 := srv.status, srv.sess != nil, srv.gen
+	srv.mu.Unlock()
+	if status != StatusReady || !live || gen2 <= gen {
+		t.Fatalf("after reconnect: status=%v live=%v gen %d→%d", status, live, gen, gen2)
+	}
+	out := tools.Execute(context.Background(), m.Tools(), "mcp__docs__greet", json.RawMessage(`{"name":"again"}`))
+	if out != "hi again" {
+		t.Errorf("greet after reconnect = %q", out)
+	}
+}
+
+// waitDrained blocks until the lifecycle goroutine has taken the queued
+// reconnect request off the channel.
+func waitDrained(t *testing.T, s *server) {
+	t.Helper()
+	deadline := probeDeadline()
+	for len(s.reconnect) > 0 {
+		if deadline.Done() {
+			t.Fatal("reconnect request was never consumed")
+		}
+		deadline.Sleep()
+	}
+}
+
+// TestKickAutoReconnectDeclines: the three cases where a dropped session must
+// NOT schedule a background retry.
+func TestKickAutoReconnectDeclines(t *testing.T) {
+	newSrv := func(cfg ServerConfig) *server {
+		return &server{name: "s", cfg: cfg, ready: make(chan struct{}), calling: make(chan struct{}, 1), reconnect: make(chan struct{}, 1)}
+	}
+	// Disabled: the user turned it off.
+	m := NewManager(nil)
+	s := newSrv(ServerConfig{Command: []string{"x"}, Enabled: new(false)})
+	s.kickAutoReconnect(m)
+
+	// Closing manager: whip is shutting down.
+	closing := NewManager(nil)
+	closing.onChangeMu.Lock()
+	closing.closed = true
+	closing.onChangeMu.Unlock()
+	s2 := newSrv(ServerConfig{Command: []string{"x"}})
+	s2.kickAutoReconnect(closing)
+
+	// Retry budget spent: stop flapping.
+	s3 := newSrv(ServerConfig{Command: []string{"x"}})
+	s3.autoTries = autoReconnectMax
+	s3.kickAutoReconnect(m)
+
+	// Each declines synchronously — nothing is ever queued.
+	time.Sleep(50 * time.Millisecond)
+	for i, got := range []*server{s, s2, s3} {
+		if len(got.reconnect) != 0 {
+			t.Errorf("case %d scheduled a reconnect", i)
+		}
+	}
+}
+
+// TestProbeRemote drives Probe through the real defaultTransport against a
+// loopback MCP server: the tool-name list is capped at five plus an ellipsis.
+func TestProbeRemote(t *testing.T) {
+	srv := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "many"}, nil)
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		sdkmcp.AddTool(srv, &sdkmcp.Tool{Name: name, InputSchema: map[string]any{"type": "object"}},
+			func(ctx context.Context, req *sdkmcp.CallToolRequest, in struct{}) (*sdkmcp.CallToolResult, any, error) {
+				return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "ok"}}}, nil, nil
+			})
+	}
+	hs := httptest.NewServer(sdkmcp.NewStreamableHTTPHandler(func(*http.Request) *sdkmcp.Server { return srv }, nil))
+	defer hs.Close()
+
+	res := Probe(context.Background(), "many", ServerConfig{URL: hs.URL, StartupTimeout: 10})
+	if res.Status != StatusReady {
+		t.Fatalf("probe = %+v", res)
+	}
+	if res.Tools != 7 {
+		t.Errorf("tools = %d, want 7", res.Tools)
+	}
+	if len(res.ToolNames) != 6 || res.ToolNames[5] != "…" {
+		t.Fatalf("tool names = %v, want 5 names + …", res.ToolNames)
+	}
+	if res.ToolNames[0] != "mcp__many__a" {
+		t.Errorf("tool names = %v", res.ToolNames)
+	}
+	if res.Elapsed <= 0 {
+		t.Error("probe should report elapsed time")
+	}
+}
+
+// TestProbeContextCancelled: a probe whose caller gives up first reports the
+// context error rather than waiting out the startup timeout.
+func TestProbeContextCancelled(t *testing.T) {
+	stop := make(chan struct{})
+	hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select { // never answers the initialize request
+		case <-r.Context().Done():
+		case <-stop:
+		}
+	}))
+	// LIFO: release the wedged handlers before Close waits on them.
+	defer hs.Close()
+	defer close(stop)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	res := Probe(ctx, "wedged", ServerConfig{URL: hs.URL, StartupTimeout: 120})
+	if res.Status != StatusFailed || res.Err == "" {
+		t.Fatalf("probe = %+v", res)
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Errorf("probe waited %s, should have given up with the caller's context", elapsed)
+	}
+}

--- a/internal/session/failure_test.go
+++ b/internal/session/failure_test.go
@@ -1,0 +1,311 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/context-labs/whip/internal/llm"
+)
+
+// exec runs test-only SQL against the store's own database. Every fault below
+// is injected this way — through the real store's real connection — so the
+// production code under test is untouched.
+func exec(t *testing.T, st *Store, query string, args ...any) {
+	t.Helper()
+	if _, err := st.db.ExecContext(context.Background(), query, args...); err != nil {
+		t.Fatalf("fault injection %q: %v", query, err)
+	}
+}
+
+// TestOpenRejectsIncompatibleDatabase: pointing the store at a database whose
+// schema collides with whip's must return an error, not a half-built Store.
+func TestOpenRejectsIncompatibleDatabase(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "s.db")
+	db, err := sql.Open("sqlite", p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// an index named "messages" makes CREATE TABLE messages fail even with
+	// IF NOT EXISTS — the name is already taken in the schema namespace
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE t(a); CREATE INDEX messages ON t(a)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Open(p)
+	if err == nil {
+		st.Close()
+		t.Fatal("Open should reject a database whose schema collides with whip's")
+	}
+	if !strings.Contains(err.Error(), "messages") {
+		t.Fatalf("error should name the colliding object: %v", err)
+	}
+}
+
+// TestClosedStoreDegradesGracefully is the graceful-degradation contract: once
+// the database is gone, every accessor must report failure (error return, or
+// nil for the ones that swallow errors) instead of panicking.
+func TestClosedStoreDegradesGracefully(t *testing.T) {
+	st, id := seeded(t)
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	errCases := map[string]func() error{
+		"LoadTasks":   func() error { _, err := st.LoadTasks(id); return err },
+		"Save":        func() error { return st.Save(id, 0, []llm.Message{{Role: "user", Content: "x"}}, "m", "p") },
+		"Load":        func() error { _, _, err := st.Load(id); return err },
+		"Recent":      func() error { _, err := st.Recent(10); return err },
+		"UserHistory": func() error { _, err := st.UserHistory(10); return err },
+		"DeleteFrom":  func() error { return st.DeleteFrom(id, 1) },
+		"Fork":        func() error { _, err := st.Fork(id, 2, "x"); return err },
+		"ForksOf":     func() error { _, err := st.ForksOf(id); return err },
+		"ForkTitle":   func() error { _, err := st.ForkTitle("base"); return err },
+		"AddSchedule": func() error { _, err := st.AddSchedule(id, "@every 1m", "p", time.Now()); return err },
+	}
+	for name, fn := range errCases {
+		if err := fn(); err == nil {
+			t.Errorf("%s on a closed store should error", name)
+		}
+	}
+
+	if got := st.Snapshots(id); got != nil {
+		t.Errorf("Snapshots on a closed store = %v, want nil", got)
+	}
+	if got := st.Schedules(id); got != nil {
+		t.Errorf("Schedules on a closed store = %v, want nil", got)
+	}
+	if got := st.Compactions(id); got != nil {
+		t.Errorf("Compactions on a closed store = %v, want nil", got)
+	}
+	if got := st.RawMessages(id); got != nil {
+		t.Errorf("RawMessages on a closed store = %v, want nil", got)
+	}
+	if got := st.Todos(id); got != "" {
+		t.Errorf("Todos on a closed store = %q, want empty", got)
+	}
+}
+
+// TestLoadReportsMissingMessageTable: the session row resolves but the message
+// query fails — Load must surface that, not return a silently empty history.
+func TestLoadReportsMissingMessageTable(t *testing.T) {
+	st, id := seeded(t)
+	exec(t, st, `DROP TABLE messages`)
+	if _, _, err := st.Load(id); err == nil {
+		t.Fatal("Load should report the failed message query")
+	}
+}
+
+// TestScanMetasRejectsCorruptRow: a session row whose fork_seq holds
+// non-numeric text (a hand-edited or corrupted database) must fail the scan
+// rather than yield a bogus Meta.
+func TestScanMetasRejectsCorruptRow(t *testing.T) {
+	st, id := seeded(t)
+	exec(t, st, `UPDATE sessions SET fork_seq='not-a-number' WHERE id=?`, id)
+
+	if _, _, err := st.Load(id); err == nil {
+		t.Error("Load should report the corrupt fork_seq")
+	}
+	if _, err := st.Recent(10); err == nil {
+		t.Error("Recent should report the corrupt fork_seq")
+	}
+	// ForksOf reads the same columns; make the corrupt row a child of itself
+	exec(t, st, `UPDATE sessions SET forked_from=? WHERE id=?`, id, id)
+	if _, err := st.ForksOf(id); err == nil {
+		t.Error("ForksOf should report the corrupt fork_seq")
+	}
+}
+
+// TestSaveReportsMessageWriteFailure: a write that the database refuses must
+// abort the whole Save (the transaction rolls back), not report success.
+func TestSaveReportsMessageWriteFailure(t *testing.T) {
+	st, id := seeded(t)
+	exec(t, st, `CREATE TRIGGER no_messages BEFORE INSERT ON messages BEGIN SELECT RAISE(ABORT,'disk full'); END`)
+
+	err := st.Save(id, 5, []llm.Message{{}, {}, {}, {}, {}, {Role: "user", Content: "new"}}, "m", "p")
+	if err == nil {
+		t.Fatal("Save should report the refused message write")
+	}
+	// the transaction rolled back: the seeded history is intact and unchanged
+	exec(t, st, `DROP TRIGGER no_messages`)
+	if _, msgs, err := st.Load(id); err != nil || len(msgs) != 4 {
+		t.Fatalf("failed Save must not commit anything: %v %d msgs", err, len(msgs))
+	}
+}
+
+// TestSaveReportsMetadataWriteFailure covers the second statement in the same
+// transaction: the message rows land but the sessions row refuses the update.
+func TestSaveReportsMetadataWriteFailure(t *testing.T) {
+	st, id := seeded(t)
+	exec(t, st, `CREATE TRIGGER no_meta BEFORE UPDATE ON sessions BEGIN SELECT RAISE(ABORT,'read only'); END`)
+
+	if err := st.Save(id, 5, []llm.Message{{}, {}, {}, {}, {}, {Role: "user", Content: "new"}}, "m", "p"); err == nil {
+		t.Fatal("Save should report the refused metadata update")
+	}
+	exec(t, st, `DROP TRIGGER no_meta`)
+	if _, msgs, err := st.Load(id); err != nil || len(msgs) != 4 {
+		t.Fatalf("the message insert must roll back with the metadata update: %v %d msgs", err, len(msgs))
+	}
+}
+
+// TestSaveSkipsPlaceholderRows: zero-value messages (padding the caller never
+// meant to persist) must not clobber the raw log.
+func TestSaveSkipsPlaceholderRows(t *testing.T) {
+	st, id := seeded(t)
+	msgs := []llm.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1", Authored: true},
+		{Role: "assistant", Content: "a1"},
+		{}, // placeholder: must be skipped, not written over seq 3
+		{Role: "assistant", Content: "a2"},
+	}
+	if err := st.Save(id, 3, msgs, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	raw := st.RawMessages(id)
+	if len(raw) != 4 {
+		t.Fatalf("placeholder should not add or replace a row: %d rows", len(raw))
+	}
+	if raw[2].Content != "q2" {
+		t.Fatalf("seq 3 should keep its original content, got %q", raw[2].Content)
+	}
+}
+
+// TestForkReportsWriteFailures: both halves of the fork transaction must
+// surface a refused write.
+func TestForkReportsWriteFailures(t *testing.T) {
+	t.Run("session row", func(t *testing.T) {
+		st, id := seeded(t)
+		exec(t, st, `CREATE TRIGGER no_sessions BEFORE INSERT ON sessions BEGIN SELECT RAISE(ABORT,'nope'); END`)
+		if _, err := st.Fork(id, 2, "x"); err == nil {
+			t.Fatal("Fork should report the refused session insert")
+		}
+	})
+	t.Run("message rows", func(t *testing.T) {
+		st, id := seeded(t)
+		exec(t, st, `CREATE TRIGGER no_messages BEFORE INSERT ON messages BEGIN SELECT RAISE(ABORT,'nope'); END`)
+		newID, err := st.Fork(id, 2, "x")
+		if err == nil {
+			t.Fatal("Fork should report the refused message copy")
+		}
+		if newID != "" {
+			t.Fatalf("a failed fork must not report an id, got %q", newID)
+		}
+		exec(t, st, `DROP TRIGGER no_messages`)
+		// the session row rolled back with it — no orphan fork
+		forks, err := st.ForksOf(id)
+		if err != nil || len(forks) != 0 {
+			t.Fatalf("a failed fork must not leave a session row behind: %v %+v", err, forks)
+		}
+	})
+}
+
+// TestForkTitleUnwrapsExistingSuffix: forking a fork increments the counter
+// instead of nesting "(fork #N)" suffixes.
+func TestForkTitleUnwrapsExistingSuffix(t *testing.T) {
+	st, id := seeded(t)
+	if _, err := st.Fork(id, 2, "notes (fork #1)"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.ForkTitle("notes (fork #1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "notes (fork #2)" {
+		t.Fatalf("forking a fork should increment, got %q", got)
+	}
+	// a suffix with trailing text is not a fork marker and stays verbatim
+	got, err = st.ForkTitle("notes (fork #9) draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "notes (fork #9) draft (fork #1)" {
+		t.Fatalf("only an exact suffix unwraps, got %q", got)
+	}
+}
+
+// TestSchedulesSkipsCorruptRow: one unreadable schedule row must not take the
+// rest of the list down with it.
+func TestSchedulesSkipsCorruptRow(t *testing.T) {
+	st, id := seeded(t)
+	anchor := time.Now().Truncate(time.Second)
+	if _, err := st.AddSchedule(id, "@every 10m", "first", anchor); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AddSchedule(id, "@every 20m", "second", anchor); err != nil {
+		t.Fatal(err)
+	}
+	exec(t, st, `UPDATE schedules SET id='corrupt' WHERE session_id=? AND prompt='first'`, id)
+
+	got := st.Schedules(id)
+	if len(got) != 1 || got[0].Prompt != "second" {
+		t.Fatalf("the readable schedule should survive, got %+v", got)
+	}
+}
+
+// TestUserHistorySkipsMalformedRows: a row whose content isn't valid message
+// JSON is skipped rather than failing the whole recall.
+func TestUserHistorySkipsMalformedRows(t *testing.T) {
+	st, id := seeded(t)
+	exec(t, st, `INSERT INTO messages (session_id, seq, role, content) VALUES (?,?,?,?)`,
+		id, 99, "user", "{not json")
+
+	got, err := st.UserHistory(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "q2" || got[1] != "q1" {
+		t.Fatalf("malformed row should be skipped, got %q", got)
+	}
+}
+
+// TestApplyCompactionKeepsPriorSummary: a second compaction must keep the
+// previous compaction's saved summary row — it covers history the new summary
+// does not reach.
+func TestApplyCompactionKeepsPriorSummary(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	id, err := st.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := []llm.Message{
+		{Role: "system", Content: "sys"}, // seq 0 is never persisted
+		{Role: "user", Content: "q1", Authored: true},
+		{Role: "system", Content: "Summary of the conversation so far:\n\nfirst gen"},
+		{Role: "user", Content: "q2", Authored: true},
+		{Role: "assistant", Content: "a2"},
+	}
+	if err := st.Save(id, 1, msgs, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RecordCompaction(id, 3, "second gen"); err != nil {
+		t.Fatal(err)
+	}
+	_, got, err := st.Load(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// the raw log is [q1, first-gen summary, q2, a2]; folding at 3 keeps the
+	// head slot, the new summary, the prior summary, and the raw tail
+	if len(got) != 4 {
+		t.Fatalf("compacted view: %d msgs %+v", len(got), got)
+	}
+	if !strings.Contains(got[1].Content, "second gen") {
+		t.Fatalf("the newest summary should come first: %q", got[1].Content)
+	}
+	if !strings.Contains(got[2].Content, "first gen") {
+		t.Fatalf("the prior summary must be kept: %q", got[2].Content)
+	}
+	if got[3].Content != "a2" {
+		t.Fatalf("raw tail lost: %+v", got[3:])
+	}
+}

--- a/internal/tools/bashrun/bashrun.go
+++ b/internal/tools/bashrun/bashrun.go
@@ -388,6 +388,22 @@ func runInteractive(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 			quietMu.Lock()
 			idle := time.Since(quiet)
 			quietMu.Unlock()
+			// A context kill outranks the inactivity timer. Without this the
+			// kill races the output pump's end-of-stream: whichever arm of
+			// this select won decided whether the same event was reported as
+			// "timed out"/"cancelled" or as "timed out waiting for input".
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				stop()
+				_ = cmd.Wait()
+				res := Result{Output: buf.String(), Killed: true, Interactive: true}
+				if errors.Is(ctxErr, context.DeadlineExceeded) {
+					res.TimedOut = true
+					res.Exit = "timed out"
+				} else {
+					res.Exit = "cancelled"
+				}
+				return res
+			}
 			if idle >= opts.InactivityTimeout {
 				stop()
 				_ = cmd.Wait()

--- a/internal/tools/bashrun/failure_test.go
+++ b/internal/tools/bashrun/failure_test.go
@@ -40,26 +40,35 @@ func TestRunReportsUnstartableShell(t *testing.T) {
 // a silent long-running child dies promptly whether the hard wall-clock cap or
 // the user's interrupt gets there first, and the result says so.
 //
-// Which of the two exit texts wins is not deterministic: killing the child
-// closes the PTY and cancels the context at the same moment, so the output
-// pump may report end-of-stream or may exit on ctx.Done and leave the
-// inactivity clock to finish the job. Both are correct kills; the contract
-// under test is "killed, quickly, and reported".
+// The reported reason comes from the context, not from whichever arm of the
+// run loop's select happened to win the race with the output pump, so each
+// case has one correct exit text.
 func TestInteractiveNeverOutlivesItsCaps(t *testing.T) {
-	cases := map[string]func() (context.Context, time.Duration){
-		"hard timeout": func() (context.Context, time.Duration) {
-			return context.Background(), 200 * time.Millisecond
+	cases := map[string]struct {
+		setup    func() (context.Context, time.Duration)
+		wantExit string
+		wantTO   bool
+	}{
+		"hard timeout": {
+			setup: func() (context.Context, time.Duration) {
+				return context.Background(), 200 * time.Millisecond
+			},
+			wantExit: "timed out",
+			wantTO:   true,
 		},
-		"cancellation": func() (context.Context, time.Duration) {
-			ctx, cancel := context.WithCancel(context.Background())
-			time.AfterFunc(150*time.Millisecond, cancel)
-			t.Cleanup(cancel)
-			return ctx, 30 * time.Second
+		"cancellation": {
+			setup: func() (context.Context, time.Duration) {
+				ctx, cancel := context.WithCancel(context.Background())
+				time.AfterFunc(150*time.Millisecond, cancel)
+				t.Cleanup(cancel)
+				return ctx, 30 * time.Second
+			},
+			wantExit: "cancelled",
 		},
 	}
-	for name, setup := range cases {
+	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, timeout := setup()
+			ctx, timeout := tc.setup()
 			start := time.Now()
 			res := Run(ctx, Options{
 				Command:           "sleep 30",
@@ -71,8 +80,11 @@ func TestInteractiveNeverOutlivesItsCaps(t *testing.T) {
 			if !res.Killed || !res.Interactive {
 				t.Fatalf("expected a killed interactive result: %+v", res)
 			}
-			if res.Exit == "" {
-				t.Fatalf("a killed command must carry an exit reason: %+v", res)
+			if res.Exit != tc.wantExit {
+				t.Fatalf("exit reason: got %q, want %q (%+v)", res.Exit, tc.wantExit, res)
+			}
+			if res.TimedOut != tc.wantTO {
+				t.Fatalf("TimedOut: got %v, want %v (%+v)", res.TimedOut, tc.wantTO, res)
 			}
 			if elapsed > 10*time.Second {
 				t.Fatalf("the child outlived its caps by %s", elapsed)

--- a/internal/tools/bashrun/failure_test.go
+++ b/internal/tools/bashrun/failure_test.go
@@ -1,0 +1,152 @@
+package bashrun
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunReportsUnstartableShell: a $SHELL that doesn't exist must come back as
+// a failed run, not a hang and not a panic — on both the piped and the
+// interactive path (the latter falls back to the piped one when pty.Start
+// fails).
+func TestRunReportsUnstartableShell(t *testing.T) {
+	for _, interactive := range []bool{false, true} {
+		t.Setenv("SHELL", "/nonexistent/definitely-not-a-shell")
+		res := Run(context.Background(), Options{
+			Command:           "echo hi",
+			Interactive:       interactive,
+			Timeout:           5 * time.Second,
+			InactivityTimeout: time.Second,
+		})
+		if res.Exit == "" {
+			t.Fatalf("interactive=%v: a shell that can't start must report an exit status: %+v", interactive, res)
+		}
+		// the piped path names the missing binary; the interactive path first
+		// fails in pty.Start and reports the failed retry of the same cmd
+		if !strings.Contains(res.Exit, "exit:") {
+			t.Fatalf("interactive=%v: exit should name the start failure, got %q", interactive, res.Exit)
+		}
+		if res.Output != "" {
+			t.Fatalf("interactive=%v: nothing ran, so there is no output: %q", interactive, res.Output)
+		}
+	}
+}
+
+// TestInteractiveNeverOutlivesItsCaps: the safety property of the PTY path —
+// a silent long-running child dies promptly whether the hard wall-clock cap or
+// the user's interrupt gets there first, and the result says so.
+//
+// Which of the two exit texts wins is not deterministic: killing the child
+// closes the PTY and cancels the context at the same moment, so the output
+// pump may report end-of-stream or may exit on ctx.Done and leave the
+// inactivity clock to finish the job. Both are correct kills; the contract
+// under test is "killed, quickly, and reported".
+func TestInteractiveNeverOutlivesItsCaps(t *testing.T) {
+	cases := map[string]func() (context.Context, time.Duration){
+		"hard timeout": func() (context.Context, time.Duration) {
+			return context.Background(), 200 * time.Millisecond
+		},
+		"cancellation": func() (context.Context, time.Duration) {
+			ctx, cancel := context.WithCancel(context.Background())
+			time.AfterFunc(150*time.Millisecond, cancel)
+			t.Cleanup(cancel)
+			return ctx, 30 * time.Second
+		},
+	}
+	for name, setup := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, timeout := setup()
+			start := time.Now()
+			res := Run(ctx, Options{
+				Command:           "sleep 30",
+				Interactive:       true,
+				Timeout:           timeout,
+				InactivityTimeout: 500 * time.Millisecond,
+			})
+			elapsed := time.Since(start)
+			if !res.Killed || !res.Interactive {
+				t.Fatalf("expected a killed interactive result: %+v", res)
+			}
+			if res.Exit == "" {
+				t.Fatalf("a killed command must carry an exit reason: %+v", res)
+			}
+			if elapsed > 10*time.Second {
+				t.Fatalf("the child outlived its caps by %s", elapsed)
+			}
+		})
+	}
+}
+
+// TestExitString covers the three renderings the model sees.
+func TestExitString(t *testing.T) {
+	if got := exitString(nil); got != "" {
+		t.Fatalf("a clean exit must render empty, got %q", got)
+	}
+	if got := exitString(errors.New("fork/exec: no such file")); got != "(exit: fork/exec: no such file)" {
+		t.Fatalf("non-exit errors: %q", got)
+	}
+	err := exec.CommandContext(t.Context(), "sh", "-c", "exit 5").Run()
+	if got := exitString(err); got != "(exit: exit status 5)" {
+		t.Fatalf("exit status: %q", got)
+	}
+}
+
+// TestIsKilledBySignal distinguishes a signalled death from a plain non-zero
+// exit and from a non-exec error.
+func TestIsKilledBySignal(t *testing.T) {
+	if isKilledBySignal(errors.New("boom")) {
+		t.Fatal("a non-exec error is not a signal kill")
+	}
+	if isKilledBySignal(exec.CommandContext(t.Context(), "sh", "-c", "exit 2").Run()) {
+		t.Fatal("a plain non-zero exit is not a signal kill")
+	}
+	err := exec.CommandContext(t.Context(), "sh", "-c", "kill -9 $$").Run()
+	if err == nil {
+		t.Fatal("self-SIGKILL should fail the command")
+	}
+	if !isKilledBySignal(err) {
+		t.Fatalf("SIGKILL should be reported as a signal kill: %v", err)
+	}
+}
+
+// TestTrackIgnoresUnstartedCommands: a command that never started has no pid,
+// so the registry must ignore it rather than record a zero key (which KillAll
+// would then signal).
+func TestTrackIgnoresUnstartedCommands(t *testing.T) {
+	before := trackedCount()
+	unstarted := exec.CommandContext(t.Context(), "true")
+	track(unstarted)
+	if got := trackedCount(); got != before {
+		t.Fatalf("tracking an unstarted command changed the registry: %d -> %d", before, got)
+	}
+	untrack(unstarted)
+	if got := trackedCount(); got != before {
+		t.Fatalf("untracking an unstarted command changed the registry: %d -> %d", before, got)
+	}
+}
+
+// TestKillAllSkipsProcesslessEntries: KillAll must not panic on a registry
+// entry whose process is gone.
+func TestKillAllSkipsProcesslessEntries(t *testing.T) {
+	trackMu.Lock()
+	tracked[-1] = exec.CommandContext(t.Context(), "true") // never started: Process is nil
+	trackMu.Unlock()
+	t.Cleanup(func() {
+		trackMu.Lock()
+		delete(tracked, -1)
+		trackMu.Unlock()
+	})
+
+	KillAll()
+
+	trackMu.Lock()
+	_, still := tracked[-1]
+	trackMu.Unlock()
+	if !still {
+		t.Fatal("KillAll should not mutate the registry")
+	}
+}

--- a/internal/tools/browser_exec_test.go
+++ b/internal/tools/browser_exec_test.go
@@ -1,0 +1,504 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/browser"
+)
+
+// fakeBackend implements browser.Backend with no Chrome behind it: it
+// records every call and returns canned values, so the whole helper
+// dispatch in exec() is drivable offline.
+type fakeBackend struct {
+	calls []string
+	err   error // when set, every backend call returns it
+
+	info  browser.PageInfo
+	eval  string
+	ax    string
+	tabs  []browser.Tab
+	shot  []byte
+	found bool
+	boxX  float64
+	boxY  float64
+	mode  browser.Mode
+}
+
+func (f *fakeBackend) log(call string) error {
+	f.calls = append(f.calls, call)
+	return f.err
+}
+
+func (f *fakeBackend) Info(context.Context) (browser.PageInfo, error) {
+	return f.info, f.log("Info()")
+}
+
+func (f *fakeBackend) Navigate(_ context.Context, url string) error {
+	return f.log("Navigate(" + url + ")")
+}
+func (f *fakeBackend) Back(context.Context) error { return f.log("Back()") }
+func (f *fakeBackend) Eval(_ context.Context, expr string) (string, error) {
+	return f.eval, f.log("Eval(" + expr + ")")
+}
+
+func (f *fakeBackend) ClickAt(_ context.Context, x, y float64) error {
+	return f.log(fmtCall("ClickAt", x, y))
+}
+
+func (f *fakeBackend) TypeText(_ context.Context, text string) error {
+	return f.log("TypeText(" + text + ")")
+}
+
+func (f *fakeBackend) PressKey(_ context.Context, key string) error {
+	return f.log("PressKey(" + key + ")")
+}
+
+func (f *fakeBackend) Fill(_ context.Context, sel, text string) error {
+	return f.log("Fill(" + sel + "," + text + ")")
+}
+
+func (f *fakeBackend) Scroll(_ context.Context, dy float64) error {
+	return f.log(fmtCall("Scroll", dy))
+}
+func (f *fakeBackend) WaitLoad(context.Context) error { return f.log("WaitLoad()") }
+func (f *fakeBackend) WaitElement(_ context.Context, sel string, visible bool) (bool, error) {
+	return f.found, f.log("WaitElement(" + sel + "," + boolStr(visible) + ")")
+}
+
+func (f *fakeBackend) Screenshot(_ context.Context, maxDim int) ([]byte, error) {
+	return f.shot, f.log(fmtCall("Screenshot", float64(maxDim)))
+}
+func (f *fakeBackend) AXTree(context.Context) (string, error) { return f.ax, f.log("AXTree()") }
+func (f *fakeBackend) BoxModel(_ context.Context, id int) (float64, float64, error) {
+	return f.boxX, f.boxY, f.log(fmtCall("BoxModel", float64(id)))
+}
+
+func (f *fakeBackend) Tabs(context.Context) ([]browser.Tab, error) { return f.tabs, f.log("Tabs()") }
+
+func (f *fakeBackend) UseTab(_ context.Context, id string) error { return f.log("UseTab(" + id + ")") }
+
+func (f *fakeBackend) UploadFiles(_ context.Context, sel string, paths []string) error {
+	return f.log("UploadFiles(" + sel + "," + strings.Join(paths, "|") + ")")
+}
+
+func (f *fakeBackend) HandleDialog(accept bool, prompt string) error {
+	return f.log("HandleDialog(" + boolStr(accept) + "," + prompt + ")")
+}
+func (f *fakeBackend) Mode() browser.Mode         { return f.mode }
+func (f *fakeBackend) Obtained() browser.Obtained { return browser.ObtainedLaunched }
+func (f *fakeBackend) Close() error               { return f.log("Close()") }
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// fmtCall renders numeric args the way %v would, keeping call logs stable.
+func fmtCall(name string, nums ...float64) string {
+	var b strings.Builder
+	b.WriteString(name + "(")
+	for i, n := range nums {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		data, _ := json.Marshal(n)
+		b.Write(data)
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+// execOne parses a single-statement program and runs it against b.
+func execOne(t *testing.T, b browser.Backend, code string) (string, []byte, error) {
+	t.Helper()
+	prog, err := parseHelperProgram(code)
+	if err != nil {
+		t.Fatalf("parse %q: %v", code, err)
+	}
+	if len(prog) != 1 {
+		t.Fatalf("want 1 statement from %q, got %d", code, len(prog))
+	}
+	return prog[0].exec(t.Context(), b)
+}
+
+// TestExecHelpers drives every helper in exec's dispatch switch, asserting
+// both the returned output and which backend call it made.
+func TestExecHelpers(t *testing.T) {
+	tests := []struct {
+		name  string
+		code  string
+		setup func(*fakeBackend)
+		out   string
+		calls []string
+	}{
+		// 93.184.216.34 is a public literal IP: no DNS, no private block.
+		{name: "goto", code: `goto("http://93.184.216.34/")`, calls: []string{"Navigate(http://93.184.216.34/)"}},
+		{name: "goto non-http skips checks", code: `goto("about:blank")`, calls: []string{"Navigate(about:blank)"}},
+		{name: "back", code: `back()`, calls: []string{"Back()"}},
+		{
+			name:  "info",
+			code:  `info()`,
+			setup: func(f *fakeBackend) { f.info = browser.PageInfo{URL: "http://x/", Title: "T", Width: 800} },
+			out:   `{"URL":"http://x/","Title":"T","Width":800,"Height":0,"ScrollX":0,"ScrollY":0,"PageWidth":0,"PageHeight":0}`,
+			calls: []string{"Info()"},
+		},
+		{
+			name:  "js",
+			code:  `js("document.title")`,
+			setup: func(f *fakeBackend) { f.eval = `"hello"` },
+			out:   `"hello"`,
+			calls: []string{"Eval(document.title)"},
+		},
+		{name: "click", code: `click(10, 20.5)`, calls: []string{"ClickAt(10,20.5)"}},
+		{name: "type", code: `type("hi there")`, calls: []string{"TypeText(hi there)"}},
+		{name: "type coerces number arg", code: `type(42)`, calls: []string{"TypeText(42)"}},
+		{name: "type coerces array arg", code: `type([1,2])`, calls: []string{"TypeText([1,2])"}},
+		{name: "press", code: `press(Enter)`, calls: []string{"PressKey(Enter)"}},
+		{name: "fill", code: `fill("#q", "paper towels")`, calls: []string{"Fill(#q,paper towels)"}},
+		{name: "scroll", code: `scroll(-120)`, calls: []string{"Scroll(-120)"}},
+		{name: "scroll defaults to -300", code: `scroll()`, calls: []string{"Scroll(-300)"}},
+		{name: "scroll defaults on non-number", code: `scroll("down")`, calls: []string{"Scroll(-300)"}},
+		{name: "waitLoad", code: `waitLoad()`, calls: []string{"WaitLoad()"}},
+		{
+			name:  "waitFor found",
+			code:  `waitFor(".ok", true)`,
+			setup: func(f *fakeBackend) { f.found = true },
+			out:   "true",
+			calls: []string{"WaitElement(.ok,true)"},
+		},
+		{name: "waitFor defaults visible false", code: `waitFor(".ok")`, out: "false", calls: []string{"WaitElement(.ok,false)"}},
+		{
+			name:  "ax",
+			code:  `ax()`,
+			setup: func(f *fakeBackend) { f.ax = `[{"role":"button"}]` },
+			out:   `[{"role":"button"}]`,
+			calls: []string{"AXTree()"},
+		},
+		{
+			name:  "box",
+			code:  `box(7)`,
+			setup: func(f *fakeBackend) { f.boxX, f.boxY = 12.34, 56.78 },
+			out:   `{"x":12.3,"y":56.8}`,
+			calls: []string{"BoxModel(7)"},
+		},
+		{
+			name:  "tabs",
+			code:  `tabs()`,
+			setup: func(f *fakeBackend) { f.tabs = []browser.Tab{{TargetID: "t1", Title: "one", URL: "http://a/"}} },
+			out:   `[{"TargetID":"t1","Title":"one","URL":"http://a/"}]`,
+			calls: []string{"Tabs()"},
+		},
+		{name: "useTab", code: `useTab("t1")`, calls: []string{"UseTab(t1)"}},
+		{name: "upload array", code: `upload("#f", ["/tmp/a.png", "/tmp/b.png"])`, calls: []string{"UploadFiles(#f,/tmp/a.png|/tmp/b.png)"}},
+		{name: "upload single string", code: `upload("#f", "/tmp/a.png")`, calls: []string{"UploadFiles(#f,/tmp/a.png)"}},
+		{name: "dialog accept", code: `dialog(true)`, calls: []string{"HandleDialog(true,)"}},
+		{name: "dialog defaults to accept", code: `dialog()`, calls: []string{"HandleDialog(true,)"}},
+		{name: "dialog with prompt text", code: `dialog(false, "answer")`, calls: []string{"HandleDialog(false,answer)"}},
+		{
+			name:  "screenshot",
+			code:  `screenshot()`,
+			setup: func(f *fakeBackend) { f.shot = []byte("jpegbytes") },
+			out:   "(screenshot captured: 9 bytes, jpeg, ≤1568px)",
+			calls: []string{"Screenshot(1568)"},
+		},
+		{name: "print literal", code: `print("hello")`, out: "hello"},
+		{name: "print number", code: `print(42)`, out: "42"},
+		{
+			name:  "print nested call",
+			code:  `print(js("1+1"))`,
+			setup: func(f *fakeBackend) { f.eval = "2" },
+			out:   "2",
+			calls: []string{"Eval(1+1)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBackend{mode: browser.ModeHeadless}
+			if tt.setup != nil {
+				tt.setup(b)
+			}
+			out, shot, err := execOne(t, b, tt.code)
+			if err != nil {
+				t.Fatalf("exec: %v", err)
+			}
+			if out != tt.out {
+				t.Errorf("out = %q, want %q", out, tt.out)
+			}
+			if got := strings.Join(b.calls, " "); got != strings.Join(tt.calls, " ") {
+				t.Errorf("calls = %v, want %v", b.calls, tt.calls)
+			}
+			if tt.name == "screenshot" && string(shot) != "jpegbytes" {
+				t.Errorf("screenshot bytes not returned: %q", shot)
+			} else if tt.name != "screenshot" && shot != nil {
+				t.Errorf("unexpected screenshot: %q", shot)
+			}
+		})
+	}
+}
+
+// TestExecArgErrors covers the missing/wrong-type argument paths.
+func TestExecArgErrors(t *testing.T) {
+	tests := []struct {
+		name, code, want string
+	}{
+		{"goto missing url", `goto()`, "goto: missing arg 1"},
+		{"js missing expr", `js()`, "js: missing arg 1"},
+		{"click missing x", `click()`, "click: missing arg 1"},
+		{"click missing y", `click(10)`, "click: missing arg 2"},
+		{"click non-numeric x", `click("a", 2)`, "click: arg 1 must be a number"},
+		{"type missing text", `type()`, "type: missing arg 1"},
+		{"press missing key", `press()`, "press: missing arg 1"},
+		{"fill missing selector", `fill()`, "fill: missing arg 1"},
+		{"fill missing text", `fill("#q")`, "fill: missing arg 2"},
+		{"waitFor missing selector", `waitFor()`, "waitFor: missing arg 1"},
+		{"box missing id", `box()`, "box: missing arg 1"},
+		{"box non-numeric", `box("x")`, "box: arg 1 must be a number"},
+		{"useTab missing id", `useTab()`, "useTab: missing arg 1"},
+		{"upload missing selector", `upload()`, "upload: missing arg 1"},
+		{"upload missing paths", `upload("#f")`, "upload: missing paths array"},
+		{"upload non-string path", `upload("#f", [1, 2])`, "upload: paths must be strings"},
+		{"upload bad paths type", `upload("#f", 7)`, "upload: paths must be an array or string"},
+		{"unknown helper", `frobnicate("x")`, `unknown helper "frobnicate"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBackend{mode: browser.ModeHeadless}
+			_, _, err := execOne(t, b, tt.code)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err = %v, want containing %q", err, tt.want)
+			}
+			if len(b.calls) != 0 {
+				t.Errorf("backend must not be called on an arg error: %v", b.calls)
+			}
+		})
+	}
+}
+
+// TestExecBackendErrors: every helper that returns a value must surface the
+// backend's error rather than a half-built result.
+func TestExecBackendErrors(t *testing.T) {
+	boom := errors.New("boom")
+	for _, code := range []string{
+		`goto("http://93.184.216.34/")`, `back()`, `info()`, `js("1")`, `click(1,2)`,
+		`type("x")`, `press(Enter)`, `fill("#q","x")`, `scroll(-10)`, `waitLoad()`,
+		`waitFor(".ok")`, `ax()`, `box(1)`, `tabs()`, `useTab("t")`,
+		`upload("#f","/tmp/a")`, `dialog(true)`, `screenshot()`,
+	} {
+		t.Run(code, func(t *testing.T) {
+			b := &fakeBackend{mode: browser.ModeHeadless, err: boom}
+			out, shot, err := execOne(t, b, code)
+			if !errors.Is(err, boom) {
+				t.Fatalf("err = %v, want boom", err)
+			}
+			if out != "" || shot != nil {
+				t.Errorf("want empty result on error, got out=%q shot=%q", out, shot)
+			}
+		})
+	}
+}
+
+// TestExecGotoSafety: the always-blocked floor applies in every mode; the
+// private-address block only outside live mode.
+func TestExecGotoSafety(t *testing.T) {
+	tests := []struct {
+		name, code string
+		mode       browser.Mode
+		wantErr    string
+		wantCalls  int
+	}{
+		{name: "metadata blocked in headless", code: `goto("http://169.254.169.254/latest/")`, mode: browser.ModeHeadless, wantErr: "cloud-metadata"},
+		{name: "metadata blocked in live", code: `goto("http://169.254.169.254/latest/")`, mode: browser.ModeLive, wantErr: "cloud-metadata"},
+		{name: "private blocked in headless", code: `goto("http://127.0.0.1:8080/")`, mode: browser.ModeHeadless, wantErr: "private/internal address"},
+		{name: "private allowed in live", code: `goto("http://127.0.0.1:8080/")`, mode: browser.ModeLive, wantCalls: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBackend{mode: tt.mode}
+			_, _, err := execOne(t, b, tt.code)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("exec: %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+			}
+			if len(b.calls) != tt.wantCalls {
+				t.Errorf("calls = %v, want %d", b.calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRunBrowserCodeProgram(t *testing.T) {
+	b := &fakeBackend{mode: browser.ModeHeadless, eval: `"title"`, info: browser.PageInfo{URL: "http://93.184.216.34/"}}
+	out, err := runBrowserCode(t.Context(), b, "# label\ngoto(\"http://93.184.216.34/\")\nprint(js(\"document.title\"))\nwaitLoad()", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "\"title\"\n" {
+		t.Errorf("out = %q", out)
+	}
+	want := "Navigate(http://93.184.216.34/) Eval(document.title) WaitLoad() Info()"
+	if got := strings.Join(b.calls, " "); got != want {
+		t.Errorf("calls = %q, want %q", got, want)
+	}
+}
+
+func TestRunBrowserCodeParseError(t *testing.T) {
+	b := &fakeBackend{mode: browser.ModeHeadless}
+	if _, err := runBrowserCode(t.Context(), b, "not a call", ""); err == nil {
+		t.Fatal("malformed program must error")
+	}
+	if len(b.calls) != 0 {
+		t.Errorf("no backend calls expected: %v", b.calls)
+	}
+}
+
+// A statement error keeps the output produced so far and wraps the failing
+// statement's text.
+func TestRunBrowserCodeStatementError(t *testing.T) {
+	b := &fakeBackend{mode: browser.ModeHeadless}
+	out, err := runBrowserCode(t.Context(), b, `print("first")`+"\n"+`box("x")`, "")
+	if err == nil || !strings.Contains(err.Error(), `box("x")`) {
+		t.Fatalf("err = %v, want the failing statement in it", err)
+	}
+	if out != "first\n" {
+		t.Errorf("partial output lost: %q", out)
+	}
+}
+
+func TestRunBrowserCodeScreenshotSink(t *testing.T) {
+	var got [][]byte
+	old := ScreenshotSink
+	ScreenshotSink = func(jpegs [][]byte) { got = jpegs }
+	defer func() { ScreenshotSink = old }()
+
+	b := &fakeBackend{mode: browser.ModeHeadless, shot: []byte("jpeg")}
+	out, err := runBrowserCode(t.Context(), b, "screenshot(); screenshot()", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || string(got[0]) != "jpeg" {
+		t.Fatalf("sink got %d shots: %q", len(got), got)
+	}
+	if !strings.Contains(out, "(2 screenshot(s) attached") {
+		t.Errorf("missing attach note: %q", out)
+	}
+}
+
+// A page that navigated itself onto a blocked URL is neutralized after the
+// program runs, with a note for the model.
+func TestNeutralizeIfBlocked(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      browser.PageInfo
+		infoErr   error
+		wantMsg   bool
+		wantCalls []string
+	}{
+		{name: "safe url", info: browser.PageInfo{URL: "http://93.184.216.34/"}, wantCalls: []string{"Info()"}},
+		{name: "blank url", wantCalls: []string{"Info()"}},
+		{name: "info error", infoErr: errors.New("nope"), wantCalls: []string{"Info()"}},
+		{
+			name:      "pending dialog is left alone",
+			info:      browser.PageInfo{URL: "http://169.254.169.254/", Dialog: &browser.Dialog{Type: "alert"}},
+			wantCalls: []string{"Info()"},
+		},
+		{
+			name:      "blocked url neutralized",
+			info:      browser.PageInfo{URL: "http://169.254.169.254/latest/"},
+			wantMsg:   true,
+			wantCalls: []string{"Info()", "Navigate(about:blank)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &fakeBackend{mode: browser.ModeHeadless, info: tt.info, err: tt.infoErr}
+			msg := neutralizeIfBlocked(t.Context(), b)
+			if tt.wantMsg != strings.Contains(msg, "neutralized to about:blank") {
+				t.Errorf("msg = %q, wantMsg = %v", msg, tt.wantMsg)
+			}
+			if got := strings.Join(b.calls, " "); got != strings.Join(tt.wantCalls, " ") {
+				t.Errorf("calls = %v, want %v", b.calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+// runBrowserCode neutralizes even on the error path, before returning.
+func TestRunBrowserCodeNeutralizesOnError(t *testing.T) {
+	b := &fakeBackend{mode: browser.ModeHeadless, info: browser.PageInfo{URL: "http://169.254.169.254/"}}
+	if _, err := runBrowserCode(t.Context(), b, `box("x")`, ""); err == nil {
+		t.Fatal("want error")
+	}
+	want := "Info() Navigate(about:blank)"
+	if got := strings.Join(b.calls, " "); got != want {
+		t.Errorf("calls = %q, want %q", got, want)
+	}
+}
+
+func TestBrowserExecArgErrors(t *testing.T) {
+	old := Browser
+	Browser = browser.NewManager(browser.ModeHeadless)
+	defer func() { Browser = old }()
+
+	tests := []struct {
+		name, args, want string
+	}{
+		{"bad json", `{"code":`, "unexpected end of JSON input"},
+		{"blank code", `{"code":"  "}`, "no code provided"},
+		{"bad session mode prefix", `{"code":"info()","session":"bogus:x"}`, "unknown mode prefix"},
+		{"bad session name", `{"code":"info()","session":"live:not a name"}`, "invalid session name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := Execute(t.Context(), []Tool{BrowserExec()}, "browser_exec", json.RawMessage(tt.args))
+			if !strings.HasPrefix(out, "Error") || !strings.Contains(out, tt.want) {
+				t.Fatalf("out = %q, want error containing %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseEdgeCases covers the parser paths the happy-path tests miss:
+// escaped quotes inside string args, trailing comments after a semicolon,
+// and the value-error wrapping.
+func TestParseEdgeCases(t *testing.T) {
+	prog, err := parseHelperProgram(`info(); # trailing comment
+js("say \"hi\"; ok")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prog) != 2 {
+		t.Fatalf("want 2 statements, got %d: %+v", len(prog), prog)
+	}
+	if prog[1].name != "js" || prog[1].args[0] != `say "hi"; ok` {
+		t.Errorf("escaped quotes in arg: %+v", prog[1].args)
+	}
+
+	for _, code := range []string{`goto(bad value)`, `print(foo(bad value))`} {
+		_, err := parseHelperProgram(code)
+		if err == nil || !strings.Contains(err.Error(), "bad value") {
+			t.Errorf("%s: err = %v, want a bad-value error", code, err)
+		}
+	}
+}
+
+// The post-navigation recheck note is appended to a successful program's
+// output when the page moved onto a blocked URL.
+func TestRunBrowserCodeAppendsSafetyNote(t *testing.T) {
+	b := &fakeBackend{mode: browser.ModeHeadless, info: browser.PageInfo{URL: "http://169.254.169.254/"}}
+	out, err := runBrowserCode(t.Context(), b, `js("location='http://169.254.169.254/'")`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "neutralized to about:blank") {
+		t.Errorf("missing safety note: %q", out)
+	}
+}

--- a/internal/tools/computer_test.go
+++ b/internal/tools/computer_test.go
@@ -254,6 +254,22 @@ func main() {
 			reply(enc, id, next)
 		case "type":
 			reply(enc, id, map[string]any{"action": "typed", "stateUnavailable": "no AX grant", "hint": "grant it"})
+		case "press", "scroll", "set", "select", "menu":
+			// press("...", "BADJSON") answers with a non-AppState result so the
+			// tool's fold-in unmarshal fails.
+			if k, _ := params["key"].(string); k == "BADJSON" {
+				reply(enc, id, "not a state object")
+				continue
+			}
+			// Echo every param back as an AX row so the test can assert what
+			// the tool actually sent over the wire.
+			var rows []map[string]any
+			i := 0
+			for k, v := range params {
+				rows = append(rows, map[string]any{"index": i, "role": "AXParam", "title": k, "value": fmt.Sprint(v)})
+				i++
+			}
+			reply(enc, id, map[string]any{"generation": 2, "app": "TestApp", "elements": rows})
 		case "screenshot":
 			reply(enc, id, map[string]any{"jpegBase64": "aGVsbG8=", "bytes": 5})
 		default:
@@ -345,5 +361,166 @@ func TestNativeTierWithFakeHelper(t *testing.T) {
 	out, err = runComputerCode(ctx, `screenshot("TestApp")`)
 	if err != nil || !strings.Contains(out, "screenshot captured: 5 bytes") {
 		t.Fatalf("screenshot: %q %v", out, err)
+	}
+}
+
+// Every remaining native mutation forwards its arguments to the helper under
+// the app + generation the tool tracks (the fake echoes the params back).
+func TestNativeMutationParams(t *testing.T) {
+	fakeNativeHelper(t)
+	withComputerPolicy(t, computer.NewPolicy([]string{"TestApp"}, nil, true))
+	ctx := t.Context()
+
+	// state() first so the generation guard has something to send.
+	if _, err := runComputerCode(ctx, `state("TestApp")`); err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	for _, tc := range []struct {
+		code string
+		want []string
+	}{
+		{`press("TestApp", "super+c")`, []string{`title="key" value="super+c"`, `title="gen" value="2"`, `title="app" value="TestApp"`}},
+		{`scroll("TestApp", 4, "down", 3)`, []string{`title="index" value="4"`, `title="dir" value="down"`, `title="clicks" value="3"`}},
+		{`scroll("TestApp", 4)`, []string{`title="index" value="4"`}}, // optional dir/clicks omitted
+		{`set("TestApp", 2, "hello")`, []string{`title="index" value="2"`, `title="value" value="hello"`}},
+		{`select("TestApp", 2, "word")`, []string{`title="index" value="2"`, `title="target" value="word"`}},
+		{`menu("TestApp", 2, "AXShowMenu")`, []string{`title="index" value="2"`, `title="action" value="AXShowMenu"`}},
+	} {
+		out, err := runComputerCode(ctx, tc.code)
+		if err != nil {
+			t.Errorf("%s: %v", tc.code, err)
+			continue
+		}
+		for _, w := range tc.want {
+			if !strings.Contains(out, w) {
+				t.Errorf("%s: missing %s in:\n%s", tc.code, w, out)
+			}
+		}
+	}
+
+	// scroll's optional dir/clicks are dropped when absent.
+	if out, err := runComputerCode(ctx, `scroll("TestApp", 4)`); err != nil || strings.Contains(out, `title="dir"`) {
+		t.Errorf("scroll without dir: %q %v", out, err)
+	}
+
+	// Pixel-coordinate click (the fallback arity) reaches the helper as x/y.
+	if _, err := runComputerCode(ctx, `state("TestApp")`); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runComputerCode(ctx, `click("TestApp", 10, 20)`)
+	if err != nil {
+		t.Fatalf("pixel click: %v", err)
+	}
+	if !strings.Contains(out, "generation=3") {
+		t.Errorf("pixel click state fold-in: %s", out)
+	}
+
+	// ax() reads the tree without capturing a screenshot (unlike state()).
+	if out, err := runComputerCode(ctx, `ax("TestApp")`); err != nil || strings.Contains(out, "screenshot(s) attached") {
+		t.Errorf("ax: %q %v", out, err)
+	}
+
+	// A helper reply that isn't an AppState surfaces as an unmarshal error
+	// rather than a silent success.
+	if _, err := runComputerCode(ctx, `press("TestApp", "BADJSON")`); err == nil || !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Errorf("non-state reply: %v", err)
+	}
+
+	// A denied app never reaches the helper.
+	withComputerPolicy(t, computer.NewPolicy(nil, []string{"TestApp"}, true))
+	if _, err := runComputerCode(ctx, `press("TestApp", "Return")`); err == nil || !strings.Contains(err.Error(), "policy") {
+		t.Errorf("denied mutation: %v", err)
+	}
+}
+
+// Argument validation and the policy gate fire before any platform call, for
+// every helper that takes arguments.
+func TestComputerArgAndGateErrors(t *testing.T) {
+	withComputerPolicy(t, computer.NewPolicy(nil, []string{"Google Chrome", "Denied"}, true))
+	ctx := t.Context()
+	for _, tc := range []struct{ code, want string }{
+		// missing/ill-typed args
+		{`state()`, "missing arg 1"},
+		{`screenshot()`, "missing arg 1"},
+		{`click()`, "missing arg 1"},
+		{`click("A", "x")`, "must be a number"},
+		{`click("A", "x", "y")`, "must be a number"},
+		{`click("A", 1, "y")`, "must be a number"},
+		{`type()`, "missing arg 1"},
+		{`type("A")`, "missing arg 2"},
+		{`press()`, "missing arg 1"},
+		{`press("A")`, "missing arg 2"},
+		{`scroll()`, "missing arg 1"},
+		{`scroll("A")`, "missing arg 2"},
+		{`set()`, "missing arg 1"},
+		{`set("A")`, "missing arg 2"},
+		{`set("A", 1)`, "missing arg 3"},
+		{`select()`, "missing arg 1"},
+		{`select("A")`, "missing arg 2"},
+		{`menu()`, "missing arg 1"},
+		{`menu("A", "x")`, "must be a number"},
+		{`menu("A", 1)`, "missing arg 3"},
+		{`tell()`, "missing arg 1"},
+		{`tell("A")`, "missing arg 2"},
+		{`chrome_goto()`, "missing arg 1"},
+		{`chrome_activate("w", 1)`, "must be a number"},
+		{`chrome_activate(1, "i")`, "must be a number"},
+		{`chrome_close(1, "i")`, "must be a number"},
+		{`chrome_find()`, "missing arg 1"},
+		// policy gate
+		{`state("Denied")`, "policy"},
+		{`screenshot("Denied")`, "policy"},
+		{`chrome_state()`, "policy"},
+		{`chrome_tabs()`, "policy"},
+		{`chrome_back()`, "policy"},
+		{`chrome_reload()`, "policy"},
+		{`chrome_js("1+1")`, "policy"},
+		{`chrome_find("x")`, "policy"},
+		{`chrome_goto("http://93.184.216.34/")`, "policy"},
+		{`chrome_activate(1, 2)`, "policy"},
+		{`chrome_close(1, 2)`, "policy"},
+	} {
+		_, err := runComputerCode(ctx, tc.code)
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%s: want %q, got %v", tc.code, tc.want, err)
+		}
+	}
+
+	// Non-string args are coerced for string parameters: numbers formatted,
+	// anything else JSON-encoded.
+	if _, err := runComputerCode(ctx, `tell("Denied", 42)`); err == nil || !strings.Contains(err.Error(), "policy") {
+		t.Errorf("number arg coercion: %v", err)
+	}
+	if _, err := runComputerCode(ctx, `tell("Denied", true)`); err == nil || !strings.Contains(err.Error(), "policy") {
+		t.Errorf("bool arg coercion: %v", err)
+	}
+}
+
+// With no policy installed at all the tool refuses rather than defaulting to
+// allow.
+func TestGateAppNoPolicy(t *testing.T) {
+	withComputerPolicy(t, nil)
+	if err := gateApp("Anything"); err == nil || !strings.Contains(err.Error(), "no policy installed") {
+		t.Errorf("nil policy: %v", err)
+	}
+}
+
+// Native helpers that need the driver report the missing-driver guidance
+// instead of a confusing RPC error.
+func TestNativeHelpersWithoutDriver(t *testing.T) {
+	if computer.Available() {
+		t.Skip("darwin: an embedded helper may exist")
+	}
+	t.Setenv("WHIP_COMPUTER_BIN", "")
+	computer.ResetShared()
+	t.Cleanup(computer.ResetShared)
+	withComputerPolicy(t, computer.NewPolicy([]string{"TestApp"}, nil, true))
+	for _, code := range []string{
+		`permissions()`, `state("TestApp")`, `ax("TestApp")`, `screenshot("TestApp")`,
+		`click("TestApp", 0)`,
+	} {
+		if _, err := runComputerCode(t.Context(), code); err == nil || !strings.Contains(err.Error(), "whip-computer driver") {
+			t.Errorf("%s: %v", code, err)
+		}
 	}
 }


### PR DESCRIPTION
## Why

Follow-up to #23. That PR took the portable set from 70.6% → 84.3%; this one takes it to **93.7%** and ratchets the floor 80% → 90%.

Targeting was done by *mass*, not by file: the starting point was 776 uncovered statements out of 4,956, ranked by how many statements each function actually held.

## Results

| Package | Before | After |
|---|---|---|
| internal/mcp | 89.8% | **98.8%** |
| internal/config | 88.6% | **97.7%** |
| internal/skills | 97.6% | 97.6% |
| internal/session | 87.9% | **96.8%** |
| internal/agent | 90.6% | **96.6%** |
| internal/schedule | 96.2% | 96.2% |
| internal/llm | 93.3% | **95.8%** |
| internal/tools | 68.8% | **95.2%** |
| internal/tools/bashrun | 89.4% | **94.3%** |
| internal/lsp | 89.3% | **92.9%** |
| internal/memory | 92.1% | 92.1% |
| cmd/whip | 71.7% | **81.0%** |
| internal/computer | 78.2% | **79.4%** |
| **total** | **84.3%** | **93.7%** |

## How the hard parts were reached

- **`browser_lang.go` + `browser.go` → 100%.** `helperStmt.exec` was the single biggest gap (20.3%, ~80 statements). It takes `browser.Backend` — an *interface* — so a recording fake drives every helper's dispatch, missing/wrong-type arg errors, and backend-error propagation, asserting the exact call log rather than just touching lines. Includes `goto`'s SSRF floor (metadata + private IP blocking, headless vs live), using literal IPs so no DNS lookup happens.
- **TOML parser (`codextoml.go`) → 100%.** Fixture tables over escapes, literal vs basic strings, nested inline tables, arrays, and malformed-input error paths.
- **Database/filesystem error branches.** Reached by fault injection *through the real objects* — SQLite `CREATE TRIGGER … RAISE(ABORT)`, dropped tables, a `fork_seq` poisoned to non-numeric text, `WHIP_HOME` pointed under a regular file. These assert graceful failure instead of panics. No mock layer was added to production code.
- **`mcpTestCLI` 56% → 100%.** Previously written off as needing a real MCP handshake or a 30s timeout; instead the test binary re-execs itself as a stdio MCP server.
- **`Probe`** runs against an `httptest` streamable-HTTP MCP server.

## What stays uncovered, and why

313 statements remain; roughly two thirds are unreachable on linux CI without adding production seams:

- `cmd/whip/main.go` (67) — globals + `os.Exit` + `tui.Run` needs a TTY.
- darwin-gated paths (69) — `computer.Available()` returns `runtime.GOOS == "darwin"` as the first statement of `ComputerExec`'s closure; `chrome.go`/`helper.go` osascript paths sit behind the same gate. The native tier *below* the gate is fully driven on linux via the `WHIP_COMPUTER_BIN` fake.
- `auth.go` TTY prompts (29) and `lsp/manager.go` branches needing a live gopls (32).

The rest are single-statement error returns needing mid-flight failures (a scan error on a `TEXT NOT NULL` column, `json.Marshal` of a type that cannot fail).

## Three production bugs found and fixed

The coverage work surfaced these; all three are fixed in this PR (commit `03434cd`).

1. **Data race in `internal/mcp/manager.go`.** `Enable`/`Disable` wrote `s.cfg.Enabled` while `run()` and `kickAutoReconnect()` read it from other goroutines — `-race` flags it reproducibly whenever a server with a live session is disabled, and the pre-existing `TestEnableDisableCycle` only escaped on timing. The writes now happen under `s.mu` (folded into the lock `Disable` already took, so no extra cost) and the reads go through a `disabled()` accessor.
2. **Dead shutdown guards in `internal/mcp/manager.go`.** `Manager.closed` is documented as "set by Close", but `Close()` never set it, so both guards were dead in production: a session dropping during shutdown could still be stored and could still schedule an auto-reconnect. `Close()` now sets the flag.
3. **Nondeterministic timeout reporting in `bashrun.go`.** On an interactive kill, the reported reason depended on which arm of the run loop's `select` beat the output pump, so the same event surfaced as either `"timed out"`/`"cancelled"` or `"timed out waiting for input"`. The context's own error now decides, symmetrically for deadline and cancellation. The test was written to accept either outcome; it now asserts one exact exit text per case and passes 5/5 under `-race -shuffle=on`.

## Verification

- `go test -race -shuffle=on` with the CI coverage recipe: pass, total 93.6% (the 0.1pp shift is the few production statements the fixes added)
- `golangci-lint run ./...`: 0 issues; `gofmt -s -l .`: clean
- Production changes are limited to the three fixes above; the coverage work itself is test-only, stdlib `testing` only, no new dependencies
- Deterministic and portable: no network, tty, Chromium, or macOS APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)