### PR TITLE
ci: cache Go build objects so compiles are incremental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # setup-go's own cache keys on go.sum alone, so once it exists it never
+      # refreshes — every run recompiles from whatever was cached the first
+      # time. Key on the sources too, with a prefix restore-key, so each run
+      # starts from the nearest previous compile and saves an updated cache.
+      - name: Go build cache (lint)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: gobuild-lint-${{ runner.os }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: gobuild-lint-${{ runner.os }}-
+
       - name: gofmt -s (matches task check)
         run: |
           unformatted=$(gofmt -s -l .)
@@ -73,6 +84,16 @@ jobs:
       # -race catches data races; -shuffle=on randomizes test order to catch
       # inter-test dependencies a contributor might introduce. Coverage is
       # recorded so the gate below can fail the PR if it drops.
+      # See the note in the lint job: the -race + -coverpkg objects are the
+      # expensive part of this job and setup-go's go.sum-keyed cache never
+      # refreshes to hold them.
+      - name: Go build cache (race + coverage objects)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: gobuild-test-${{ runner.os }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: gobuild-test-${{ runner.os }}-
+
       - name: go test (portable set, with coverage)
         run: |
           PKGS=$(go list ./... | grep -v -e /internal/browser -e /internal/tui)
@@ -105,6 +126,15 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      # Per-target: each GOOS/GOARCH has its own standard-library objects, so
+      # they get their own cache rather than evicting each other.
+      - name: Go build cache (${{ matrix.target }})
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: gobuild-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: gobuild-${{ matrix.target }}-${{ runner.os }}-
 
       - name: Cross-compile check (${{ matrix.target }})
         env:


### PR DESCRIPTION
Follow-up to #26 — this commit was still on the branch when #26 merged, so it's here on its own.

## The problem

#26 got the CI run from **404s → 104s**, and left `test` as the long pole at 93s. Its `go test` step costs **75s** while the tests themselves run in 21s, so the rest is compilation. The job log says why:

```
Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.27.0-8170a47b...
Cache hit occurred on the primary key ..., not saving cache.
```

`setup-go` keys its cache on `go.sum` alone. Once that cache exists the key always hits, so it is **never refreshed** — every run restores whatever objects were cached the first time and recompiles the rest. The `-race` + `-coverpkg` objects (the expensive part) are recompiled from scratch on every single run.

## The fix

Key the build cache on the sources as well, with a prefix `restore-keys`, so each run starts from the nearest previous compile and saves an updated cache when sources change. Per-job prefixes (`lint`, `test`, and one per cross-compile target) keep the different object sets from evicting one another — a `darwin/arm64` standard library is not useful to the race-instrumented test build.

Correctness is untouched: this changes only what gets reused between runs, not what is compiled, run, or asserted.

## Measuring it

The first run on this branch is a deliberate cache miss that populates the new keys; the run after it (same sources) shows the steady state. I'll post both numbers on this PR.