### PR TITLE
feat: first-class inference-net auth (device login + BYOK)

### DIFF
--- a/cmd/whip/auth.go
+++ b/cmd/whip/auth.go
@@ -33,13 +33,15 @@ import (
 // interactive terminal we offer to append the export to the shell rc file.
 func authCLI(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: whip auth <provider> [<key>]   (providers: openrouter)")
+		return errors.New("usage: whip auth <provider> [<args>]\n  providers: inference-net (login [flags] | status | logout | key rotate), openrouter [--env] [<key>]")
 	}
 	switch args[0] {
+	case "inference-net", "inference":
+		return authInferenceNetCLI(args[1:])
 	case "openrouter":
 		return authOpenRouterCLI(args[1:])
 	default:
-		return fmt.Errorf("unknown provider %q (supported: openrouter)", args[0])
+		return fmt.Errorf("unknown provider %q (supported: inference-net, openrouter)", args[0])
 	}
 }
 

--- a/cmd/whip/auth_inferencenet.go
+++ b/cmd/whip/auth_inferencenet.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/inferencenet"
+)
+
+// authInferenceNetCLI implements `whip auth inference-net …`: first-class
+// Inference.net sign-in. The default path is a browser device-authorization
+// login that provisions a machine API key automatically — no key handling.
+// BYOK is supported via login --key / --env.
+//
+//	whip auth inference-net login [--key <apikey> | --env]
+//	whip auth inference-net status
+//	whip auth inference-net logout
+//	whip auth inference-net key rotate
+func authInferenceNetCLI(args []string) error {
+	sub := "login"
+	if len(args) > 0 {
+		sub = args[0]
+		args = args[1:]
+	}
+	switch sub {
+	case "login":
+		return inferenceNetLoginCLI(args)
+	case "status":
+		return inferenceNetStatusCLI()
+	case "logout":
+		return inferenceNetLogoutCLI()
+	case "key":
+		if len(args) > 0 && args[0] == "rotate" {
+			return inferenceNetKeyRotateCLI()
+		}
+		return errors.New("usage: whip auth inference-net key rotate")
+	default:
+		return fmt.Errorf("unknown inference-net subcommand %q (login | status | logout | key rotate)", sub)
+	}
+}
+
+func inferenceNetLoginCLI(args []string) error {
+	fs := flag.NewFlagSet("auth inference-net login", flag.ContinueOnError)
+	key := fs.String("key", "", "bring your own Inference.net API key instead of the browser login")
+	envMode := fs.Bool("env", false, "store the BYOK key as apiKeyEnv: "+config.InferenceNetEnvVar+" instead of a literal in config.json")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	k := config.TrimKey(*key)
+	if k == "" {
+		k = config.TrimKey(os.Getenv(config.InferenceNetEnvVar))
+	}
+	if k != "" || *envMode {
+		return inferenceNetBYOK(k, *envMode)
+	}
+	return inferenceNetDeviceLogin()
+}
+
+// inferenceNetBYOK validates a user-supplied key and persists it on the
+// provider entry. Nothing is written until the key validates.
+func inferenceNetBYOK(key string, envMode bool) error {
+	if key == "" {
+		return errors.New("no API key provided (set " + config.InferenceNetEnvVar + " or pass --key; get one at https://inference.net)")
+	}
+	fmt.Print("validating key against Inference.net… ")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	err := inferencenet.ValidateKey(ctx, key)
+	cancel()
+	if err != nil {
+		fmt.Println("failed")
+		return err
+	}
+	fmt.Println("ok")
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	cfg.UpsertInferenceNet(key, envMode)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	if envMode && os.Getenv(config.InferenceNetEnvVar) == "" {
+		offerShellExport(key)
+	}
+	fmt.Println("inference-net provider configured.")
+	fmt.Println("  run `whip`, then /model to pick a model on inference-net.")
+	return nil
+}
+
+// inferenceNetDeviceLogin runs the browser device flow, mints a machine API
+// key, and registers the provider — the user never touches a key.
+func inferenceNetDeviceLogin() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	fmt.Println("Starting secure terminal authorization…")
+	var opened bool
+	auth, err := inferencenet.CompleteLogin(ctx, func(verificationURL, userCode string) {
+		fmt.Println("\n  Approve this terminal in your browser:")
+		fmt.Println("  " + verificationURL + "\n")
+		fmt.Println("  Code: " + userCode + "\n")
+		opened = openBrowser(verificationURL)
+		if opened {
+			fmt.Println("  Browser opened. Waiting for approval…")
+		} else {
+			fmt.Println("  Open the URL manually. Waiting for approval…")
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Provisioning an API key for this machine…")
+	if _, err := auth.EnsureMachineKey(ctx); err != nil {
+		_ = inferencenet.ClearAuth()
+		return err
+	}
+	if err := inferencenet.SaveAuth(auth); err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	// The machine key resolves via the ~/.whip/inference-net.json fallback, so
+	// the provider entry carries no literal key.
+	cfg.UpsertInferenceNet("", false)
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	fmt.Printf("\n✓ Signed in as %s\n", auth.UserEmail)
+	fmt.Printf("  Project: %s (%s)\n", auth.ProjectName, auth.ProjectID)
+	fmt.Printf("  Machine key: %s\n", auth.MachineKeyName)
+	fmt.Println("  inference-net provider configured — run `whip`, then /model.")
+	return nil
+}
+
+func inferenceNetStatusCLI() error {
+	auth, err := inferencenet.LoadAuth()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	p, ok := cfg.Providers[config.InferenceNetProvider]
+	fmt.Println("Inference.net")
+	if auth.SignedIn() {
+		fmt.Println("  Account     " + auth.UserEmail)
+		fmt.Println("  Project     " + auth.ProjectName + " (" + auth.ProjectID + ")")
+	} else {
+		fmt.Println("  Account     not signed in (whip auth inference-net login)")
+	}
+	if auth.HasMachineKey() {
+		fmt.Println("  Machine key " + auth.MachineKeyName)
+	}
+	switch {
+	case !ok:
+		fmt.Println("  Provider    not configured")
+	case p.APIKeyEnv != "":
+		fmt.Println("  Provider    apiKeyEnv " + p.APIKeyEnv)
+	case p.APIKey != "":
+		fmt.Println("  Provider    literal apiKey")
+	default:
+		fmt.Println("  Provider    machine key (browser login)")
+	}
+	return nil
+}
+
+func inferenceNetLogoutCLI() error {
+	auth, err := inferencenet.LoadAuth()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if auth.HasMachineKey() {
+		if err := auth.ArchiveMachineKey(ctx); err != nil {
+			fmt.Fprintln(os.Stderr, "whip: could not disable the machine API key:", err)
+		} else {
+			fmt.Println("  Disabled this machine's API key.")
+		}
+	}
+	if auth.SignedIn() {
+		if err := inferencenet.SignOut(ctx, auth.SessionToken); err != nil {
+			fmt.Fprintln(os.Stderr, "whip: the remote session could not be closed:", err)
+		}
+	}
+	if err := inferencenet.ClearAuth(); err != nil {
+		return err
+	}
+	fmt.Println("✓ Signed out of inference-net.")
+	return nil
+}
+
+func inferenceNetKeyRotateCLI() error {
+	auth, err := inferencenet.LoadAuth()
+	if err != nil {
+		return err
+	}
+	if !auth.SignedIn() {
+		return errors.New("run `whip auth inference-net login` before rotating the machine API key")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := auth.Rotate(ctx); err != nil {
+		return err
+	}
+	if err := inferencenet.SaveAuth(auth); err != nil {
+		return err
+	}
+	fmt.Println("✓ Rotated the machine API key: " + auth.MachineKeyName)
+	return nil
+}
+
+// openBrowser opens url in the default browser; false when it can't.
+func openBrowser(url string) bool {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(context.Background(), "open", url)
+	case "windows":
+		cmd = exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.CommandContext(context.Background(), "xdg-open", url)
+	}
+	return cmd.Start() == nil
+}

--- a/cmd/whip/auth_inferencenet_test.go
+++ b/cmd/whip/auth_inferencenet_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/inferencenet"
+)
+
+func TestAuthInferenceNetDispatch(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	// Unknown subcommand is rejected.
+	if err := authCLI([]string{"inference-net", "bogus"}); err == nil {
+		t.Error("unknown subcommand should error")
+	}
+	// key without "rotate" is rejected.
+	if err := authCLI([]string{"inference-net", "key"}); err == nil {
+		t.Error("`key` without rotate should error")
+	}
+	// The legacy "inference" provider name still routes.
+	if err := authCLI([]string{"inference", "bogus"}); err == nil {
+		t.Error("legacy alias should route to inference-net handler")
+	}
+}
+
+func TestAuthInferenceNetBYOKNoKey(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	t.Setenv(config.InferenceNetEnvVar, "")
+	if err := authCLI([]string{"inference-net", "login", "--key", ""}); err == nil {
+		t.Error("BYOK with no key should error")
+	}
+}
+
+func TestAuthInferenceNetStatusAndLogoutUnsigned(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := authCLI([]string{"inference-net", "status"}); err != nil {
+		t.Errorf("status on a fresh home should not error: %v", err)
+	}
+	// Logout with nothing stored is a clean no-op.
+	if err := authCLI([]string{"inference-net", "logout"}); err != nil {
+		t.Errorf("logout with no session should not error: %v", err)
+	}
+	// Rotate without a session tells the user to log in first.
+	if err := authCLI([]string{"inference-net", "key", "rotate"}); err == nil ||
+		!strings.Contains(err.Error(), "login") {
+		t.Errorf("rotate without session should point at login, got %v", err)
+	}
+}
+
+func TestAuthInferenceNetLogoutClearsStoredAuth(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := inferencenet.SaveAuth(inferencenet.Auth{SessionToken: "tok", MachineKey: "mk"}); err != nil {
+		t.Fatal(err)
+	}
+	// Logout hits the network for the remote calls; with unreachable URLs those
+	// fail soft (warnings), and the local state is still cleared.
+	if err := authCLI([]string{"inference-net", "logout"}); err != nil {
+		t.Errorf("logout should clear local state even when remote calls fail: %v", err)
+	}
+	a, _ := inferencenet.LoadAuth()
+	if a != (inferencenet.Auth{}) {
+		t.Errorf("logout should clear stored auth, got %+v", a)
+	}
+}

--- a/cmd/whip/auth_test.go
+++ b/cmd/whip/auth_test.go
@@ -124,7 +124,7 @@ func TestAuthOpenRouterReauthKeepsOtherState(t *testing.T) {
 	if cfg.Providers["openrouter"].APIKey != "sk-or-new" {
 		t.Error("re-auth should replace the key")
 	}
-	if _, ok := cfg.Providers["inference"]; !ok {
+	if _, ok := cfg.Providers["inference-net"]; !ok {
 		t.Error("re-auth clobbered the default provider")
 	}
 	if len(cfg.Models) == 0 {

--- a/docs/features.md
+++ b/docs/features.md
@@ -180,6 +180,30 @@ so re-authing fixes a 401 without a `/model` round-trip. Tests:
 re-auth keeps other providers/models), `tui/auth_cmd_test.go` (usage,
 masked prompt open/cancel, good/bad result, live-session rekey).
 
+`cmd/whip/auth_inferencenet.go`, `internal/inferencenet/`,
+`internal/config/inferencenet.go`, `internal/tui/auth_inferencenet_cmd.go` —
+first-class Inference.net auth. `whip auth inference-net login` runs the
+**OAuth device-authorization flow** against the relay
+(`internal/inferencenet/device.go`): request a code, open the dashboard's
+approval page in the browser, poll until approved — then select the account's
+primary project and **mint a machine API key** (`whip-<host>-<timestamp>`)
+via the relay's tRPC (`apiKey.create`), all without the user touching a key.
+State lands in `~/.whip/inference-net.json` (0600 — session token + machine
+key, kept out of config.json); the provider entry carries no key material and
+resolves the machine key from that file at request time (`Provider.ResolveKey`
+fallback, ahead of the legacy `~/.inf/config.json` read). BYOK is supported
+too: `login --key <k>` / `--env` validates against the gateway (`GET /models`)
+before writing. Subcommands: `status`, `logout` (archives the machine key +
+closes the remote session), `key rotate`. The tRPC client
+(`internal/inferencenet/trpc.go`) is stdlib-only — the superjson transport is
+plain JSON plus a `{"json": …}` envelope for the shapes whip touches. The
+provider key was renamed `inference` → `inference-net`; `Config.normalize`
+migrates old configs (provider, model routes, default/compact provider)
+transparently on load. Tests: `inferencenet/inferencenet_test.go` (stubbed
+relay: full device login + key mint, store round-trip, key validation),
+`config/inferencenet_test.go` (rename migration, upsert modes, key fallback),
+`cmd/whip/auth_inferencenet_test.go`, `tui/auth_inferencenet_cmd_test.go`.
+
 ## The TUI
 
 `internal/tui/tui.go` — bubbletea fullscreen alt-screen. Highlights:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,11 +45,35 @@ func (p Provider) ResolveKey() (string, error) {
 		}
 		return k, nil
 	}
-	// ponytail: special-case fallback to the inf CLI's stored key; generalize to apiKeyFile if more providers need it
+	// Inference.net fallbacks: the machine key provisioned by
+	// `whip auth inference-net login`, then the inf CLI's stored key.
 	if strings.Contains(p.BaseURL, "api.inference.net") {
+		if k := whipInferenceNetKey(); k != "" {
+			return k, nil
+		}
 		return infKey(), nil
 	}
 	return "", nil
+}
+
+// whipInferenceNetKey reads the machine key from ~/.whip/inference-net.json
+// (written by `whip auth inference-net login`).
+func whipInferenceNetKey() string {
+	dir, err := Dir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "inference-net.json"))
+	if err != nil {
+		return ""
+	}
+	var a struct {
+		MachineKey string `json:"machineKey"`
+	}
+	if json.Unmarshal(data, &a) != nil {
+		return ""
+	}
+	return a.MachineKey
 }
 
 // infKey reads apiKey/codingAgentApiKey from ~/.inf/config.json (written by `inf auth set-key`).
