### PR TITLE
ci: make the PR gate ~5x faster without dropping a check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: ci
 # PR health gate: format, vet, lint, tests, build, dependency hygiene.
 # Mirrors `task check` (the pre-commit hook) plus the release workflow's
 # Swift driver build, so a PR can't break the next tag's release.
+#
+# The work is split across jobs that run on separate runners, so wall-clock is
+# the slowest job rather than the sum of every step. `go` is a required status
+# check (repo ruleset), so it stays — as the gate that fails unless all three
+# parallel jobs succeeded. Add a new job to `go`'s `needs` when you add one,
+# or its failures won't block a merge.
 on:
   pull_request:
   push:
@@ -18,7 +24,7 @@ permissions:
   contents: read
 
 jobs:
-  go:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +40,8 @@ jobs:
             echo "needs gofmt -s:"; echo "$unformatted"; exit 1
           fi
 
+      # Kept alongside golangci-lint's govet: the two run overlapping but not
+      # identical analyzer sets, and here it costs no extra wall-clock.
       - name: go vet
         run: go vet ./...
 
@@ -44,6 +52,20 @@ jobs:
           # Go 1.27 export data. Bump deliberately alongside the Go toolchain.
           # The enabled linters live in .golangci.yml (repo source of truth).
           version: v2.13.1
+
+      - name: go mod tidy is a no-op
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum || { echo "run \`go mod tidy\` and commit"; exit 1; }
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
       # internal/browser e2e tests need a Chromium sandbox and internal/tui
       # tests need a tty — neither exists on hosted runners. Same portable
@@ -58,7 +80,7 @@ jobs:
             -coverprofile=cover.out -coverpkg="$(echo $PKGS | tr ' ' ',')" $PKGS
 
       # Self-contained coverage floor — no external service or token, so it
-      # works identically on fork PRs. Baseline today is ~93.7%; the gate fails
+      # works identically on fork PRs. Baseline today is ~93.6%; the gate fails
       # if total statement coverage drops below the floor. Ratchet the floor up
       # over time as coverage improves (don't lower it).
       - name: coverage floor (90%)
@@ -67,17 +89,47 @@ jobs:
           echo "total coverage: ${total}%"
           awk -v t="$total" -v floor=90 'BEGIN { if (t+0 < floor) { printf "coverage %.1f%% is below the %d%% floor\n", t, floor; exit 1 } }'
 
