### PR TITLE
Add startup update check against GitHub releases

### DIFF
--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/context-labs/whip/internal/config"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/tui"
+	"github.com/context-labs/whip/internal/update"
 )
 
 var version = "dev" // set via -ldflags "-X main.version=..."
@@ -110,6 +111,11 @@ func main() {
 		_ = agent.New(llm.New(prov.BaseURL, "bench"), id, mdl.MaxTokens, systemPrompt())
 		return
 	}
+
+	// Update check: concurrent with the trust prompt and agent setup, so its
+	// ~1 RTT is usually free — and when startup wins the race, the recorded
+	// notice still shows on the next launch.
+	go update.Check(version)
 	tui.Version = version // /report names the build in the bug-report bundle
 	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(), *resumeFlag, *cautiousFlag)
 	if err != nil {

--- a/cmd/whip/update.go
+++ b/cmd/whip/update.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/context-labs/whip/internal/update"
 )
 
 // installURL is the same curl-pipe-sh installer the README documents; update
@@ -22,6 +24,7 @@ func updateCLI() error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("update failed: %w", err)
 	}
+	update.Acknowledge() // the pending startup notice is now satisfied
 	fmt.Println("\nwhip updated — restart any running sessions to use the new version.")
 	return nil
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -411,6 +411,34 @@ prompts, killed after 15s of no input.
 Tests: `killall_test.go` — `TestKillAllReapsChildren` (kills a live `sleep 60`),
 `TestBackgroundGrandchildDoesNotHang`.
 
+## Update check
+
+`internal/update/update.go` — on interactive startup `main` fires
+`update.Check(version)` in a goroutine, concurrent with the trust prompt and
+agent setup, so its ~1 RTT is usually free: when the check wins, the notice
+shows in that very startup report; when startup wins, the recorded notice is
+durable and shows next launch.
+
+The check reads `~/.whip/update.json` first and skips the network when a
+notice is pending for a release not yet installed (never nags twice about the
+same version) or the last check is under 24h old. Otherwise it GETs
+`api.github.com/.../releases/latest` (2s timeout, `gh` token / `GH_TOKEN`
+auth mirroring `install.sh` while the repo is private), and a strictly newer
+semver (prereleases sort before their release) is written to the notice file
+atomically (tmp+rename). The startup report shows `update available: vX.Y.Z
+(run: whip update)`; a successful `whip update` calls `update.Acknowledge()`
+so an installed release stops nagging — and a user who updates out of band
+(curl|sh) has the now-stale notice cleared on next launch, so checks resume.
+`dev` builds never check. Every failure — offline, rate-limited, corrupt
+notice — is silent by design: a version check must never break startup.
+
+Tests: `internal/update/update_test.go` (`TestCheckNewerRelease`,
+`TestCheckSkips` — pending notice / fresh TTL / dev build never fetch,
+`TestCheckStaleTTLRefetches`, `TestCheckOutOfBandUpdate` clears the stale
+notice of a curl|sh updater, `TestCheckFetchFailure` still records the
+attempt, `TestCheckCorruptNotice`, `TestNewer`, `TestPendingAndAcknowledge`);
+`tui/startup_report_test.go` (`TestStartupReportUpdateNotice`).
+
 ## LSP diagnostics
 
 `internal/lsp/` — a stdlib-only LSP client over stdio (JSON-RPC +

--- a/internal/tui/startup_report_test.go
+++ b/internal/tui/startup_report_test.go
@@ -73,3 +73,22 @@ func TestStartupReportSilent(t *testing.T) {
 		t.Errorf("expected silence, got %q", m.blocks[0].text)
 	}
 }