@@ -309,7 +333,37 @@ func Load() (*Config, error) {
 		return def, def.Save()
 	}
 	logf("config.load", "ok (%s)", cfg.fingerprint())
+	cfg.normalize()
 	return &cfg, nil
+}
+
+// normalize upgrades legacy config shapes in place. Today: the provider key
+// "inference" was renamed to "inference-net" — old configs (and model routes
+// pointing at it) are migrated transparently. No file write happens here;
+// the next Save persists the rename.
+func (c *Config) normalize() {
+	p, ok := c.Providers["inference"]
+	if !ok {
+		return
+	}
+	if _, clash := c.Providers["inference-net"]; !clash {
+		c.Providers["inference-net"] = p
+	}
+	delete(c.Providers, "inference")
+	for name, m := range c.Models {
+		for i, prov := range m.Providers {
+			if prov == "inference" {
+				m.Providers[i] = "inference-net"
+			}
+		}
+		c.Models[name] = m
+	}
+	if c.DefaultProvider == "inference" {
+		c.DefaultProvider = "inference-net"
+	}
+	if c.CompactProvider == "inference" {
+		c.CompactProvider = "inference-net"
+	}
 }
 
 // Save writes the config back to ~/.whip/config.json. The write is atomic
@@ -474,7 +528,7 @@ func Default() *Config {
 		CompactModel: DefaultCompactModel,
 		//nolint:gosec // G101: APIKeyEnv holds env var NAMES, not credentials
 		Providers: map[string]Provider{
-			"inference": {
+			"inference-net": {
 				Name:      "Inference.net",
 				BaseURL:   "https://api.inference.net/v1",
 				API:       "openai-completions",
@@ -482,10 +536,10 @@ func Default() *Config {
 			},
 		},
 		Models: map[string]Model{
-			"kimi-k3":                {Providers: []string{"inference"}, Context: 1048576, Vision: true},
-			"kimi-k3-fast":           {Providers: []string{"inference"}, Context: 1048576, Vision: true},
-			"glm-5.2-fast":           {Providers: []string{"inference"}, Context: 128000},
-			"deepseek-v4-flash-0731": {Providers: []string{"inference"}, Context: 384000},
+			"kimi-k3":                {Providers: []string{"inference-net"}, Context: 1048576, Vision: true},
+			"kimi-k3-fast":           {Providers: []string{"inference-net"}, Context: 1048576, Vision: true},
+			"glm-5.2-fast":           {Providers: []string{"inference-net"}, Context: 128000},
+			"deepseek-v4-flash-0731": {Providers: []string{"inference-net"}, Context: 384000},
 		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,7 @@ func TestLoadSaveDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.DefaultModel != "kimi-k3-fast" || cfg.Providers["inference"].BaseURL != "https://api.inference.net/v1" {
+	if cfg.DefaultModel != "kimi-k3-fast" || cfg.Providers["inference-net"].BaseURL != "https://api.inference.net/v1" {
 		t.Fatalf("defaults: %+v", cfg)
 	}
 	cfg.DefaultModel = "glm-5.2-fast"

--- a/internal/config/inferencenet.go
+++ b/internal/config/inferencenet.go
@@ -1,0 +1,41 @@
+package config
+
+// Inference.net is whip's first-class provider: `whip auth inference-net
+// login` provisions a machine API key (stored in ~/.whip/inference-net.json)
+// and registers the provider entry here, so a user never handles a key.
+// BYOK is also supported (literal apiKey or apiKeyEnv). These helpers back
+// `whip auth inference-net` and `/auth inference-net`.
+
+const (
+	// InferenceNetProvider is the provider map key (renamed from "inference";
+	// Load's normalize migrates old configs).
+	InferenceNetProvider = "inference-net"
+	// InferenceNetBaseURL is the OpenAI-compatible API root.
+	InferenceNetBaseURL = "https://api.inference.net/v1"
+	// InferenceNetEnvVar is the env var the provider reads in env mode.
+	InferenceNetEnvVar = "INFERENCE_API_KEY"
+)
+
+// UpsertInferenceNet registers (or re-registers) the "inference-net" provider,
+// leaving every other provider and all model routes untouched. envMode stores
+// the key as apiKeyEnv; otherwise a literal apiKey. When neither applies (the
+// machine-key fallback in ResolveKey covers it), both key fields are left
+// empty so the stored machine key is used. The caller owns Save().
+func (c *Config) UpsertInferenceNet(key string, envMode bool) {
+	p := Provider{
+		Name:    "Inference.net",
+		BaseURL: InferenceNetBaseURL,
+		API:     "openai-completions",
+	}
+	if envMode {
+		p.APIKeyEnv = InferenceNetEnvVar
+	} else if key != "" {
+		p.APIKey = key
+	}
+	if c.Providers == nil {
+		c.Providers = map[string]Provider{}
+	}
+	delete(c.Providers, "inference") // fold any legacy entry into the new key
+	c.Providers[InferenceNetProvider] = p
+	logf("config.inferencenet", "upserted inference-net provider (envMode=%v, literal=%v)", envMode, key != "")
+}

--- a/internal/config/inferencenet_test.go
+++ b/internal/config/inferencenet_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeRenamesInferenceProvider(t *testing.T) {
+	cfg := &Config{
+		DefaultProvider: "inference",
+		CompactProvider: "inference",
+		Providers: map[string]Provider{
+			"inference": {Name: "Inference.net", BaseURL: InferenceNetBaseURL, API: "openai-completions"},
+		},
+		Models: map[string]Model{
+			"kimi-k3": {Providers: []string{"inference", "openrouter"}},
+		},
+	}
+	cfg.normalize()
+
+	if _, ok := cfg.Providers["inference"]; ok {
+		t.Error("legacy \"inference\" provider not removed")
+	}
+	if _, ok := cfg.Providers[InferenceNetProvider]; !ok {
+		t.Fatal("provider not renamed to inference-net")
+	}
+	if got := cfg.Models["kimi-k3"].Providers; got[0] != "inference-net" || got[1] != "openrouter" {
+		t.Errorf("model route not migrated: %v", got)
+	}
+	if cfg.DefaultProvider != "inference-net" || cfg.CompactProvider != "inference-net" {
+		t.Errorf("default/compact provider not migrated: %+v", cfg)
+	}
+}
+
+func TestNormalizeNoLegacyIsNoop(t *testing.T) {
+	cfg := Default()
+	before := len(cfg.Providers)
+	cfg.normalize()
+	if len(cfg.Providers) != before {
+		t.Errorf("normalize changed a fresh Default: %v", cfg.Providers)
+	}
+	if _, ok := cfg.Providers[InferenceNetProvider]; !ok {
+		t.Error("Default should already use inference-net")
+	}
+}
+
+func TestUpsertInferenceNetModes(t *testing.T) {
+	cfg := &Config{}
+	cfg.UpsertInferenceNet("inf-literal", false)
+	p := cfg.Providers[InferenceNetProvider]
+	if p.APIKey != "inf-literal" || p.APIKeyEnv != "" {
+		t.Errorf("literal mode: %+v", p)
+	}
+	cfg.UpsertInferenceNet("", true)
+	p = cfg.Providers[InferenceNetProvider]
+	if p.APIKeyEnv != InferenceNetEnvVar || p.APIKey != "" {
+		t.Errorf("env mode: %+v", p)
+	}
+	// Machine-key login: no key material on the entry.
+	cfg.UpsertInferenceNet("", false)
+	p = cfg.Providers[InferenceNetProvider]
+	if p.APIKey != "" || p.APIKeyEnv != "" {
+		t.Errorf("machine-key mode should leave key fields empty: %+v", p)
+	}
+}
+
+func TestProviderKeyFallsBackToStoredMachineKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+	keyFile := filepath.Join(home, "inference-net.json")
+	if err := os.WriteFile(keyFile, []byte(`{"machineKey":"mk-stored"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := Provider{BaseURL: InferenceNetBaseURL}
+	if got := p.Key(); got != "mk-stored" {
+		t.Errorf("machine-key fallback: got %q", got)
+	}
+	// An explicit env var wins over the stored key.
+	t.Setenv(InferenceNetEnvVar, "env-key")
+	p.APIKeyEnv = InferenceNetEnvVar
+	if got := p.Key(); got != "env-key" {
+		t.Errorf("env should win: got %q", got)
+	}
+}

--- a/internal/inferencenet/device.go
+++ b/internal/inferencenet/device.go
@@ -1,0 +1,254 @@
+package inferencenet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+var errDeviceCodeExpired = errors.New("the device code expired; run `whip auth inference-net login` again")
+
+// deviceCodeResponse is the relay's /api/auth/device/code reply.
+type deviceCodeResponse struct {
+	DeviceCode string `json:"device_code"`
+	UserCode   string `json:"user_code"`
+	ExpiresIn  int    `json:"expires_in"`
+	Interval   int    `json:"interval"`
+}
+
+// session is the outcome of a completed device login: the identity plus the
+// session token the control-plane calls authorize with.
+type session struct {
+	Token  string
+	Email  string
+	UserID string
+	TeamID string
+}
+
+// Login runs the OAuth device-authorization flow: request a device code,
+// report the approval URL/code via onCode (the CLI opens the browser there),
+// and poll until the user approves, denies, or the code expires. It resolves
+// the signed-in identity and active team before returning.
+func Login(ctx context.Context, onCode func(verificationURL, userCode string)) (session, error) {
+	code, err := requestDeviceCode(ctx)
+	if err != nil {
+		return session{}, err
+	}
+	verificationURL := dashboardURL + "/device/approve?user_code=" + code.UserCode
+	if onCode != nil {
+		onCode(verificationURL, code.UserCode)
+	}
+	token, err := pollForDeviceToken(ctx, code)
+	if err != nil {
+		return session{}, err
+	}
+	identity, err := getSessionIdentity(ctx, token)
+	if err != nil {
+		return session{}, err
+	}
+	teamID, err := selectOrganization(ctx, token, identity.UserID)
+	if err != nil {
+		return session{}, err
+	}
+	return session{Token: token, Email: identity.Email, UserID: identity.UserID, TeamID: teamID}, nil
+}
+
+func requestDeviceCode(ctx context.Context) (deviceCodeResponse, error) {
+	var out deviceCodeResponse
+	err := doJSON(ctx, http.MethodPost, relayURL+"/api/auth/device/code",
+		map[string]string{"client_id": DeviceClientID}, nil, &out)
+	return out, err
+}
+
+func pollForDeviceToken(ctx context.Context, code deviceCodeResponse) (string, error) {
+	interval := code.Interval
+	if interval <= 0 {
+		interval = defaultPollIntervalSeconds
+	}
+	if pollSleepOverride != nil { // tests collapse the wait
+		interval = 0
+	}
+	deadline := time.Now().Add(time.Duration(code.ExpiresIn) * time.Second)
+	for time.Now().Before(deadline) {
+		if err := sleepCtx(ctx, time.Duration(interval)*time.Second); err != nil {
+			return "", err
+		}
+		var resp struct {
+			AccessToken string `json:"access_token"`
+			Error       string `json:"error"`
+			Message     string `json:"message"`
+		}
+		status, err := doJSONStatus(ctx, http.MethodPost, relayURL+"/api/auth/device/token",
+			map[string]string{
+				"client_id":   DeviceClientID,
+				"device_code": code.DeviceCode,
+				"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+			}, nil, &resp)
+		if err != nil {
+			return "", err
+		}
+		if status == http.StatusOK && resp.AccessToken != "" {
+			return resp.AccessToken, nil
+		}
+		switch resp.Error {
+		case "authorization_pending":
+			continue
+		case "slow_down":
+			interval += 5
+		case "access_denied":
+			return "", errors.New("terminal authorization was denied")
+		case "expired_token":
+			return "", errDeviceCodeExpired
+		default:
+			msg := resp.Message
+			if msg == "" {
+				msg = resp.Error
+			}
+			if msg == "" {
+				msg = fmt.Sprintf("authorization failed (HTTP %d)", status)
+			}
+			return "", errors.New(msg)
+		}
+	}
+	return "", errDeviceCodeExpired
+}
+
+func getSessionIdentity(ctx context.Context, token string) (struct {
+	Email  string
+	UserID string
+}, error,
+) {
+	var resp struct {
+		User struct {
+			Email string `json:"email"`
+			ID    string `json:"id"`
+		} `json:"user"`
+	}
+	err := doJSON(ctx, http.MethodGet, relayURL+"/api/auth/get-session?disableCookieCache=true",
+		nil, bearerHeaders(token, ""), &resp)
+	return struct {
+		Email  string
+		UserID string
+	}{resp.User.Email, resp.User.ID}, err
+}
+
+// selectOrganization picks the user's personal workspace (falling back to the
+// first) and marks it active, returning its team id.
+func selectOrganization(ctx context.Context, token, userID string) (string, error) {
+	var orgs []struct {
+		ID string `json:"id"`
+	}
+	h := bearerHeaders(token, dashboardURL)
+	if err := doJSON(ctx, http.MethodGet, relayURL+"/api/auth/organization/list", nil, h, &orgs); err != nil {
+		return "", err
+	}
+	orgID := ""
+	for _, o := range orgs {
+		if o.ID == userID {
+			orgID = o.ID
+			break
+		}
+	}
+	if orgID == "" && len(orgs) > 0 {
+		orgID = orgs[0].ID
+	}
+	if orgID == "" {
+		return "", errors.New("no workspace was found for this account; finish signup in the dashboard, then try again")
+	}
+	if err := doJSON(ctx, http.MethodPost, relayURL+"/api/auth/organization/set-active",
+		map[string]string{"organizationId": orgID}, h, nil); err != nil {
+		return "", err
+	}
+	return orgID, nil
+}
+
+// SignOut closes the remote session; a 401 (already gone) is not an error.
+func SignOut(ctx context.Context, token string) error {
+	status, err := doJSONStatus(ctx, http.MethodPost, relayURL+"/api/auth/sign-out",
+		map[string]string{}, bearerHeaders(token, dashboardURL), nil)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK && status != http.StatusUnauthorized {
+		return fmt.Errorf("sign out failed (HTTP %d)", status)
+	}
+	return nil
+}
+
+func bearerHeaders(token, origin string) map[string]string {
+	h := map[string]string{"Authorization": "Bearer " + token}
+	if origin != "" {
+		h["Origin"] = origin
+	}
+	return h
+}
+
+// doJSON performs an HTTP call with a JSON body and decodes a JSON reply,
+// erroring on non-2xx with the server's message when present.
+func doJSON(ctx context.Context, method, url string, body any, headers map[string]string, out any) error {
+	status, err := doJSONStatus(ctx, method, url, body, headers, out)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("%s %s failed (HTTP %d)", method, url, status)
+	}
+	return nil
+}
+
+// doJSONStatus is doJSON but returns the status so callers can branch on it.
+func doJSONStatus(ctx context.Context, method, url string, body any, headers map[string]string, out any) (int, error) {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return 0, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if out == nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		return resp.StatusCode, nil
+	}
+	return resp.StatusCode, json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(out)
+}
+
+const defaultPollIntervalSeconds = 5
+
+// pollSleepOverride, when non-nil, replaces the poll sleep (tests collapse the
+// 5s wait). Production code leaves it nil.
+var pollSleepOverride func(context.Context, time.Duration) error
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if pollSleepOverride != nil {
+		return pollSleepOverride(ctx, d)
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/inferencenet/inferencenet.go
+++ b/internal/inferencenet/inferencenet.go
@@ -1,0 +1,34 @@
+// Package inferencenet implements first-class Inference.net auth for whip:
+// the browser-based device-authorization login (bring-your-own-account, no key
+// handling) plus machine API-key provisioning over the relay's tRPC surface.
+// It mirrors the @inference/fast CLI's flow (apps/fast-cli/src/lib/auth.ts).
+package inferencenet
+
+// DeviceClientID is registered in the relay's device-authorization allowlist
+// (packages/auth/src/device-authorization.ts) — the approval page names it.
+const DeviceClientID = "whip"
+
+const (
+	// BaseURL is the OpenAI-compatible inference gateway root.
+	BaseURL = "https://api.inference.net/v1"
+	// EnvVar is the environment variable the provider entry reads its key
+	// from in env mode.
+	EnvVar = "INFERENCE_API_KEY"
+)
+
+var (
+	// relayURL is the control-plane (auth/session/org/api-key) API.
+	relayURL = "https://observability-api.inference.net"
+	// dashboardURL hosts the device-approval page the user authorizes from.
+	dashboardURL = "https://inference.net"
+	// baseURL mirrors BaseURL; a var so tests can point at a stub gateway.
+	baseURL = BaseURL
+)
+
+// trpcEndpoint is where the relay mounts the rich appRouter (project, apiKey,
+// …): the host root, superjson transport. ("/api/trpc" is a separate, narrow
+// relay-compat router that does NOT have these procedures.)
+const trpcEndpoint = ""
+
+// teamIDHeader carries the active team on relay tRPC calls.
+const teamIDHeader = "x-inference-team-id"

--- a/internal/inferencenet/inferencenet_test.go
+++ b/internal/inferencenet/inferencenet_test.go
@@ -1,0 +1,169 @@
+package inferencenet
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubRelay serves the device-auth + tRPC surface CompleteLogin and key
+// minting touch: device/code, device/token, get-session, organization/*,
+// project.getProjects, apiKey.create.
+func stubRelay(t *testing.T) *httptest.Server {
+	t.Helper()
+	var tokenPolls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/auth/device/code", func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			ClientID string `json:"client_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.ClientID != DeviceClientID {
+			http.Error(w, `{"error":"invalid_client"}`, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code": "dc-123", "user_code": "ABCD-1234", "expires_in": 600, "interval": 0,
+		})
+	})
+	mux.HandleFunc("/api/auth/device/token", func(w http.ResponseWriter, r *http.Request) {
+		// Approve on the second poll to exercise authorization_pending.
+		if tokenPolls.Add(1) < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "authorization_pending"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "sess-tok", "token_type": "Bearer"})
+	})
+	mux.HandleFunc("/api/auth/get-session", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"user": map[string]any{"email": "abe@x.dev", "id": "user-1"}})
+	})
+	mux.HandleFunc("/api/auth/organization/list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "user-1", "name": "personal"}})
+	})
+	mux.HandleFunc("/api/auth/organization/set-active", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("/project.getProjects", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer sess-tok" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "auth required"}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"data": map[string]any{
+				"json": []map[string]any{{"id": "proj-1", "name": "Primary"}},
+			}},
+		})
+	})
+	mux.HandleFunc("/apiKey.create", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Inference-Team-Id") != "user-1" {
+			http.Error(w, "missing team header", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"data": map[string]any{
+				"json": map[string]any{"id": "key-1", "key": "inf-machine-secret"},
+			}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// useStub points the package's URLs at the stub relay and restores them after.
+func useStub(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	oldRelay, oldDash, oldBase := relayURL, dashboardURL, baseURL
+	relayURL, dashboardURL, baseURL = srv.URL, srv.URL, srv.URL
+	t.Cleanup(func() { relayURL, dashboardURL, baseURL = oldRelay, oldDash, oldBase })
+}
+
+func TestCompleteLoginAndMachineKey(t *testing.T) {
+	srv := stubRelay(t)
+	useStub(t, srv)
+	// Collapse the poll sleep so the test doesn't wait out the real interval.
+	pollSleepOverride = func(context.Context, time.Duration) error { return nil }
+	t.Cleanup(func() { pollSleepOverride = nil })
+
+	var gotURL, gotCode string
+	auth, err := CompleteLogin(context.Background(), func(vu, uc string) { gotURL, gotCode = vu, uc })
+	if err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+	if !strings.Contains(gotURL, "/device/approve?user_code=ABCD-1234") {
+		t.Errorf("verification URL not surfaced: %q", gotURL)
+	}
+	if gotCode != "ABCD-1234" {
+		t.Errorf("user code not surfaced: %q", gotCode)
+	}
+	if auth.SessionToken != "sess-tok" || auth.UserEmail != "abe@x.dev" || auth.TeamID != "user-1" {
+		t.Errorf("unexpected session: %+v", auth)
+	}
+	if auth.ProjectID != "proj-1" || auth.ProjectName != "Primary" {
+		t.Errorf("primary project not selected: %+v", auth)
+	}
+
+	key, err := auth.EnsureMachineKey(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureMachineKey: %v", err)
+	}
+	if key != "inf-machine-secret" || auth.MachineKeyID != "key-1" {
+		t.Errorf("machine key not minted: %+v", auth)
+	}
+	// A second call returns the stored key without re-minting.
+	if k, _ := auth.EnsureMachineKey(context.Background()); k != key {
+		t.Errorf("EnsureMachineKey re-minted: %q", k)
+	}
+}
+
+func TestAuthStoreRoundTrip(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if a, _ := LoadAuth(); a != (Auth{}) {
+		t.Errorf("missing file should yield zero Auth, got %+v", a)
+	}
+	want := Auth{SessionToken: "tok", UserEmail: "abe@x.dev", TeamID: "t1", ProjectID: "p1", MachineKey: "mk"}
+	if err := SaveAuth(want); err != nil {
+		t.Fatalf("SaveAuth: %v", err)
+	}
+	got, err := LoadAuth()
+	if err != nil {
+		t.Fatalf("LoadAuth: %v", err)
+	}
+	if got != want {
+		t.Errorf("round trip mismatch: got %+v want %+v", got, want)
+	}
+	if err := ClearAuth(); err != nil {
+		t.Fatalf("ClearAuth: %v", err)
+	}
+	if a, _ := LoadAuth(); a != (Auth{}) {
+		t.Errorf("after clear, got %+v", a)
+	}
+}
+
+func TestValidateKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer good" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+	old := baseURL
+	baseURL = srv.URL
+	t.Cleanup(func() { baseURL = old })
+
+	if err := ValidateKey(context.Background(), "good"); err != nil {
+		t.Errorf("good key rejected: %v", err)
+	}
+	if err := ValidateKey(context.Background(), "bad"); err == nil {
+		t.Error("bad key accepted")
+	}
+}

--- a/internal/inferencenet/machinekey.go
+++ b/internal/inferencenet/machinekey.go
@@ -1,0 +1,138 @@
+package inferencenet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// ValidateKey reports whether an API key is accepted by the inference
+// gateway. GET /models is authenticated and free, so it's the cheap probe.
+func ValidateKey(ctx context.Context, key string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/models", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("the gateway rejected the key (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("could not validate the key (HTTP %d)", resp.StatusCode)
+	}
+	return nil
+}
+
+// apiKeyNameMaxLength matches the relay's apiKeyNameSchema cap; the hostname
+// absorbs it so the timestamp always survives (mirrors fast-cli).
+const apiKeyNameMaxLength = 64
+
+// createAPIKey mints a machine key named `whip-<host>-<timestamp>` scoped to
+// the primary project, returning id and plaintext key (shown once).
+func createAPIKey(ctx context.Context, token, teamID, projectID string) (id, key, name string, err error) {
+	hostname, _ := os.Hostname()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	budget := apiKeyNameMaxLength - len("whip--"+ts)
+	if len(hostname) > budget {
+		hostname = hostname[:budget]
+	}
+	name = "whip-" + hostname + "-" + ts
+
+	input := map[string]any{
+		"defaultProjectId": projectID,
+		"name":             name,
+		"teamId":           teamID,
+		"scopes": []map[string]any{
+			{"permissions": []string{"read", "write"}, "projectId": projectID},
+		},
+	}
+	var created struct {
+		ID  string `json:"id"`
+		Key string `json:"key"`
+	}
+	if err := trpcMutate(ctx, token, teamID, "apiKey.create", input, &created); err != nil {
+		return "", "", "", err
+	}
+	return created.ID, created.Key, name, nil
+}
+
+// archiveAPIKey disables a key (logout / rotation).
+func archiveAPIKey(ctx context.Context, token, teamID, apiKeyID string) error {
+	return trpcMutate(ctx, token, teamID, "apiKey.archive",
+		map[string]any{"apiKeyId": apiKeyID, "teamId": teamID}, nil)
+}
+
+// CompleteLogin runs the device flow, then selects and persists the primary
+// project. The returned Auth has session + identity + project but no machine
+// key yet — see EnsureMachineKey.
+func CompleteLogin(ctx context.Context, onCode func(verificationURL, userCode string)) (Auth, error) {
+	sess, err := Login(ctx, onCode)
+	if err != nil {
+		return Auth{}, err
+	}
+	a := Auth{SessionToken: sess.Token, UserEmail: sess.Email, TeamID: sess.TeamID}
+	if err := a.selectPrimaryProject(ctx); err != nil {
+		return Auth{}, err
+	}
+	return a, nil
+}
+
+// selectPrimaryProject records the team's first project on the auth state.
+func (a *Auth) selectPrimaryProject(ctx context.Context) error {
+	projects, err := getProjects(ctx, a.SessionToken, a.TeamID)
+	if err != nil {
+		return err
+	}
+	if len(projects) == 0 {
+		return errors.New("no project found for this account; finish signup in the dashboard, then run `whip auth inference-net login` again")
+	}
+	a.ProjectID, a.ProjectName = projects[0].ID, projects[0].Name
+	return nil
+}
+
+// EnsureMachineKey returns the stored machine key, minting one when absent.
+// It does not re-validate a stored key (the inference call itself is the
+// check); Rotate forces a fresh key.
+func (a *Auth) EnsureMachineKey(ctx context.Context) (string, error) {
+	if a.MachineKey != "" {
+		return a.MachineKey, nil
+	}
+	return a.mintMachineKey(ctx)
+}
+
+// Rotate archives the stored key (if any) and mints a replacement.
+func (a *Auth) Rotate(ctx context.Context) (string, error) {
+	if a.MachineKeyID != "" {
+		_ = archiveAPIKey(ctx, a.SessionToken, a.TeamID, a.MachineKeyID) // best-effort
+		a.MachineKeyID, a.MachineKey, a.MachineKeyName = "", "", ""
+	}
+	return a.mintMachineKey(ctx)
+}
+
+// ArchiveMachineKey disables the stored machine key (logout).
+func (a *Auth) ArchiveMachineKey(ctx context.Context) error {
+	if a.MachineKeyID == "" || a.SessionToken == "" || a.TeamID == "" {
+		return nil
+	}
+	return archiveAPIKey(ctx, a.SessionToken, a.TeamID, a.MachineKeyID)
+}
+
+func (a *Auth) mintMachineKey(ctx context.Context) (string, error) {
+	if a.SessionToken == "" || a.TeamID == "" || a.ProjectID == "" {
+		return "", errors.New("run `whip auth inference-net login` first")
+	}
+	id, key, name, err := createAPIKey(ctx, a.SessionToken, a.TeamID, a.ProjectID)
+	if err != nil {
+		return "", err
+	}
+	a.MachineKeyID, a.MachineKey, a.MachineKeyName = id, key, name
+	return key, nil
+}

--- a/internal/inferencenet/store.go
+++ b/internal/inferencenet/store.go
@@ -1,0 +1,94 @@
+package inferencenet
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/context-labs/whip/internal/config"
+)
+
+// Auth is whip's Inference.net sign-in state, persisted to
+// ~/.whip/inference-net.json (0600). The session token drives the control
+// plane (device flow, key minting); the machine key is what the provider
+// entry resolves to for inference calls.
+type Auth struct {
+	SessionToken   string `json:"sessionToken,omitempty"`
+	UserEmail      string `json:"userEmail,omitempty"`
+	TeamID         string `json:"teamId,omitempty"`
+	ProjectID      string `json:"projectId,omitempty"`
+	ProjectName    string `json:"projectName,omitempty"`
+	MachineKeyID   string `json:"machineKeyId,omitempty"`
+	MachineKey     string `json:"machineKey,omitempty"`
+	MachineKeyName string `json:"machineKeyName,omitempty"`
+}
+
+// SignedIn reports whether a device-flow session token is stored.
+func (a Auth) SignedIn() bool { return a.SessionToken != "" }
+
+// HasMachineKey reports whether a provisioned machine API key is stored.
+func (a Auth) HasMachineKey() bool { return a.MachineKey != "" }
+
+func authPath() (string, error) {
+	dir, err := config.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "inference-net.json"), nil
+}
+
+// LoadAuth reads the stored auth state; a missing file yields the zero value.
+func LoadAuth() (Auth, error) {
+	p, err := authPath()
+	if err != nil {
+		return Auth{}, err
+	}
+	data, err := os.ReadFile(p) //nolint:gosec // G304: p is whip's own auth-state path
+	if errors.Is(err, os.ErrNotExist) {
+		return Auth{}, nil
+	}
+	if err != nil {
+		return Auth{}, err
+	}
+	var a Auth
+	if err := json.Unmarshal(data, &a); err != nil {
+		return Auth{}, err
+	}
+	return a, nil
+}
+
+// SaveAuth writes the auth state atomically with owner-only perms.
+func SaveAuth(a Auth) error {
+	p, err := authPath()
+	if err != nil {
+		return err
+	}
+	//nolint:gosec // G117: persisting the session token + machine key is the whole point
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// ClearAuth removes the stored auth state (logout).
+func ClearAuth() error {
+	p, err := authPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/inferencenet/trpc.go
+++ b/internal/inferencenet/trpc.go
@@ -1,0 +1,119 @@
+package inferencenet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// The relay's tRPC uses the superjson transport. For the request/response
+// shapes whip touches (plain JSON, no Date/Map/Set round-trips), superjson is
+// identical to plain JSON plus a {"json": …} envelope, which is what the
+// helpers below add and strip. That keeps the client stdlib-only.
+
+type Project struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// envelope is a tRPC/superjson response: a result on success, an error on
+// failure. The error message may be plain or superjson-masked ({"json":…}).
+type envelope struct {
+	Result struct {
+		Data json.RawMessage `json:"data"`
+	} `json:"result"`
+	Error *struct {
+		Message json.RawMessage `json:"message"`
+	} `json:"error"`
+}
+
+func (e envelope) err(path string) error {
+	if e.Error == nil {
+		return nil
+	}
+	msg := string(e.Error.Message)
+	var s string
+	if json.Unmarshal(e.Error.Message, &s) == nil {
+		msg = s // plain string
+	} else {
+		var wrap struct {
+			JSON string `json:"json"`
+		}
+		if json.Unmarshal(e.Error.Message, &wrap) == nil && wrap.JSON != "" {
+			msg = wrap.JSON // superjson-masked
+		}
+	}
+	return fmt.Errorf("%s: %s", path, msg)
+}
+
+// trpcQuery runs a tRPC query (GET, input in the query string).
+func trpcQuery(ctx context.Context, token, teamID, path string, input, out any) error {
+	q := url.Values{}
+	if input == nil {
+		// A z.void() input arrives as undefined; encode it as superjson does.
+		q.Set("input", `{"json":null,"meta":{"values":["undefined"]}}`)
+	} else {
+		b, err := json.Marshal(map[string]any{"json": input})
+		if err != nil {
+			return err
+		}
+		q.Set("input", string(b))
+	}
+	u := relayURL + trpcEndpoint + "/" + path + "?" + q.Encode()
+	var env envelope
+	if err := doJSON(ctx, http.MethodGet, u, nil, trpcHeaders(token, teamID), &env); err != nil {
+		return err
+	}
+	if err := env.err(path); err != nil {
+		return err
+	}
+	return unmarshalData(env.Result.Data, out)
+}
+
+// trpcMutate runs a tRPC mutation (POST, body in the request).
+func trpcMutate(ctx context.Context, token, teamID, path string, input, out any) error {
+	var env envelope
+	if err := doJSON(ctx, http.MethodPost, relayURL+trpcEndpoint+"/"+path,
+		map[string]any{"json": input}, trpcHeaders(token, teamID), &env); err != nil {
+		return err
+	}
+	if err := env.err(path); err != nil {
+		return err
+	}
+	return unmarshalData(env.Result.Data, out)
+}
+
+// unmarshalData unwraps the superjson {"json": value} data envelope into out.
+func unmarshalData(raw json.RawMessage, out any) error {
+	if len(raw) == 0 {
+		return errors.New("empty result")
+	}
+	var wrap struct {
+		JSON json.RawMessage `json:"json"`
+	}
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return err
+	}
+	if len(wrap.JSON) == 0 || out == nil {
+		return nil
+	}
+	return json.Unmarshal(wrap.JSON, out)
+}
+
+func trpcHeaders(token, teamID string) map[string]string {
+	h := map[string]string{"Authorization": "Bearer " + token}
+	if teamID != "" {
+		h[teamIDHeader] = teamID
+	}
+	return h
+}
+
+// getProjects lists the active team's projects.
+func getProjects(ctx context.Context, token, teamID string) ([]Project, error) {
+	var projects []Project
+	err := trpcQuery(ctx, token, teamID, "project.getProjects", nil, &projects)
+	return projects, err
+}

--- a/internal/tui/auth_cmd.go
+++ b/internal/tui/auth_cmd.go
@@ -23,11 +23,16 @@ import (
 
 func (m *model) authCommand(args []string) {
 	if len(args) == 0 {
-		m.append(dimStyle.Render("usage: /auth openrouter [key] — paste a key, or bare to type it invisibly (get one at https://openrouter.ai/keys)"))
+		m.append(dimStyle.Render("usage: /auth <provider> [key] — inference-net (bare = browser login) or openrouter (bare = masked prompt)"))
 		return
 	}
-	if args[0] != "openrouter" {
-		m.append(errStyle.Render("unknown provider " + args[0] + " (supported: openrouter)"))
+	switch args[0] {
+	case "inference-net", "inference":
+		m.authInferenceNetCommand(args)
+		return
+	case "openrouter":
+	default:
+		m.append(errStyle.Render("unknown provider " + args[0] + " (supported: inference-net, openrouter)"))
 		return
 	}
 	if len(args) > 1 {

--- a/internal/tui/auth_cmd_test.go
+++ b/internal/tui/auth_cmd_test.go
@@ -44,7 +44,7 @@ func TestAuthCommandUsageAndUnknownProvider(t *testing.T) {
 	m.authCommand(nil)
 	m.authCommand([]string{"anthropic"})
 	out := m.transcriptText()
-	if !strings.Contains(out, "usage: /auth openrouter") {
+	if !strings.Contains(out, "usage: /auth") {
 		t.Errorf("bare /auth should print usage:\n%s", out)
 	}
 	if !strings.Contains(out, "unknown provider anthropic") {

--- a/internal/tui/auth_inferencenet_cmd.go
+++ b/internal/tui/auth_inferencenet_cmd.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/inferencenet"
+)
+
+// /auth inference-net [key] connects Inference.net. The bare form runs the
+// browser device-authorization login (no key handling); a pasted key goes
+// through the same masked validate-and-upsert path as /auth openrouter.
+//
+// The device login is async: a goroutine runs the flow and reports back via
+// inferenceNetAuthMsg so the UI goroutine owns all appends/config writes.
+
+// authInferenceNetCommand dispatches the inference-net branch of /auth.
+func (m *model) authInferenceNetCommand(args []string) {
+	if len(args) > 1 {
+		m.authInferenceNetKey(config.TrimKey(strings.Join(args[1:], "")), false)
+		return
+	}
+	// Bare: browser device login (the smooth path). The paste-a-key route is
+	// still available via `/auth inference-net <key>`.
+	m.authInferenceNetLogin()
+}
+
+// inferenceNetAuthMsg carries a finished device login back to the UI.
+type inferenceNetAuthMsg struct {
+	auth inferencenet.Auth
+	err  error
+}
+
+// authInferenceNetLogin runs the device-authorization flow in the background,
+// then provisions a machine key and registers the provider.
+func (m *model) authInferenceNetLogin() {
+	m.append(dimStyle.Render("starting Inference.net sign-in… (approve in your browser)"))
+	if m.prog == nil {
+		return // tests drive applyInferenceNetAuth directly
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		auth, err := inferencenet.CompleteLogin(ctx, func(verificationURL, userCode string) {
+			m.prog.Send(noticeMsg("approve this terminal in your browser:\n  " + verificationURL + "\n  code: " + userCode))
+			if openBrowserURL(verificationURL) {
+				m.prog.Send(noticeMsg("browser opened; waiting for approval…"))
+			}
+		})
+		if err == nil {
+			m.prog.Send(noticeMsg("provisioning an API key for this machine…"))
+			_, err = auth.EnsureMachineKey(ctx)
+			if err == nil {
+				err = inferencenet.SaveAuth(auth)
+			}
+		}
+		m.prog.Send(inferenceNetAuthMsg{auth: auth, err: err})
+	}()
+}
+
+// applyInferenceNetAuth commits a finished device login on the UI goroutine:
+// register the provider (machine key resolves from the stored auth file) and
+// hot-swap the live agent when the session already routes inference-net.
+func (m *model) applyInferenceNetAuth(msg inferenceNetAuthMsg) {
+	if msg.err != nil {
+		m.append(errStyle.Render("Inference.net sign-in failed: " + msg.err.Error()))
+		return
+	}
+	m.cfg.UpsertInferenceNet("", false) // machine key resolves from disk
+	if err := m.cfg.Save(); err != nil {
+		m.append(errStyle.Render("config save failed: " + err.Error()))
+		return
+	}
+	m.append(dimStyle.Render("✓ signed in as " + msg.auth.UserEmail + " — project " + msg.auth.ProjectName + "; inference-net provider configured"))
+	if m.prog != nil {
+		go m.fetchCatalogs(true)
+	}
+}
+
+// authInferenceNetKey validates a pasted Inference.net key and upserts the
+// provider (mirrors the openrouter BYOK path).
+func (m *model) authInferenceNetKey(key string, envMode bool) {
+	if key == "" {
+		m.append(errStyle.Render("/auth inference-net <key> needs a key (get one at https://inference.net)"))
+		return
+	}
+	m.append(dimStyle.Render("validating key against Inference.net…"))
+	if m.prog == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		err := inferencenet.ValidateKey(ctx, key)
+		cancel()
+		m.prog.Send(inferenceNetKeyMsg{key: key, envMode: envMode, err: err})
+	}()
+}
+
+type inferenceNetKeyMsg struct {
+	key     string
+	envMode bool
+	err     error
+}
+
+func (m *model) applyInferenceNetKey(msg inferenceNetKeyMsg) {
+	if msg.err != nil {
+		m.append(errStyle.Render("Inference.net rejected the key: " + msg.err.Error()))
+		return
+	}
+	m.cfg.UpsertInferenceNet(msg.key, msg.envMode)
+	if err := m.cfg.Save(); err != nil {
+		m.append(errStyle.Render("config save failed: " + err.Error()))
+		return
+	}
+	m.append(dimStyle.Render("✓ inference-net configured; /model lists its models"))
+	if m.prog != nil {
+		go m.fetchCatalogs(true)
+	}
+}

--- a/internal/tui/auth_inferencenet_cmd_test.go
+++ b/internal/tui/auth_inferencenet_cmd_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/inferencenet"
+)
+
+func TestAuthInferenceNetDispatch(t *testing.T) {
+	m := authTestModel(t)
+	// The legacy "inference" alias routes to the same handler.
+	m.authCommand([]string{"inference"})
+	if !strings.Contains(m.transcriptText(), "sign-in") {
+		t.Errorf("bare /auth inference should start device login:\n%s", m.transcriptText())
+	}
+}
+
+func TestApplyInferenceNetKeyUpsertsProvider(t *testing.T) {
+	m := authTestModel(t)
+	m.applyInferenceNetKey(inferenceNetKeyMsg{key: "inf-good"})
+	p, ok := m.cfg.Providers[config.InferenceNetProvider]
+	if !ok {
+		t.Fatal("inference-net provider not upserted")
+	}
+	if p.APIKey != "inf-good" {
+		t.Errorf("key not stored: %+v", p)
+	}
+	if !strings.Contains(m.transcriptText(), "inference-net configured") {
+		t.Errorf("no confirmation appended:\n%s", m.transcriptText())
+	}
+}
+
+func TestApplyInferenceNetAuthUsesMachineKey(t *testing.T) {
+	m := authTestModel(t)
+	auth := inferencenet.Auth{UserEmail: "abe@x.dev", ProjectName: "Primary"}
+	m.applyInferenceNetAuth(inferenceNetAuthMsg{auth: auth})
+	p := m.cfg.Providers[config.InferenceNetProvider]
+	if p.APIKey != "" || p.APIKeyEnv != "" {
+		t.Errorf("device login should leave key fields empty (machine key resolves from disk): %+v", p)
+	}
+	if !strings.Contains(m.transcriptText(), "signed in as abe@x.dev") {
+		t.Errorf("no sign-in confirmation:\n%s", m.transcriptText())
+	}
+}
+
+func TestApplyInferenceNetAuthError(t *testing.T) {
+	m := authTestModel(t)
+	m.applyInferenceNetAuth(inferenceNetAuthMsg{err: errors.New("denied")})
+	if !strings.Contains(m.transcriptText(), "sign-in failed") {
+		t.Errorf("error not surfaced:\n%s", m.transcriptText())
+	}
+}

--- a/internal/tui/openbrowser.go
+++ b/internal/tui/openbrowser.go
@@ -1,0 +1,23 @@
+package tui
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+)
+
+// openBrowserURL opens url in the default browser; false when it can't
+// (headless box, no opener). Best-effort: the auth flow prints the URL for
+// manual opening regardless.
+func openBrowserURL(url string) bool {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(context.Background(), "open", url)
+	case "windows":
+		cmd = exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.CommandContext(context.Background(), "xdg-open", url)
+	}
+	return cmd.Start() == nil
+}

--- a/internal/tui/registry.go
+++ b/internal/tui/registry.go
@@ -23,7 +23,7 @@ type registryEntry struct {
 // their hint/keybind in palette.go as constants, so a keybind or description
 // still has exactly one home even when it's not a slash command.
 var registry = []registryEntry{
-	{Name: "/auth", Hint: "openrouter [key] — connect OpenRouter: validates the key, wires the provider, /model lists the whole catalog (bare = masked prompt; also: whip auth openrouter)", Category: "Agent"},
+	{Name: "/auth", Hint: "<provider> [key] — connect a provider: inference-net (bare = browser login) or openrouter (bare = masked prompt). /model lists the catalog; also: whip auth <provider>", Category: "Agent"},
 	{Name: "/cd", Hint: "[dir] — change working directory (bare prints it)", Category: "Session"},
 	{Name: "/clear", Hint: "— reset conversation", Category: "Session"},
 	{Name: "/compact", Hint: "[model] [provider]|off — compact now, or pick the compaction model (off restores the default); retry undoes the last compaction, log lists them; compaction level: ctrl+p › Compaction level", Category: "Session"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1899,6 +1899,14 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyAuthResult(msg)
 		return m, nil
 
+	case inferenceNetAuthMsg:
+		m.applyInferenceNetAuth(msg)
+		return m, nil
+
+	case inferenceNetKeyMsg:
+		m.applyInferenceNetKey(msg)
+		return m, nil
+
 	case noticeMsg:
 		m.append(dimStyle.Render(string(msg)))
 		return m, nil


### PR DESCRIPTION
## What

First-class Inference.net auth for whip, mirroring the `@inference/fast` CLI's flow. Two ways to connect:

- **Browser device login (the smooth path)** — `whip auth inference-net login` runs the OAuth device-authorization flow against the relay: open the dashboard approval page in a browser, approve, and whip provisions a machine API key (`whip-<host>-<timestamp>`) automatically via `apiKey.create`. The user never touches a key.
- **BYOK** — `whip auth inference-net login --key <k>` / `--env` validates a pasted key against the gateway before writing.

## Changes

- **`internal/inferencenet/`** (new, stdlib-only): device flow, a minimal superjson-envelope tRPC client (`project.getProjects`, `apiKey.create`, `apiKey.archive`), machine-key provisioning/rotation, key validation (`GET /models`), and a `0600 ~/.whip/inference-net.json` store (session token + machine key, kept out of config.json).
- **Rename** provider key `inference` → `inference-net`; `Config.normalize` migrates old configs (provider, model routes, default/compact provider) transparently on load.
- **config**: `ResolveKey` falls back to the stored machine key (ahead of the legacy `~/.inf/config.json` read); `UpsertInferenceNet` helper.
- **CLI** `whip auth inference-net`: `login [--key|--env]`, `status`, `logout` (archives the key + closes the session), `key rotate`.
- **TUI** `/auth inference-net` (bare = async browser login; `<key>` = masked BYOK) with catalog hot-refresh.
- **Docs**: features.md entry.

## Companion change

The relay's device-authorization allowlist needs the `whip` client id or the device flow gets `invalid_client`. That's the companion monorepo PR (registers `WHIP_DEVICE_CLIENT_ID = "whip"`). Until that deploys, `--key` / `--env` BYOK works today.

## Tests

New coverage: device login + key mint against a stubbed relay, store round-trip, key validation, rename migration, upsert modes, key fallback, CLI dispatch/status/logout, TUI dispatch/apply. Full suite green locally (`go test ./...`), lint clean (`golangci-lint run ./...`).