### PR TITLE
feat: agent-loop feedback — live bash output streaming + truncation spill

### DIFF
--- a/.ai-docs/plans/bash-feedback/README.md
+++ b/.ai-docs/plans/bash-feedback/README.md
@@ -1,0 +1,156 @@
+# Agent-loop feedback: bash output spill + streamed partial output
+
+Branch: `feat/bash-feedback`
+
+## What this does
+
+Two bash-tool feedback gaps from `docs/roadmap.md` ("Agent loop" section), plus
+one stale-checkbox fix:
+
+1. **Spill truncated bash output to a temp file** (roadmap line 69). When
+   combined stdout/stderr exceeds `maxOutput` (50_000 bytes) and gets
+   tail-truncated, write the **full** output to a temp file and name the path
+   in the tool result, so the model can `read`/`grep` the rest instead of
+   guessing (pi bash tool does this; pi itself not on this machine — behavior
+   per the roadmap citation).
+2. **Streamed partial bash output** (roadmap line 68). Add an `OnUpdate`
+   callback to `bashrun.Options`, invoked with the accumulated output at most
+   every ~100ms while a command runs (pi: bash `onUpdate` throttled at 100ms),
+   wired `bashrun → tools → agent.Events → TUI` so in-flight output is visible
+   on the running tool row before the command exits.
+3. **Tick roadmap line 70** (`WHIP_SESSION_ID`/`WHIP_MODEL` env injection) —
+   already implemented in `internal/tools/bashrun/markers.go` (`SetMarkers`,
+   wired at `internal/tui/tui.go:690,786`). Checkbox only; **no code change**.
+
+## Goal
+
+A long/verbose bash command is no longer a black box: the human watches output
+live (throttled), and the model gets a path to the full log when the result is
+truncated.
+
+## Non-goals
+
+- Custom agents / `@agent` mentions (roadmap 77/79) — the big follow-up.
+- Streaming for the **interactive** PTY path — it already streams raw chunks
+  via `Options.OnOutput` (`internal/tui/interactive.go`). Non-interactive
+  `runPiped` is the gap.
+- Rendering tool-call args as they stream from the model (roadmap line 45) —
+  separate item.
+- Env-marker implementation (line 70) — done already.
+- Changing `maxOutput` or the truncation format beyond the spill notice.
+
+## Design
+
+### Surfaces & files
+
+- `internal/tools/bashrun/bashrun.go` — `Options.OnUpdate func(outputSoFar string)`;
+  `runPiped` takes `opts` and fires a throttled snapshot of the accumulated
+  buffer from the drain path.
+- `internal/tools/bashrun/spill.go` (new, small) — `spill(full string) string`:
+  write full output to `os.MkdirTemp`/`os.CreateTemp` under
+  `$TMPDIR/whip-bash-*`, return the path ("" on failure — spill must never
+  break a tool result).
+- `internal/tools/tools.go` — bash tool: after `TruncateTail` triggers, append
+  `\n[full output: <path>]`; thread a per-call `OnUpdate` into `bashrun.Run`
+  via a package hook (same pattern as `InteractiveBash`):
+  `var BashOnUpdate func(chunk-so-far string)` set by the agent layer per run.
+  **Concurrency:** tool calls run in parallel and bash takes the global bash
+  lock (`toolMutationPath` → one global channel), so only one bash run is
+  in flight at a time — but the hook must still be set/cleared around each
+  run, not left dangling. Use a context-carried or mutex-guarded setter;
+  check how `runTools` invokes `Tool.Run` and pick the shape that doesn't
+  leak state across parallel batches.
+- `internal/agent/agent.go` — `Events.OnToolOutput func(id, outputSoFar string)`
+  (optional); `runTools` passes a per-call callback down for the bash tool.
+  Tools are shared `Tool{Def, Run}` values, so the per-call identity has to
+  travel via ctx or a tools-level setter keyed for the current call — decide
+  during implementation; ctx value is the cleaner Go shape.
+- `internal/tui/tui.go` — new `toolOutputMsg{id, text}`; on receipt, update the
+  `blockToolRun` row for that id in place (throttled already upstream, so a
+  plain `send()` is fine); keep the completed-row behavior on `toolEndMsg`.
+
+### Channel/lifecycle notes (per docs/concurrency.md)
+
+- Throttling happens **inside bashrun's drain goroutine**: last-fire timestamp
+  guarded by the existing `mu`; fire at most every 100ms, always fire once at
+  the end is NOT needed (toolEndMsg delivers the final text). Callback is
+  invoked from the run goroutine — documented as such, same as `OnOutput`.
+- No new goroutines; the drain loop already exists. No unbounded channels.
+- TUI callback path: agent worker goroutine → `prog.Send` — same discipline as
+  OnToolStart/End (never touch UI state directly).
+
+### Spill details
+
+- Trigger: `len(res.Output) > maxOutput` in the bash tool wrapper (the same
+  condition `TruncateTail` uses).
+- File: `filepath.Join(os.TempDir(), fmt.Sprintf("whip-bash-%d-*.txt", ...))`
+  via `os.CreateTemp`, `0o600`. Notice appended after the truncation marker:
+  `\n[full output (%d bytes): <path>]`.
+- Cleanup: none — temp dir, OS reaps. Document it.
+
+## Prior art
+
+- pi bash tool: `onUpdate` throttled at 100ms; spill-truncated-output-to-file
+  (roadmap lines 68-69 citations). pi source not on this machine; behavior
+  taken from the roadmap + features docs.
+- whip interactive PTY streaming: `internal/tools/bashrun/bashrun.go` `OnOutput`
+  (raw chunks) — the non-interactive analog here is throttled snapshots, since
+  the TUI row re-renders the whole buffer, not deltas.
+- `InteractiveBash` hook (`internal/tools/tools.go:34-37`) — the precedent for
+  TUI-installed behavior in the tools package.
+
+## Test plan
+
+- `internal/tools/bashrun/bashrun_test.go` (extend or new file):
+  - Spill: command emitting > maxOutput bytes → result contains the spill
+    notice, temp file exists, file content == full untruncated output.
+    (Spill lives in tools.go where maxOutput lives — test at that level.)
+  - OnUpdate: command with staged output (`echo a; sleep 0.35; echo b`) →
+    callback fired ≥2 times, monotonically growing snapshots, inter-fire gap
+    ≥ ~95ms (throttle proof), final snapshot ⊆ final output.
+  - `-race` clean.
+- `internal/agent/agent_test.go`: fake-provider loop test — bash tool call
+  with OnToolOutput wired fires while the command runs (use a slow command),
+  event carries the tool-call id.
+- `internal/tui` headless test: `toolOutputMsg` updates the matching running
+  block's text; unknown id is a no-op.
+
+## Docs plan
+
+- `docs/features.md`: extend the agent-loop/bash section — spill behavior +
+  streaming, naming code + tests.
+- `docs/roadmap.md`: check lines 68, 69 (implemented here) and line 70
+  (already implemented in markers.go — tick with a pointer).
+- `docs/concurrency.md`: only if the throttle introduces a pattern worth
+  teaching (likely a one-liner addition at most).
+
+## Tasks (ordered)
+
+1. bashrun: `Options.OnUpdate` + throttle in `runPiped` + unit test.
+2. bashrun: `spill.go` + unit test.
+3. tools.go: wire spill into bash result; wire OnUpdate hook; tests.
+4. agent: `Events.OnToolOutput` + runTools plumbing + fake-provider test.
+5. TUI: `toolOutputMsg` + block update + headless test.
+6. Roadmap checkboxes (68, 69, 70) + features.md section.
+7. `task check` + `go test -race ./internal/...`; adversarial pass (parallel
+   tool calls, ctrl+c mid-run, spill failure path, narrow terminal re-render).
+8. Open PR.
+
+## Deviations / breadcrumbs
+
+- OnUpdate plumbing uses a **ctx value** (`tools.WithOnUpdate`), not a package
+  var hook as first sketched — no shared mutable state, parallel-safe by
+  construction.
+- `runPiped` signature gained an `onUpdate func(string)` param (was `Options`
+  pass-through); interactive fallback passes nil (PTY already streams raw).
+- The ticker goroutine shares the drains' `mu` for buffer snapshots — no new
+  synchronization introduced.
+- TUI renders only the **last 3 non-empty lines** under the running row
+  (`block.live`), cleared on `toolEndMsg`; persisted sessions never serialize
+  `live` (blocks are in-memory only; SQLite holds llm.Messages).
+- Pre-existing race on main: `TestScheduleFiresWakeup` reads
+  `m.agent.Messages` while the turn goroutine appends (agent.go:287). Not
+  caused by this diff (reproduces with the diff stashed); flagged for a
+  follow-up fix, left out of scope here.
+- Status: implemented, `task check` + full `go test ./...` green, `-race`
+  green on tools/bashrun/tools/agent/tui (minus the pre-existing flake above).

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,6 +34,42 @@ Tests: `parallel_test.go` — `TestToolCallsRunInParallel` (overlap measured via
 a concurrency counter), `TestSamePathEditsSerialize`, `TestToolMutationPath`,
 `TestCanonicalPathKey`.
 