+
+// TestStartupReportUpdateNotice: a pending newer release (spotted by main's
+// background check) renders as a notice line naming `whip update`.
+func TestStartupReportUpdateNotice(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HOME", t.TempDir())
+
+	m := tasksModel("http://unused")
+	m.updateLatest = "v0.4.0"
+	m.startupReport()
+	if len(m.blocks) == 0 {
+		t.Fatal("no report rendered")
+	}
+	out := m.blocks[0].text
+	if !strings.Contains(out, "update available: v0.4.0") || !strings.Contains(out, "whip update") {
+		t.Errorf("missing update notice:\n%s", out)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -34,6 +34,7 @@ import (
 	"github.com/context-labs/whip/internal/skills"
 	"github.com/context-labs/whip/internal/tools"
 	"github.com/context-labs/whip/internal/tools/bashrun"
+	"github.com/context-labs/whip/internal/update"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
@@ -176,6 +177,10 @@ type model struct {
 	themeHow     string // how auto theme detection resolved (env var, OSC query, …) — captured at startup/theme change for /report; never re-queried
 	compactModel string // config model name for compaction summaries; "" = the built-in default
 	compactProv  string
+	// updateLatest is a pending newer release tag ("" when none), picked up
+	// from update.Pending at startup; the notice it renders is durable, so a
+	// check that lands after the report still shows next launch.
+	updateLatest string
 	effortX      int                       // screen column where the clickable ⚡ effort control starts
 	catalogs     map[string]config.Catalog // provider model lists (capabilities)
 	mcpMgr       *mcp.Manager              // MCP server connections; nil when none configured
@@ -378,6 +383,11 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 			return "", err
 		}
 	}
+	// Pick up whatever the update check recorded: a notice from an earlier
+	// launch always shows; one discovered by main's background check shows
+	// this launch if its 1 RTT beats startup (first-run trust prompt), else
+	// next launch — the record is durable either way.
+	m.updateLatest = update.Pending(Version)
 	m.startupReport()
 
 	// Inline rendering (no alt-screen): the transcript lives in the normal
@@ -498,6 +508,10 @@ func (m *model) startupReport() {
 		if len(parts) > 0 {
 			line("mcp: %s", strings.Join(parts, " · "))
 		}
+	}
+	if m.updateLatest != "" {
+		line("update available: %s (run: whip update)", m.updateLatest)
+		warned = true
 	}
 	if b.Len() == 0 {
 		return

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -10,6 +10,7 @@ package update
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -220,7 +221,7 @@ func fetchLatestGitHub() (string, error) {
 		return "", err
 	}
 	if rel.TagName == "" {
-		return "", fmt.Errorf("github: empty tag_name")
+		return "", errors.New("github: empty tag_name")
 	}
 	return rel.TagName, nil
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,236 @@
+// Package update checks GitHub for a newer whip release and leaves a
+// notice in ~/.whip for the next startup report.
+//
+// The check is best-effort by design: any failure (offline, rate-limited,
+// corrupt state) is silent — a version check must never break startup.
+// Auth mirrors install.sh: the `gh` CLI token or GH_TOKEN while the repo
+// is private, anonymous once public.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/context-labs/whip/internal/config"
+)
+
+const (
+	noticeFile = "update.json"
+	// checkTTL caps the network check at once per day; a pending notice for
+	// a release not yet installed suppresses re-checks entirely.
+	checkTTL     = 24 * time.Hour
+	latestURL    = "https://api.github.com/repos/context-labs/whip/releases/latest"
+	fetchTimeout = 2 * time.Second
+)
+
+// Notice is ~/.whip/update.json: the last check's outcome. Latest is set
+// only when a newer release exists; Acknowledged is flipped by `whip
+// update` so an installed release stops nagging.
+type Notice struct {
+	CheckedAt    time.Time `json:"checkedAt"`
+	Latest       string    `json:"latest,omitempty"`
+	Acknowledged bool      `json:"acknowledged,omitempty"`
+}
+
+// fetchLatest returns the newest release tag. A var so tests can stub the
+// network.
+var fetchLatest = fetchLatestGitHub
+
+// Check runs the startup check: if a newer release than current exists, its
+// tag is recorded in ~/.whip/update.json and returned. "" means nothing to
+// say (up to date, dev build, already noted, checked recently, or the check
+// failed). Never errors.
+func Check(current string) string {
+	dir, err := config.Dir()
+	if err != nil {
+		return ""
+	}
+	return check(current, filepath.Join(dir, noticeFile), fetchLatest, time.Now())
+}
+
+// Pending reads a recorded notice: the latest tag if a newer-than-current
+// release is waiting to be acknowledged, else "".
+func Pending(current string) string {
+	dir, err := config.Dir()
+	if err != nil {
+		return ""
+	}
+	n, err := readNotice(filepath.Join(dir, noticeFile))
+	if err != nil || n.Acknowledged || !Newer(current, n.Latest) {
+		return ""
+	}
+	return n.Latest
+}
+
+// Acknowledge marks any pending notice as acted on (called by `whip update`
+// after a successful install). Best-effort.
+func Acknowledge() {
+	dir, err := config.Dir()
+	if err != nil {
+		return
+	}
+	p := filepath.Join(dir, noticeFile)
+	n, err := readNotice(p)
+	if err != nil || n.Latest == "" {
+		return
+	}
+	n.Acknowledged = true
+	_ = writeNotice(p, n)
+}
+
+// check is the pure core, I/O injected for tests.
+func check(current, noticePath string, fetch func() (string, error), now time.Time) string {
+	if current == "dev" || current == "" {
+		return "" // dev builds never nag
+	}
+	n, err := readNotice(noticePath)
+	if err == nil {
+		if n.Latest != "" && !n.Acknowledged {
+			if Newer(current, n.Latest) {
+				return "" // a release is already noted; don't nag twice
+			}
+			// The pending release is installed (or jumped past) — the user
+			// updated out of band (curl|sh, package manager), so
+			// Acknowledge never ran. Clear the stale Latest but keep the
+			// original CheckedAt: stamping now would trip the TTL below and
+			// defer the refetch by a day, and the user is owed a check.
+			n.Latest = ""
+		}
+		if now.Sub(n.CheckedAt) < checkTTL {
+			return "" // checked recently
+		}
+	}
+	latest, err := fetch()
+	if err != nil || !Newer(current, latest) {
+		// Record the check itself (even when current/unknown) so the TTL
+		// applies and an offline stretch doesn't retry every launch.
+		_ = writeNotice(noticePath, Notice{CheckedAt: now})
+		return ""
+	}
+	_ = writeNotice(noticePath, Notice{CheckedAt: now, Latest: latest})
+	return latest
+}
+
+// Newer reports whether latest is a strictly newer semver than current.
+// A prerelease sorts before the same-numbered release ("v0.3.0-rc.1" <
+// "v0.3.0"). Non-semver strings ("dev", "", "v0.3") never compare newer.
+func Newer(current, latest string) bool {
+	c, cpre, lok := parseSemver(current)
+	l, lpre, rok := parseSemver(latest)
+	if !lok || !rok {
+		return false
+	}
+	for i := range c {
+		if l[i] != c[i] {
+			return l[i] > c[i]
+		}
+	}
+	return cpre && !lpre
+}
+
+// parseSemver extracts the numeric major/minor/patch of a "v1.2.3" tag and
+// reports a "-prerelease" suffix.
+func parseSemver(v string) (nums [3]int, prerelease, ok bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	base, suffix, _ := strings.Cut(v, "-")
+	parts := strings.SplitN(base, ".", 3)
+	if len(parts) != 3 {
+		return nums, false, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return nums, false, false
+		}
+		nums[i] = n
+	}
+	return nums, suffix != "", true
+}
+
+func readNotice(path string) (Notice, error) {
+	var n Notice
+	data, err := os.ReadFile(path) //nolint:gosec // G703: path is the whip-owned notice file
+	if err != nil {
+		return n, err
+	}
+	if err := json.Unmarshal(data, &n); err != nil {
+		return Notice{}, err // corrupt notice: treat as never checked
+	}
+	return n, nil
+}
+
+// writeNotice persists the notice atomically (tmp+rename) — persisted state
+// never gets a bare WriteFile.
+func writeNotice(path string, n Notice) error {
+	data, err := json.Marshal(n)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".update-*.tmp")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
+// fetchLatestGitHub asks the releases API for the newest tag. Auth follows
+// install.sh: gh token → GH_TOKEN → anonymous.
+func fetchLatestGitHub() (string, error) {
+	// context.Background is deliberate: the check is fire-and-forget (fired
+	// from a detached goroutine in main), so there is no caller ctx to
+	// thread — the 2s timeout is the bound that matters.
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if tok := ghToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github: %s", resp.Status)
+	}
+	var rel struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", err
+	}
+	if rel.TagName == "" {
+		return "", fmt.Errorf("github: empty tag_name")
+	}
+	return rel.TagName, nil
+}
+
+// ghToken mirrors install.sh's auth order. Best-effort: no gh, no token.
+func ghToken() string {
+	if out, err := exec.CommandContext(context.Background(), "gh", "auth", "token").Output(); err == nil {
+		if tok := strings.TrimSpace(string(out)); tok != "" {
+			return tok
+		}
+	}
+	return os.Getenv("GH_TOKEN")
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,223 @@
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func fetchOK(tag string) func() (string, error) {
+	return func() (string, error) { return tag, nil }
+}
+
+func fetchErr() func() (string, error) {
+	return func() (string, error) { return "", errors.New("offline") }
+}
+
+// TestCheckNewerRelease: a newer tag is recorded in the notice file and
+// returned so the startup report can name it.
+func TestCheckNewerRelease(t *testing.T) {
+	p := filepath.Join(t.TempDir(), noticeFile)
+	got := check("v0.3.0", p, fetchOK("v0.4.0"), time.Now())
+	if got != "v0.4.0" {
+		t.Fatalf("check = %q, want v0.4.0", got)
+	}
+	n, err := readNotice(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Latest != "v0.4.0" || n.Acknowledged {
+		t.Errorf("notice = %+v, want Latest v0.4.0 unacknowledged", n)
+	}
+}
+
+// TestCheckSkips: the network stays untouched when a notice is pending, the
+// TTL is fresh, or the build is dev.
+func TestCheckSkips(t *testing.T) {
+	called := false
+	spy := func() (string, error) { called = true; return "v9.9.9", nil }
+	now := time.Now()
+
+	// Pending unacknowledged notice for a release not yet installed.
+	p := filepath.Join(t.TempDir(), noticeFile)
+	if err := writeNotice(p, Notice{CheckedAt: now.Add(-365 * 24 * time.Hour), Latest: "v0.4.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := check("v0.3.0", p, spy, now); got != "" {
+		t.Errorf("pending notice: check = %q, want \"\"", got)
+	}
+	if called {
+		t.Error("pending notice: fetch was called")
+	}
+
+	// Fresh TTL, nothing pending.
+	p2 := filepath.Join(t.TempDir(), noticeFile)
+	if err := writeNotice(p2, Notice{CheckedAt: now.Add(-time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if got := check("v0.3.0", p2, spy, now); got != "" {
+		t.Errorf("fresh TTL: check = %q, want \"\"", got)
+	}
+	if called {
+		t.Error("fresh TTL: fetch was called")
+	}
+
+	// Dev builds never nag.
+	p3 := filepath.Join(t.TempDir(), noticeFile)
+	if got := check("dev", p3, spy, now); got != "" {
+		t.Errorf("dev build: check = %q, want \"\"", got)
+	}
+	if called {
+		t.Error("dev build: fetch was called")
+	}
+}
+
+// TestCheckStaleTTLRefetches: past the TTL the check runs again; a still-
+// current release records only the check time (clears any stale Latest).
+func TestCheckStaleTTLRefetches(t *testing.T) {
+	p := filepath.Join(t.TempDir(), noticeFile)
+	old := time.Now().Add(-48 * time.Hour)
+	if err := writeNotice(p, Notice{CheckedAt: old, Latest: "v0.3.0", Acknowledged: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := check("v0.3.0", p, fetchOK("v0.3.0"), time.Now()); got != "" {
+		t.Fatalf("check = %q, want \"\" (already on latest)", got)
+	}
+	n, err := readNotice(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Latest != "" {
+		t.Errorf("stale Latest %q not cleared", n.Latest)
+	}
+	if !n.CheckedAt.After(old) {
+		t.Error("CheckedAt not refreshed")
+	}
+}
+
+// TestCheckFetchFailure: an offline check is silent but still records the
+// attempt, so every launch doesn't hammer the API.
+func TestCheckFetchFailure(t *testing.T) {
+	p := filepath.Join(t.TempDir(), noticeFile)
+	if got := check("v0.3.0", p, fetchErr(), time.Now()); got != "" {
+		t.Fatalf("check = %q, want \"\"", got)
+	}
+	n, err := readNotice(p)
+	if err != nil {
+		t.Fatal("fetch failure should still record the check")
+	}
+	if n.Latest != "" {
+		t.Errorf("Latest = %q, want \"\"", n.Latest)
+	}
+}
+
+// TestCheckOutOfBandUpdate: the user updated via curl|sh (never ran
+// `whip update`), so the notice for the now-installed release is stale and
+// unacknowledged. check clears it and resumes checking — otherwise they'd
+// never hear about a new release again.
+func TestCheckOutOfBandUpdate(t *testing.T) {
+	p := filepath.Join(t.TempDir(), noticeFile)
+	// The notice was written days ago; the user has since installed v0.4.0.
+	old := time.Now().Add(-48 * time.Hour)
+	if err := writeNotice(p, Notice{CheckedAt: old, Latest: "v0.4.0"}); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	spy := func() (string, error) { called = true; return "v0.5.0", nil }
+	// Now ON v0.4.0: the stale notice must not suppress the check.
+	if got := check("v0.4.0", p, spy, time.Now()); got != "v0.5.0" {
+		t.Fatalf("check = %q, want v0.5.0", got)
+	}
+	if !called {
+		t.Error("stale notice suppressed the fetch")
+	}
+	n, err := readNotice(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Latest != "v0.5.0" {
+		t.Errorf("notice Latest = %q, want v0.5.0", n.Latest)
+	}
+}
+
+// TestCheckCorruptNotice: a clobbered notice file is treated as "never
+// checked" — the check runs and rewrites it.
+func TestCheckCorruptNotice(t *testing.T) {
+	p := filepath.Join(t.TempDir(), noticeFile)
+	if err := os.WriteFile(p, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := check("v0.3.0", p, fetchOK("v0.4.0"), time.Now())
+	if got != "v0.4.0" {
+		t.Fatalf("check = %q, want v0.4.0", got)
+	}
+	if _, err := readNotice(p); err != nil {
+		t.Fatal("corrupt notice was not rewritten:", err)
+	}
+}
+
+// TestNewer: semver-ish comparison.
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"v0.3.0", "v0.4.0", true},
+		{"v0.3.0", "v0.3.1", true},
+		{"v0.3.0", "v1.0.0", true},
+		{"0.3.0", "0.4.0", true}, // missing v prefix tolerated
+		{"v0.3.0", "v0.3.0", false},
+		{"v0.4.0", "v0.3.0", false},
+		{"v0.3.0", "v0.3.0-rc.1", false}, // prerelease of the same version
+		{"v0.3.0-rc.1", "v0.3.0", true},
+		{"dev", "v0.4.0", false},
+		{"v0.3.0", "", false},
+		{"v0.3.0", "garbage", false},
+		{"v0.3", "v0.4.0", false},
+	}
+	for _, c := range cases {
+		if got := Newer(c.current, c.latest); got != c.want {
+			t.Errorf("Newer(%q, %q) = %v, want %v", c.current, c.latest, got, c.want)
+		}
+	}
+}
+
+// TestPendingAndAcknowledge: Pending reports only unacknowledged newer
+// notices; Acknowledge silences them.
+func TestPendingAndAcknowledge(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+
+	if got := Pending("v0.3.0"); got != "" {
+		t.Fatalf("no notice: Pending = %q, want \"\"", got)
+	}
+	if err := writeNotice(filepath.Join(home, noticeFile), Notice{CheckedAt: time.Now(), Latest: "v0.4.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := Pending("v0.3.0"); got != "v0.4.0" {
+		t.Fatalf("Pending = %q, want v0.4.0", got)
+	}
+	if got := Pending("v0.4.0"); got != "" {
+		t.Errorf("already on latest: Pending = %q, want \"\"", got)
+	}
+	Acknowledge()
+	if got := Pending("v0.3.0"); got != "" {
+		t.Errorf("after Acknowledge: Pending = %q, want \"\"", got)
+	}
+	// Acknowledge is a no-op with nothing pending, and notice JSON stays valid.
+	Acknowledge()
+	data, err := os.ReadFile(filepath.Join(home, noticeFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n Notice
+	if err := json.Unmarshal(data, &n); err != nil {
+		t.Fatal(err)
+	}
+	if !n.Acknowledged {
+		t.Error("notice lost its acknowledgement")
+	}
+}


### PR DESCRIPTION
## What

On interactive startup, whip now checks GitHub for a newer release and surfaces it as a startup-report line:

```
update available: v0.4.0 (run: whip update)
```

## How

- `internal/update` (new): `Check` skips the network when `~/.whip/update.json` already holds an unacknowledged notice for a newer release (never nags twice) or the last check is < 24h old; otherwise GETs `releases/latest` with a 2s timeout and `gh`-token/`GH_TOKEN`/anonymous auth mirroring `install.sh` (repo is private). Notices persist atomically (tmp+rename). `Pending` reads the notice for the report; `Acknowledge` clears it after `whip update`.
- `cmd/whip/main.go`: the check fires in a goroutine concurrent with the trust prompt + agent setup, so its RTT is usually free; subcommands (`run`, `mcp`, `sessions`, `--bench`…) never trigger it.
- `internal/tui`: `startupReport` renders the notice line.

## Design notes

- `dev` builds never check or nag; prereleases sort before their release.
- A user who updates out of band (`curl | sh`) has the now-stale notice cleared on next launch, so checks resume — caught in adversarial review, pinned by `TestCheckOutOfBandUpdate`.
- Every failure (offline, rate-limited, corrupt notice) is silent by design: a version check must never break startup.
- No new dependencies.

## Tests

`internal/update/update_test.go` — newer-release record, all skip branches with a fetch spy (pending notice / fresh TTL / dev build), stale-TTL refetch, out-of-band-update recovery, fetch-failure still records the attempt, corrupt notice rewritten, `Newer` table, Pending/Acknowledge round-trip. `tui/startup_report_test.go` — notice line render.

## Gate

`task check` green (17/17 packages); `go test -race` clean on touched packages. Pre-existing flakes unrelated to this diff (reproduce on main): `internal/browser/extrelay/TestTokenAuth`, a `TestScheduleFiresWakeup` race in `internal/tui`.