-      - name: go mod tidy is a no-op
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum || { echo "run \`go mod tidy\` and commit"; exit 1; }
+  # Each GOOS/GOARCH compiles its own copy of the standard library and shares
+  # no build cache with the others, and `go build` already saturates a
+  # runner's cores on one target — so the four get a runner each rather than
+  # taking turns. `needs: [build]` waits for every leg.
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [linux/amd64, linux/arm64, darwin/amd64, darwin/arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
-      - name: Cross-compile check (release targets)
+      - name: Cross-compile check (${{ matrix.target }})
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-            GOOS=${target%/*} GOARCH=${target#*/} CGO_ENABLED=0 \
-              go build -trimpath -o /dev/null ./cmd/whip || exit 1
-          done
+          GOOS=${TARGET%/*} GOARCH=${TARGET#*/} CGO_ENABLED=0 \
+            go build -trimpath -o /dev/null ./cmd/whip
+
+  # `go` is a required status check in the repo's ruleset, so the name has to
+  # survive the split. It is now the aggregate gate: green only when lint,
+  # test and build all passed. if: always() so a failed dependency reports as
+  # a failure here rather than a skip.
+  go:
+    needs: [lint, test, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: require every gate to have passed
+        run: |
+          echo "lint=${{ needs.lint.result }}"
+          echo "test=${{ needs.test.result }}"
+          echo "build=${{ needs.build.result }}"
+          [ "${{ needs.lint.result }}" = success ] || exit 1
+          [ "${{ needs.test.result }}" = success ] || exit 1
+          [ "${{ needs.build.result }}" = success ] || exit 1
 
   # The release pipeline builds the computer-use Swift driver on macOS and
   # go:embeds it — build it here too so a driver-breaking change fails the

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -196,7 +196,12 @@ func TestTurnAPIError(t *testing.T) {
 		http.Error(w, "nope", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
-	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	// Single attempt: this test is about the error surfacing from Turn, not
+	// about the retry ladder (covered in internal/llm/retry_test.go). Leaving
+	// retries on made it sleep through the full backoff — ~80s for one assert.
+	c := llm.New(srv.URL, "k")
+	c.MaxRetries = 1
+	ag := New(c, "m", 100, "sys")
 	if _, err := ag.Turn(context.Background(), "go", Events{}); err == nil {
 		t.Fatal("expected error")
 	}
@@ -568,7 +573,12 @@ func TestCompactThresholdExplicitOverride(t *testing.T) {
 
 	// CompactThreshold wins over the default: same history at the default 50%
 	// would have compacted
-	ag2 := New(llm.New(srv.URL, "m"), "m", 100, "sys")
+	// The compaction call fails here by design (textServer speaks SSE, compact
+	// uses the non-streaming Complete) — that failure is the signal compaction
+	// was attempted. Single attempt so the assert doesn't wait out the backoff.
+	c2 := llm.New(srv.URL, "m")
+	c2.MaxRetries = 1
+	ag2 := New(c2, "m", 100, "sys")
 	ag2.ContextLimit = 1000
 	for range 8 {
 		ag2.Messages = append(ag2.Messages, llm.Message{Role: "user", Content: strings.Repeat("x", 360)})


### PR DESCRIPTION
## Why

The `go` job took **6m54s**. Pulling the per-step timings showed where it actually went:

| Step | Before |
|---|---|
| `go test` (race + coverage) | 222s |
| Cross-compile (4 targets, sequential) | 132s |
| `go vet` | 28s |
| setup-go | 13s |
| golangci-lint | 9s |

## The tests weren't slow, they were asleep

`TestTurnAPIError` (82s) and `TestCompactThresholdExplicitOverride` (77s) were **~160s of the 222s**. Timed in isolation, the second one is 77.5s wall for **0.54s of user CPU — 1% utilization**. A goroutine dump pinned it exactly:

```
agent_test.go:576 → maybeCompact → compact → llm.Complete → llm.sleep (openai.go:485)
```

Both were sitting in the LLM retry ladder (1s+2s+4s+8s+16s+20s+20s). Neither test is *about* retrying — one asserts an API error surfaces from `Turn`, the other that compaction was attempted. `internal/llm` has a `sleep` seam for this, but it's unexported, so only that package's own tests benefit.

Both now set `MaxRetries = 1`, the documented single-attempt setting. The retry ladder stays covered where it belongs, in `internal/llm/retry_test.go` (10 tests, using the seam, fast).

**Portable suite: ~210s → 21s.** Coverage is unchanged at 93.6%.

## The workflow was sequential

One job ran every step end to end. It's now `lint | test | build` on separate runners, so wall-clock is the slowest job instead of the sum.

The cross-compile is a **4-way matrix**. I measured this rather than assuming: sequential and in-job-parallel cross-compiles both take ~42s locally, because `go build` already saturates every core on a single target (738% CPU). Four targets need four *runners*, not more parallelism inside one.

**`go` is a required status check in the repo ruleset**, so the name survives the split — it's now the aggregate gate that passes only when lint, test and build all passed (`if: always()`, so a failed dependency reports as a failure rather than a skip). If you add a job, add it to `go`'s `needs` or its failures won't block a merge.

## Nothing was dropped

gofmt, `go vet`, golangci-lint, `go mod tidy`, the `-race -shuffle=on` run, the 90% coverage floor, and all four release targets still gate every PR. `go vet` is kept even though golangci-lint runs `govet` — the analyzer sets overlap but aren't identical, and on its own runner it costs no wall-clock.

Validated with `actionlint`.