+### Bash output feedback: live streaming + truncation spill
+
+Two ways a bash command stops being a black box (pi's bash tool has both):
+
+- **Streamed partial output.** `bashrun.Options.OnUpdate` reports the
+  accumulated combined stdout/stderr at most every 100ms
+  (`bashrun.updateInterval`) from a snapshot ticker goroutine owned by the
+  run — it snapshots the shared buffer under the drains' mutex and exits on a
+  done-channel close when `runPiped` returns (one trailing tick may land after
+  return; the TUI's `toolRunning` check makes it a no-op). The TUI callback
+  uses a detached `go p.Send(...)`, so a wedged UI queue can never park the
+  ticker goroutine (docs/concurrency.md's ABBA rule). The bash
+  tool receives the callback through a **per-call context value**
+  (`tools.WithOnUpdate`), not a package var, so parallel tool calls can't
+  cross wires; `agent.runTools` attaches it when `Events.OnToolOutput` is set
+  and the call is bash. The TUI (`toolOutputMsg`) renders the last three
+  non-empty lines under the running tool row's verb line (`block.live`);
+  `toolEndMsg` clears it and collapses the row as before. The final output
+  still arrives via the tool result — snapshots are progress, never state.
+- **Truncation spill.** When combined output exceeds `maxOutput` (50KB) and
+  `TruncateTail` fires, `bashrun.Spill` writes the **full** bytes to
+  `$TMPDIR/whip-bash-<pid>/*.log` (0600, OS-reaped) and the tool result
+  appends `[full output (N bytes): <path>]` so the model can read/grep the
+  head it never saw. Spill failure degrades silently — a broken temp dir must
+  not cost the tool result.
+
+Tests: `internal/tools/bashrun/feedback_test.go` — `TestOnUpdateThrottle`
+(≥95ms between fires, prefix-growing snapshots), `TestOnUpdateNil`,
+`TestOnUpdateFastCommand`, `TestSpill` (content round-trip + 0600 perms);
+`internal/tools/bash_feedback_test.go` — `TestBashToolSpillOnTruncation`
+(notice + file holds the truncated-away head), `TestBashToolNoSpillUnderCap`,
+`TestBashToolOnUpdateCtx`; `internal/agent/tool_output_test.go` —
+`TestOnToolOutputStreamsBash` (event carries the tool-call id, fires mid-run);
+`internal/tui/tool_output_test.go` — `TestToolOutputMsgUpdatesRunningRow`
+(unknown id ignored, tail replaces, end clears), `TestLastLines`.
+
 ### Compaction
 
 When the conversation fills the context window, old turns fold into an

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,9 +65,9 @@ parallel tool calls and background subagents).
 
 - [x] Parallel tool-call execution with per-path file mutation lock (pi: `withFileMutationQueue`, `executeToolCallsParallel`) — `agent.runTools` fans a tool-call batch out to goroutines; write/edit serialize through a per-canonical-path channel semaphore, bash takes a global lock; results land in call order, OnToolStart/End fire per call
 - [x] Retry with backoff on provider errors (pi settings: `retry: {maxRetries, baseDelayMs}`) — transient failures (429/5xx/transport) retry with exponential backoff (1s→2s→4s… capped 20s, jittered), configurable via `maxRetries` (default 8, 1 disables); streaming retries stop once visible text has been emitted so the transcript never double-prints, and context-limit errors pass straight through to the compaction retry
-- [ ] Streamed partial tool output (bash `onUpdate` throttled at 100ms in pi)
-- [ ] Spill truncated bash output to a temp file and mention the path (pi bash tool)
-- [ ] Inject `WHIP_SESSION_ID` / `WHIP_MODEL` env into bash children (pi injects `PI_*`)
+- [x] Streamed partial tool output (bash `onUpdate` throttled at 100ms in pi) — `bashrun.Options.OnUpdate` fires accumulated-output snapshots at most every 100ms from the run's own goroutine; the bash tool picks it up via a per-call ctx value (`tools.WithOnUpdate` — parallel calls can't cross wires), `agent.Events.OnToolOutput` carries it with the tool-call id, and the TUI renders the last-3-lines tail under the running tool row until `toolEndMsg` collapses it
+- [x] Spill truncated bash output to a temp file and mention the path (pi bash tool) — when combined output exceeds `maxOutput` and gets tail-truncated, `bashrun.Spill` writes the full bytes to `$TMPDIR/whip-bash-<pid>/*.log` (0600) and the tool result appends `[full output (N bytes): <path>]` so the model can read/grep the rest; spill failure degrades silently, never breaks the result
+- [x] Inject `WHIP_SESSION_ID` / `WHIP_MODEL` env into bash children (pi injects `PI_*`) — already shipped: `bashrun.SetMarkers` stamps `WHIP=1`, `WHIP_SESSION_ID`, `WHIP_MODEL`, `WHIP_PID` on every child env (wired from `tui.go` on session create/resume); checkbox was stale
 
 ## Skills & subagents
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,15 +16,18 @@ import (
 
 // Events receives streaming callbacks during a turn. All fields are optional.
 type Events struct {
-	OnText      func(delta string)               // assistant text as it streams
-	OnThink     func(delta string)               // reasoning/thinking tokens as they stream
-	OnToolStart func(id, name, args string)      // a tool call is about to run
-	OnToolEnd   func(id, name, result string)    // a tool call finished
-	OnSteer     func(text string)                // a steered message was injected
-	OnCompact   func(took, kept int)             // context was auto-compacted (messages removed/kept)
-	OnCompacted func(summary string, cutoff int) // a compaction ran; record it (raw log survives)
-	OnUsage     func(u llm.Usage)                // a request reported its token usage
-	OnRetry     func(ev llm.RetryEvent)          // a transient request failure is being retried
+	OnText      func(delta string)            // assistant text as it streams
+	OnThink     func(delta string)            // reasoning/thinking tokens as they stream
+	OnToolStart func(id, name, args string)   // a tool call is about to run
+	OnToolEnd   func(id, name, result string) // a tool call finished
+	// OnToolOutput streams partial output for a running tool call (bash only —
+	// throttled snapshots, ~100ms apart). Fires from tool worker goroutines.
+	OnToolOutput func(id, outputSoFar string)
+	OnSteer      func(text string)                // a steered message was injected
+	OnCompact    func(took, kept int)             // context was auto-compacted (messages removed/kept)
+	OnCompacted  func(summary string, cutoff int) // a compaction ran; record it (raw log survives)
+	OnUsage      func(u llm.Usage)                // a request reported its token usage
+	OnRetry      func(ev llm.RetryEvent)          // a transient request failure is being retried
 }
 
 // Agent holds one conversation.
@@ -424,7 +427,13 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 				ev.OnToolStart(tc.ID, name, args)
 			}
 			start := time.Now()
-			out := tools.Execute(ctx, a.AllTools(), name, json.RawMessage(args))
+			callCtx := ctx
+			if ev.OnToolOutput != nil && name == "bash" {
+				callCtx = tools.WithOnUpdate(ctx, func(soFar string) {
+					ev.OnToolOutput(tc.ID, soFar)
+				})
+			}
+			out := tools.Execute(callCtx, a.AllTools(), name, json.RawMessage(args))
 			ms := time.Since(start).Milliseconds()
 			if ev.OnToolEnd != nil {
 				ev.OnToolEnd(tc.ID, name, out)

--- a/internal/agent/tool_output_test.go
+++ b/internal/agent/tool_output_test.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools"
+)
+
+// TestOnToolOutputStreamsBash: a slow bash tool call fires OnToolOutput with
+// the tool-call id and partial output while the command is still running
+// (roadmap: "streamed partial tool output"). The event never fires for
+// non-bash tools.
+func TestOnToolOutputStreamsBash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Only tool call: bash with staged output so snapshots exist mid-run.
+		last := req.Messages[len(req.Messages)-1]
+		if last.Role == "tool" {
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}`+"\n\n")
+		} else {
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc1","type":"function","function":{"name":"bash","arguments":"{\"command\":\"echo early; sleep 0.3; echo late\"}"}}]}}]}`+"\n\n")
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.Tools = tools.All()
+
+	var mu sync.Mutex
+	var ids []string
+	var snaps []string
+	final, err := ag.Turn(context.Background(), "go", Events{
+		OnToolOutput: func(id, soFar string) {
+			mu.Lock()
+			ids = append(ids, id)
+			snaps = append(snaps, soFar)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final != "done" {
+		t.Fatalf("final: %q", final)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(snaps) == 0 {
+		t.Fatal("OnToolOutput never fired for a slow bash call")
+	}
+	for _, id := range ids {
+		if id != "tc1" {
+			t.Fatalf("OnToolOutput carried the wrong tool-call id: %q", id)
+		}
+	}
+	if !strings.Contains(strings.Join(snaps, ""), "early") {
+		t.Fatalf("snapshots missed the in-flight output: %v", snaps)
+	}
+}

--- a/internal/tools/bash_feedback_test.go
+++ b/internal/tools/bash_feedback_test.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestBashToolSpillOnTruncation: output beyond maxOutput is tail-truncated for
+// the model AND spilled to a file the tool result names, so the model can
+// read/grep the rest (roadmap: "spill truncated bash output to a temp file").
+func TestBashToolSpillOnTruncation(t *testing.T) {
+	// Emit maxOutput+1000 bytes: head marker, 60KB of filler, tail marker.
+	cmd := `printf 'HEADMARKER\n'; head -c 60000 /dev/zero | tr '\0' 'x'; printf '\nTAILMARKER\n'`
+	out := run(t, "bash", fmt.Sprintf(`{"command":%q}`, cmd))
+
+	if !strings.Contains(out, "truncated") {
+		t.Fatalf("expected truncation marker:\n%.300s", out)
+	}
+	// The spill notice names a file holding the FULL output.
+	i := strings.Index(out, "[full output (")
+	if i < 0 {
+		t.Fatalf("missing spill notice:\n%.500s", out)
+	}
+	pathStart := strings.Index(out[i:], ": ") + 2 + i
+	path := strings.TrimSuffix(strings.TrimSpace(out[pathStart:]), "]")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("spill file unreadable: %v", err)
+	}
+	defer os.Remove(path)
+	if !strings.Contains(string(data), "HEADMARKER") || !strings.Contains(string(data), "TAILMARKER") {
+		t.Fatalf("spill file lost content: %d bytes, head=%v tail=%v",
+			len(data), strings.Contains(string(data), "HEADMARKER"), strings.Contains(string(data), "TAILMARKER"))
+	}
+	// The truncated result keeps the tail (the interesting end of the log).
+	if !strings.Contains(out, "TAILMARKER") {
+		t.Errorf("truncated result lost the tail marker")
+	}
+}
+
+// TestBashToolNoSpillUnderCap: output within maxOutput spills nothing.
+func TestBashToolNoSpillUnderCap(t *testing.T) {
+	out := run(t, "bash", `{"command":"echo small"}`)
+	if strings.Contains(out, "full output") {
+		t.Fatalf("small output must not spill: %q", out)
+	}
+}
+
+// TestBashToolOnUpdateCtx: WithOnUpdate on the ctx reaches bashrun — partial
+// snapshots arrive while a staged command is still running.
+func TestBashToolOnUpdateCtx(t *testing.T) {
+	var mu sync.Mutex
+	var snaps []string
+	ctx := WithOnUpdate(context.Background(), func(soFar string) {
+		mu.Lock()
+		snaps = append(snaps, soFar)
+		mu.Unlock()
+	})
+	out := Execute(ctx, All(), "bash",
+		json.RawMessage(`{"command":"echo early; sleep 0.3; echo late"}`))
+	if !strings.Contains(out, "late") {
+		t.Fatalf("final result wrong: %q", out)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(snaps) == 0 {
+		t.Fatal("no partial snapshots delivered through the ctx callback")
+	}
+	if !strings.Contains(strings.Join(snaps, ""), "early") {
+		t.Fatalf("snapshots missed the early output: %v", snaps)
+	}
+}

--- a/internal/tools/bashrun/bashrun.go
+++ b/internal/tools/bashrun/bashrun.go
@@ -97,6 +97,12 @@ type Options struct {
 	// OnOutput streams PTY stdout/stderr deltas back to the caller (live
 	// transcript). Interactive only; safe to call from the run goroutine.
 	OnOutput func(chunk string)
+	// OnUpdate reports the accumulated combined output while a non-interactive
+	// command runs, throttled to at most one call per ~100ms (pi's bash
+	// onUpdate). Invoked from the run's own goroutines; must not block.
+	// The final output is delivered via Result, not OnUpdate; one trailing
+	// call may land after Run returns if a tick was in flight.
+	OnUpdate func(outputSoFar string)
 	// OnAwaitInput is called once per second while the child is quiet and
 	// likely waiting for input; secLeft is the seconds remaining before the
 	// inactivity timeout fires. Interactive only.
@@ -129,7 +135,7 @@ func Run(ctx context.Context, opts Options) Result {
 	if opts.Interactive {
 		return runInteractive(ctx, cmd, opts)
 	}
-	return runPiped(ctx, cmd)
+	return runPiped(ctx, cmd, opts.OnUpdate)
 }
 
 // runPiped runs the command with stdout/stderr captured, stdin wired to
@@ -145,7 +151,11 @@ func Run(ctx context.Context, opts Options) Result {
 // our read ends the moment the process exits, so a lingering grandchild can't
 // stall us. (We don't get the grandchild's later output, which is correct —
 // it outlived the command.)
-func runPiped(ctx context.Context, cmd *exec.Cmd) Result {
+// updateInterval is the minimum gap between OnUpdate calls while a command
+// runs (pi throttles its bash onUpdate at 100ms too).
+const updateInterval = 100 * time.Millisecond
+
+func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result {
 	// Hand-rolled pipes, NOT cmd.StdoutPipe: Wait() closes StdoutPipe's read
 	// ends the moment the child exits, discarding kernel-buffered output the
 	// drain goroutines haven't read yet (lost output on fast commands). With
@@ -208,6 +218,29 @@ func runPiped(ctx context.Context, cmd *exec.Cmd) Result {
 	}
 	go drain(stdout)
 	go drain(stderr)
+	// Stream throttled snapshots of the accumulated output to the caller so
+	// in-flight progress is visible before the command exits. One goroutine,
+	// owned by this run, exits when updatesDone closes below.
+	var updatesDone chan struct{}
+	if onUpdate != nil {
+		updatesDone = make(chan struct{})
+		defer close(updatesDone)
+		go func() {
+			ticker := time.NewTicker(updateInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-updatesDone:
+					return
+				case <-ticker.C:
+					mu.Lock()
+					snap := out.String()
+					mu.Unlock()
+					onUpdate(snap)
+				}
+			}
+		}()
+	}
 	// Kill the process group if the run context is cancelled/times out.
 	watchDone := make(chan struct{})
 	defer close(watchDone)
@@ -272,7 +305,7 @@ func runInteractive(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 	if err != nil {
 		// Fall back to the safe non-interactive path; an interactive failure
 		// must never hang the agent.
-		return runPiped(ctx, cmd)
+		return runPiped(ctx, cmd, nil)
 	}
 	defer ptmx.Close()
 	track(cmd) // register for KillAll on whip exit

--- a/internal/tools/bashrun/feedback_test.go
+++ b/internal/tools/bashrun/feedback_test.go
@@ -1,0 +1,110 @@
+package bashrun
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestOnUpdateThrottle: a command emitting output in stages fires OnUpdate
+// with monotonically growing snapshots, and the throttle keeps consecutive
+// calls at least ~updateInterval apart (pi's bash onUpdate is 100ms).
+func TestOnUpdateThrottle(t *testing.T) {
+	var mu sync.Mutex
+	var snaps []string
+	var times []time.Time
+
+	res := Run(context.Background(), Options{
+		Command: `echo stage1; sleep 0.35; echo stage2; sleep 0.35; echo stage3`,
+		Timeout: 10 * time.Second,
+		OnUpdate: func(soFar string) {
+			mu.Lock()
+			snaps = append(snaps, soFar)
+			times = append(times, time.Now())
+			mu.Unlock()
+		},
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(snaps) < 2 {
+		t.Fatalf("expected ≥2 partial snapshots over ~0.7s of staged output, got %d: %v", len(snaps), snaps)
+	}
+	// Snapshots are cumulative: each is a prefix-extension of the last, and
+	// the union covers what the command printed before the final Result.
+	for i := 1; i < len(snaps); i++ {
+		if !strings.HasPrefix(snaps[i], snaps[i-1]) && !strings.HasPrefix(snaps[i-1], snaps[i]) {
+			t.Errorf("snapshot %d is not a prefix-extension of %d:\n%q\nvs\n%q", i, i-1, snaps[i], snaps[i-1])
+		}
+	}
+	joined := strings.Join(snaps, "")
+	if !strings.Contains(joined, "stage1") {
+		t.Errorf("no snapshot contained the first stage's output: %v", snaps)
+	}
+	// Throttle: consecutive fires are at least ~updateInterval apart (5ms
+	// slack for scheduler jitter on a loaded CI box).
+	for i := 1; i < len(times); i++ {
+		if gap := times[i].Sub(times[i-1]); gap < updateInterval-5*time.Millisecond {
+			t.Errorf("OnUpdate fired %s after previous call — throttle regressed (< %s)", gap, updateInterval)
+		}
+	}
+	// The final Result still carries the complete output (OnUpdate never
+	// claims to deliver the end state).
+	if !strings.Contains(res.Output, "stage3") {
+		t.Errorf("final result missing last stage: %q", res.Output)
+	}
+}
+
+// TestOnUpdateNil: no callback, no panic, output intact (the default path).
+func TestOnUpdateNil(t *testing.T) {
+	res := Run(context.Background(), Options{Command: `echo plain`})
+	if strings.TrimSpace(res.Output) != "plain" {
+		t.Fatalf("output wrong without OnUpdate: %q", res.Output)
+	}
+}
+
+// TestOnUpdateFastCommand: a command that exits before the first tick may
+// legitimately fire zero times; what matters is the run doesn't stall.
+func TestOnUpdateFastCommand(t *testing.T) {
+	fired := make(chan struct{}, 8)
+	done := make(chan Result, 1)
+	go func() {
+		done <- Run(context.Background(), Options{
+			Command:  `echo fast`,
+			OnUpdate: func(string) { fired <- struct{}{} },
+		})
+	}()
+	select {
+	case res := <-done:
+		if !strings.Contains(res.Output, "fast") {
+			t.Fatalf("output wrong: %q", res.Output)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("fast command with OnUpdate stalled")
+	}
+}
+
+// TestSpill: the full output lands in a temp file the model can read back.
+func TestSpill(t *testing.T) {
+	full := "HEAD\n" + strings.Repeat("x", 100) + "\nTAIL\n"
+	path := Spill(full)
+	if path == "" {
+		t.Fatal("Spill returned no path")
+	}
+	defer os.Remove(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("spill file unreadable: %v", err)
+	}
+	if string(data) != full {
+		t.Fatalf("spill file content mismatch: got %d bytes, want %d", len(data), len(full))
+	}
+	// Private to the user — the output may carry secrets.
+	if fi, err := os.Stat(path); err != nil || fi.Mode().Perm() != 0o600 {
+		t.Fatalf("spill file perms wrong: %v %v", fi, err)
+	}
+}

--- a/internal/tools/bashrun/spill.go
+++ b/internal/tools/bashrun/spill.go
@@ -1,0 +1,34 @@
+package bashrun
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Spill writes the full (untruncated) command output to a temp file so the
+// model can read/grep the rest when the tool result had to be truncated
+// (pi's bash tool does the same). Returns the file path, or "" on failure —
+// a spill failure must never break a tool result.
+//
+// Files live in $TMPDIR/whip-bash-<pid>-* and are left for the OS to reap.
+func Spill(output string) string {
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("whip-bash-%d", os.Getpid()))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return ""
+	}
+	f, err := os.CreateTemp(dir, "*.log")
+	if err != nil {
+		return ""
+	}
+	if _, err := f.WriteString(output); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name()) // don't leave a partial file claiming to be full
+		return ""
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return ""
+	}
+	return f.Name()
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -50,6 +50,18 @@ func All() []Tool {
 	return []Tool{bashTool(), readTool(), writeTool(), editTool()}
 }
 
+// updateKey carries a per-tool-call partial-output callback. The agent layer
+// attaches it to the ctx for one call (a context value, not a package var, so
+// parallel tool calls can't cross wires); the bash tool forwards it to
+// bashrun's OnUpdate. Non-callers (whip run, tests) simply don't set it.
+type updateKey struct{}
+
+// WithOnUpdate returns a ctx that makes the bash tool report throttled partial
+// output snapshots for this one call.
+func WithOnUpdate(ctx context.Context, onUpdate func(outputSoFar string)) context.Context {
+	return context.WithValue(ctx, updateKey{}, onUpdate)
+}
+
 // Defs returns the llm.Tool definitions for a tool set.
 func Defs(ts []Tool) []llm.Tool {
 	defs := make([]llm.Tool, len(ts))
@@ -155,12 +167,24 @@ func bashTool() Tool {
 				return TruncateTail(out), nil
 			}
 
+			var onUpdate func(string)
+			if cb, ok := ctx.Value(updateKey{}).(func(string)); ok {
+				onUpdate = cb
+			}
 			res := bashrun.Run(ctx, bashrun.Options{
-				Command: a.Command,
-				Timeout: dur,
+				Command:  a.Command,
+				Timeout:  dur,
+				OnUpdate: onUpdate,
 			})
 
 			s := TruncateTail(res.Output)
+			if len(res.Output) > maxOutput {
+				// The model only sees the tail; give it a way to reach the
+				// rest (pi spills truncated bash output to a file too).
+				if path := bashrun.Spill(res.Output); path != "" {
+					s += fmt.Sprintf("\n[full output (%d bytes): %s]", len(res.Output), path)
+				}
+			}
 			if res.TimedOut {
 				return s + "\n(command timed out)", nil
 			}

--- a/internal/tui/rewind.go
+++ b/internal/tui/rewind.go
@@ -78,6 +78,19 @@ func firstLine(s string) string {
 	return "(no output)"
 }
 
+// lastLines is the running tool row's live tail: the last n non-empty lines,
+// each truncated for width sanity, joined with newlines.
+func lastLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	var kept []string
+	for i := len(lines) - 1; i >= 0 && len(kept) < n; i-- {
+		if l := strings.TrimRight(lines[i], "\r \t"); l != "" {
+			kept = append([]string{truncLine(l, 200)}, kept...)
+		}
+	}
+	return strings.Join(kept, "\n  ")
+}
+
 // toolVerb is the present-participle a running row leads with ("Reading
 // file…"-style); the tool name verbatim when there's no nicer verb.
 func toolVerb(name string) string {

--- a/internal/tui/tool_output_test.go
+++ b/internal/tui/tool_output_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// toolOutputMsg streams partial bash output onto the running row: the tail of
+// what has arrived shows under the verb line, and the row collapses clean
+// (live tail gone) when the tool ends. Unknown ids are ignored.
+func TestToolOutputMsgUpdatesRunningRow(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 24))
+
+	m.Update(toolStartMsg{id: "c1", name: "bash", args: `{"command":"make"}`})
+	// An update for a different/unknown id must not touch the row.
+	m.Update(toolOutputMsg{id: "zzz", text: "stray"})
+	row := m.blocks[len(m.blocks)-1]
+	if row.live != "" {
+		t.Fatalf("unknown id must not set live output, got %q", row.live)
+	}
+
+	m.Update(toolOutputMsg{id: "c1", text: "compiling a.c\ncompiling b.c\nlinking"})
+	row = m.blocks[len(m.blocks)-1]
+	if row.live == "" {
+		t.Fatal("toolOutputMsg should set the live tail on the running row")
+	}
+	got := ansi.Strip(row.render(m.width))
+	if !strings.Contains(got, "linking") || !strings.Contains(got, "Running") && !strings.Contains(got, "⚒") {
+		t.Fatalf("running row should show verb + live tail, got %q", got)
+	}
+	// Newer snapshots replace the older tail, and only the last lines show.
+	m.Update(toolOutputMsg{id: "c1", text: "line1\nline2\nline3\nline4\nline5"})
+	row = m.blocks[len(m.blocks)-1]
+	if strings.Contains(row.live, "line1") || !strings.Contains(row.live, "line5") {
+		t.Fatalf("live tail should keep only the last lines: %q", row.live)
+	}
+
+	// Completion clears the live tail; the collapsed row is one line.
+	m.Update(toolEndMsg{id: "c1", name: "bash", result: "done\n"})
+	row = m.blocks[len(m.blocks)-2]
+	if row.live != "" {
+		t.Fatalf("toolEndMsg should clear the live tail, got %q", row.live)
+	}
+	if got := ansi.Strip(row.render(m.width)); strings.Count(got, "\n") > 0 {
+		t.Fatalf("completed row should collapse to one line, got %q", got)
+	}
+}
+
+// lastLines keeps the last n non-empty lines, each width-capped.
+func TestLastLines(t *testing.T) {
+	got := lastLines("a\n\nb\nc\n", 2)
+	if got != "b\n  c" {
+		t.Fatalf("lastLines: %q", got)
+	}
+	if lastLines("", 3) != "" {
+		t.Fatal("empty input should give empty tail")
+	}
+	long := strings.Repeat("x", 300)
+	if got := lastLines(long, 1); len(got) > 210 {
+		t.Fatalf("lastLines should cap each line, got %d chars", len(got))
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -54,10 +54,11 @@ var (
 
 // messages sent from the agent goroutine
 type (
-	textMsg      string
-	toolStartMsg struct{ id, name, args string }
-	toolEndMsg   struct{ id, name, result string }
-	steeredMsg   string
+	textMsg       string
+	toolStartMsg  struct{ id, name, args string }
+	toolEndMsg    struct{ id, name, result string }
+	toolOutputMsg struct{ id, text string } // partial output for a running tool row
+	steeredMsg    string
 )
 
 // goalFromContextMsg carries the model-formulated goal back from the
@@ -1018,6 +1019,9 @@ type block struct {
 	toolID      string
 	toolRunning bool
 	toolFailed  bool
+	// live is the latest partial-output snapshot for a running bash call,
+	// rendered under the verb line; cleared when the tool ends.
+	live string
 	// y0/y1 are the block's line range in the last rendered content (set by
 	// refreshVP); used to map a mouse click to the block under it.
 	y0, y1 int
@@ -1076,9 +1080,13 @@ func (b block) render(width int) string {
 		hint := fmt.Sprintf("\n  … +%d lines (ctrl+e or click to expand)", len(lines)-toolPreviewLines)
 		return wrap(out+dimStyle.Render(hint), width)
 	case blockToolRun:
-		// While running, the verb line shows in full. On completion the same
-		// block collapses in place to one line (red on failure); ctrl+e expands.
+		// While running, the verb line shows in full with the live output
+		// tail under it. On completion the same block collapses in place to
+		// one line (red on failure); ctrl+e expands.
 		if b.toolRunning || b.expanded {
+			if b.live != "" && b.toolRunning {
+				return wrap(b.text, width) + "\n" + wrap(dimStyle.Render("  "+b.live), width)
+			}
 			return wrap(b.text, width)
 		}
 		line := ansi.Truncate(b.text, width, "…")
@@ -1683,6 +1691,23 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshVP()
 		return m, nil
 
+	case toolOutputMsg:
+		// partial output for a running bash row: show the tail of what's
+		// arrived so far under the verb line. toolEndMsg replaces it with
+		// the final collapsed row, so no truncation bookkeeping here.
+		for i := len(m.blocks) - 1; i >= 0; i-- {
+			b := &m.blocks[i]
+			if b.kind == blockToolRun && b.toolRunning && b.toolID == msg.id {
+				if tail := lastLines(msg.text, 3); tail != "" {
+					b.live = tail
+					b.stale = true
+					m.refreshVP()
+				}
+				break
+			}
+		}
+		return m, nil
+
 	case toolEndMsg:
 		// store the raw result; render collapses to a preview (ctrl+e /
 		// click expands) and re-wraps on resize
@@ -1694,6 +1719,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if b.kind == blockToolRun && b.toolRunning && b.toolID == msg.id {
 				b.toolRunning = false
 				b.toolFailed = strings.HasPrefix(msg.result, "Error:")
+				b.live = ""
 				b.text = toolStyle.Render("⚒ "+msg.name+" ") + dimStyle.Render(firstLine(msg.result))
 				b.stale = true
 				break
@@ -3146,6 +3172,10 @@ func (m *model) submitTurn(text string, authored bool) (tea.Model, tea.Cmd) {
 				send(toolStartMsg{id, n, a})
 			},
 			OnToolEnd: func(id, n, r string) { send(toolEndMsg{id, n, r}) },
+			// Detached send: snapshots are lossy progress, and a parked
+			// p.Send must never wedge bashrun's ticker goroutine (the ABBA
+			// lesson from docs/concurrency.md — same rule as sendTaskMsg).
+			OnToolOutput: func(id, soFar string) { go send(toolOutputMsg{id, soFar}) },
 			OnSteer: func(s string) {
 				flush()
 				send(steeredMsg(s))


### PR DESCRIPTION
## What

Ships roadmap items L68 and L69 (agent-loop section), and ticks the stale L70 checkbox:

- **L68 — streamed partial tool output.** `bashrun.Options.OnUpdate` fires accumulated-output snapshots at most every 100ms from a ticker goroutine owned by the run (pi's bash `onUpdate`). Wired `bashrun → tools → agent.Events.OnToolOutput → TUI`: the callback travels as a **per-call ctx value** (`tools.WithOnUpdate`) — no package-var hook, so parallel tool calls can't cross wires. The TUI (`toolOutputMsg`) renders the last 3 non-empty lines under the running tool row's verb line; `toolEndMsg` clears it and collapses the row as before. The TUI callback uses a **detached `go p.Send(...)`** so a wedged UI queue can never park the ticker goroutine (the ABBA rule from docs/concurrency.md).

- **L69 — spill truncated bash output to a temp file.** When combined output exceeds `maxOutput` (50KB, `TruncateTail`), `bashrun.Spill` writes the full bytes to `$TMPDIR/whip-bash-<pid>/*.log` (0600) and the tool result appends `[full output (N bytes): <path>]` so the model can read/grep the head it never saw. Spill failure degrades silently; partial writes are removed.

- **L70 — WHIP env markers.** No code change: `bashrun.SetMarkers` already stamps `WHIP=1`, `WHIP_SESSION_ID`, `WHIP_MODEL`, `WHIP_PID` on every child env (tui.go:690,786). Checkbox was stale.

## Tests

- `bashrun/feedback_test.go`: throttle proof (≥2 snapshots over staged 0.7s run, prefix-growing, inter-fire gap ≥95ms), nil-callback, fast-exit no-stall, spill content round-trip + 0600 perms.
- `tools/bash_feedback_test.go`: spill notice + file holds the truncated-away head (HEADMARKER recovered), no spill under the cap, ctx callback reaches bashrun mid-run.
- `agent/tool_output_test.go`: fake-provider loop — `OnToolOutput` fires mid-run with the correct tool-call id.
- `tui/tool_output_test.go`: `toolOutputMsg` updates only the matching running row (unknown id no-op), newer snapshots replace, `toolEndMsg` clears; `lastLines` capping.

`task check` green; `go test -race` clean on tools/bashrun/tools/agent/tui.

## Notes / pre-existing (not from this diff)

- `TestScheduleFiresWakeup` (tui) has a data race **on main** (test reads `m.agent.Messages` while the turn goroutine appends, agent.go:287); reproduces with this diff stashed. Follow-up fix suggested.
- `TestExtensionDisconnectDetaches` (extrelay) is timing-flaky on main (~20% in a small sample); this PR touches nothing in that package.

Plan doc: `.ai-docs/plans/bash-feedback/README.md`.