### PR TITLE
feat(tui): render tool calls as they stream, before execution

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,7 +42,7 @@ parallel tool calls and background subagents).
 - [x] Markdown rendering for assistant messages (glamour, hardcoded dark style — no OSC background query; finalized segments + resumed transcripts render rich, in-flight streaming stays plain text; right-padding stripped, body aligned under the "● " marker)
 - [x] Diff view for `edit` tool results (pi edit tool returns `details: {diff, patch, firstChangedLine}` — `packages/agent/src/harness/tools/edit.ts`; opencode picks split vs unified by terminal width >120)
 - [x] Tool rows: icon + present-participle verb while running ("Reading file…"), collapse to one line on completion, red + expandable on failure (opencode `routes/session/index.tsx:1836`, `util/collapse-tool-output.ts` — 19 lines)
-- [ ] Render tool calls as they stream, before execution starts (pi: `message_update` spawns `ToolExecutionComponent` keyed by tool-call id)
+- [x] Render tool calls as they stream, before execution starts (pi: `message_update` spawns `ToolExecutionComponent` keyed by tool-call id)
 - [x] Spinner with elapsed time + token count (% of context window) in status line (opencode `routes/session/footer.tsx`) — cost part done (status line shows session spend when the provider advertises pricing)
 - [ ] Toast-style transient notifications for command success/failure (opencode `ui/toast.tsx` — 102 lines)
 - [ ] Desktop notification/sound when a turn finishes and the terminal is blurred (opencode `attention.ts` — "when: blurred" is the detail that makes it not-annoying)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,6 +20,10 @@ type Events struct {
 	OnThink     func(delta string)            // reasoning/thinking tokens as they stream
 	OnToolStart func(id, name, args string)   // a tool call is about to run
 	OnToolEnd   func(id, name, result string) // a tool call finished
+	// OnToolCall fires as a tool call streams in (id/name/args snapshots; args
+	// may be partial mid-stream), so the UI can show a pending row before
+	// execution starts. Distinct from OnToolStart, which fires at run time.
+	OnToolCall func(id, name, args string)
 	// OnToolOutput streams partial output for a running tool call (bash only —
 	// throttled snapshots, ~100ms apart). Fires from tool worker goroutines.
 	OnToolOutput func(id, outputSoFar string)
@@ -321,7 +325,7 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 			Messages:        msgs,
 			Tools:           tools.Defs(a.AllTools()),
 			ReasoningEffort: a.Effort,
-		}, ev.OnText, ev.OnThink)
+		}, ev.OnText, ev.OnThink, ev.OnToolCall)
 		a.Client.OnRetry = nil
 		a.AddUsage(usage)
 		if ev.OnUsage != nil {

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -296,6 +296,13 @@ func (r *taskRegistry) emitter(id string) Events {
 				}
 			})
 		},
+		OnToolCall: func(tcID, n, a string) {
+			r.broadcast(id, func(e Events) {
+				if e.OnToolCall != nil {
+					e.OnToolCall(tcID, n, a)
+				}
+			})
+		},
 		OnToolEnd: func(tcID, n, res string) {
 			r.broadcast(id, func(e Events) {
 				if e.OnToolEnd != nil {

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -30,6 +30,13 @@ func FanIn(evs ...Events) Events {
 				}
 			}
 		},
+		OnToolCall: func(id, name, args string) {
+			for _, e := range evs {
+				if e.OnToolCall != nil {
+					e.OnToolCall(id, name, args)
+				}
+			}
+		},
 		OnToolEnd: func(id, name, result string) {
 			for _, e := range evs {
 				if e.OnToolEnd != nil {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -602,10 +602,12 @@ func (c *Client) Models(ctx context.Context) ([]ModelInfo, error) {
 	return list.Data, nil
 }
 
-// Stream sends the request and invokes onText for each content delta and
-// onThink for each reasoning_content delta (both may be nil). It returns the
-// final assistant message (with any accumulated tool calls) plus the usage
-// the provider reports on the terminal chunk (stream_options:include_usage).
+// Stream sends the request and invokes onText for each content delta,
+// onThink for each reasoning_content delta (both may be nil), and onToolCall
+// for each tool-call state change as it streams (id/name/args snapshots; may
+// be partial mid-stream). It returns the final assistant message (with any
+// accumulated tool calls) plus the usage the provider reports on the terminal
+// chunk (stream_options:include_usage).
 //
 // Transient failures (transport errors, 429, 5xx) are retried with backoff —
 // but only until the first visible delta has been handed to onText/onThink.
@@ -613,7 +615,7 @@ func (c *Client) Models(ctx context.Context) ([]ModelInfo, error) {
 // the error is surfaced instead. A retry regenerates the whole assistant
 // message server-side; nothing in the request messages is mutated by a failed
 // attempt, so retrying is idempotent.
-func (c *Client) Stream(ctx context.Context, req Request, onText, onThink func(string)) (Message, Usage, error) {
+func (c *Client) Stream(ctx context.Context, req Request, onText, onThink func(string), onToolCall func(id, name, args string)) (Message, Usage, error) {
 	req.Stream = true
 	req.StreamOptions = &struct {
 		IncludeUsage bool `json:"include_usage"`
@@ -633,7 +635,7 @@ func (c *Client) Stream(ctx context.Context, req Request, onText, onThink func(s
 		if onThink != nil {
 			wrapThink = func(s string) { emitted = true; onThink(s) }
 		}
-		msg, usage, err := c.streamOnce(ctx, body, wrapText, wrapThink)
+		msg, usage, err := c.streamOnce(ctx, body, wrapText, wrapThink, onToolCall)
 		if err == nil {
 			return msg, usage, nil
 		}
@@ -656,7 +658,7 @@ func (c *Client) Stream(ctx context.Context, req Request, onText, onThink func(s
 // streamOnce performs a single streaming request attempt; the Stream retry
 // wrapper calls it per attempt and reads its own `emitted` flag (set by the
 // wrapped callbacks) to decide whether a retry would replay visible output.
-func (c *Client) streamOnce(ctx context.Context, body []byte, onText, onThink func(string)) (Message, Usage, error) {
+func (c *Client) streamOnce(ctx context.Context, body []byte, onText, onThink func(string), onToolCall func(id, name, args string)) (Message, Usage, error) {
 	hr, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return Message{}, Usage{}, err
@@ -731,6 +733,12 @@ func (c *Client) streamOnce(ctx context.Context, body []byte, onText, onThink fu
 				cur.Function.Name += tc.Function.Name
 			}
 			cur.Function.Arguments += tc.Function.Arguments
+			// Surface the streaming tool call as soon as it has an id, so the
+			// UI can show a pending row before execution (tool_call arguments
+			// stream in fragments, so re-fire each delta with the snapshot).
+			if onToolCall != nil && cur.ID != "" {
+				onToolCall(cur.ID, cur.Function.Name, cur.Function.Arguments)
+			}
 		}
 	}
 	if err := sc.Err(); err != nil {

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -129,6 +129,39 @@ func TestStreamTextAndToolCalls(t *testing.T) {
 	}
 }
 
+// onToolCall fires for each streaming tool-call delta once the call has an
+// id, with the id/name/args snapshot at that point — so the UI can render a
+// pending row before execution. A nil onToolCall must not panic.
+func TestStreamOnToolCallFiresPerDelta(t *testing.T) {
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"ba","arguments":"{\"comm"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"sh","arguments":"and\":\"ls\"}"}}]}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+	defer srv.Close()
+
+	type snap struct{ id, name, args string }
+	var got []snap
+	_, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil,
+		func(id, name, args string) { got = append(got, snap{id, name, args}) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) < 2 {
+		t.Fatalf("onToolCall should fire per delta once the id exists, got %d calls: %+v", len(got), got)
+	}
+	for _, s := range got {
+		if s.id != "c1" {
+			t.Fatalf("snapshot missing id: %+v", s)
+		}
+	}
+	last := got[len(got)-1]
+	if last.name != "bash" || last.args != `{"command":"ls"}` {
+		t.Fatalf("final snapshot should have the assembled name+args, got %+v", last)
+	}
+}
+
 func TestStreamLengthDiscardsToolCalls(t *testing.T) {
 	srv := sseServer(t,
 		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"bash","arguments":"{\"comm"}}]}}]}`,

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -43,7 +43,7 @@ func TestStreamStripsAuthoredFlag(t *testing.T) {
 
 	sent := time.Now()
 	msgs := []Message{{Role: "user", Content: "typed by me", Authored: true, SentAt: &sent}}
-	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil); err != nil {
+	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(string(body), "authored") {
@@ -113,7 +113,7 @@ func TestStreamTextAndToolCalls(t *testing.T) {
 	defer srv.Close()
 
 	var streamed strings.Builder
-	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, func(d string) { streamed.WriteString(d) }, nil)
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, func(d string) { streamed.WriteString(d) }, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestStreamLengthDiscardsToolCalls(t *testing.T) {
 	)
 	defer srv.Close()
 
-	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestStreamLengthDiscardsToolCalls(t *testing.T) {
 func TestStreamAPIError(t *testing.T) {
 	srv := sseServer(t, `data: {"error":{"message":"boom"}}`)
 	defer srv.Close()
-	_, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected api error, got %v", err)
 	}
@@ -170,7 +170,7 @@ func TestStreamReasoningRoutedToOnThink(t *testing.T) {
 
 	var think, text strings.Builder
 	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"},
-		func(d string) { text.WriteString(d) }, func(d string) { think.WriteString(d) })
+		func(d string) { text.WriteString(d) }, func(d string) { think.WriteString(d) }, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestStreamHTTPError(t *testing.T) {
 	srv := sseServer(t)
 	defer srv.Close()
 	c.BaseURL = srv.URL
-	_, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Fatalf("expected 401 error, got %v", err)
 	}
@@ -202,12 +202,12 @@ func TestNewTool(t *testing.T) {
 
 func TestStreamTransportErrors(t *testing.T) {
 	noSleep(t) // connection-refused is retryable; don't burn real backoff
-	if _, _, err := New("http://\x7f", "k").Stream(context.Background(), Request{}, nil, nil); err == nil {
+	if _, _, err := New("http://\x7f", "k").Stream(context.Background(), Request{}, nil, nil, nil); err == nil {
 		t.Fatal("expected bad-url error")
 	}
 	srv := sseServer(t)
 	srv.Close() // connection refused
-	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{}, nil, nil); err == nil {
+	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{}, nil, nil, nil); err == nil {
 		t.Fatal("expected connection error")
 	}
 }
@@ -269,7 +269,7 @@ func TestStreamUsageParsed(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, u, err := New(srv.URL, "k").Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, u, err := New(srv.URL, "k").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/llm/repair_test.go
+++ b/internal/llm/repair_test.go
@@ -111,7 +111,7 @@ func TestStreamSendsSyntheticResultsForUnansweredCalls(t *testing.T) {
 		{Role: "user", Content: "q"},
 		{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_1"}}},
 	}
-	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil); err != nil {
+	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	s := string(body)
@@ -142,7 +142,7 @@ func TestStreamToolMessagesCarryName(t *testing.T) {
 		{Role: "tool", Content: "ok", ToolCallID: "call_1"},
 		{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_2"}}}, // unanswered
 	}
-	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil); err != nil {
+	if _, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	s := string(body)

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -65,7 +65,7 @@ func TestStreamRetriesTransientStatus(t *testing.T) {
 	var retries []RetryEvent
 	c.OnRetry = func(ev RetryEvent) { retries = append(retries, ev) }
 
-	msg, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	msg, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestStreamRetriesTransportError(t *testing.T) {
 	var retried int
 	c.OnRetry = func(RetryEvent) { retried++ }
 
-	_, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error after retries exhausted")
 	}
@@ -113,7 +113,7 @@ func TestStreamDoesNotRetryPermanentStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := New(srv.URL, "k").Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, _, err := New(srv.URL, "k").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Fatalf("expected 401, got %v", err)
 	}
@@ -134,7 +134,7 @@ func TestStreamDoesNotRetryContextLimit(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := New(srv.URL, "k").Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, _, err := New(srv.URL, "k").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if !IsContextLimit(err) {
 		t.Fatalf("expected context-limit error, got %v", err)
 	}
@@ -161,7 +161,7 @@ func TestStreamDoesNotRetryAfterEmission(t *testing.T) {
 	var retried int
 	c.OnRetry = func(RetryEvent) { retried++ }
 	_, _, err := c.Stream(context.Background(), Request{Model: "m"},
-		func(d string) { streamed.WriteString(d) }, nil)
+		func(d string) { streamed.WriteString(d) }, nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -185,7 +185,7 @@ func TestMaxRetriesConfigurable(t *testing.T) {
 
 	c := New(srv.URL, "k")
 	c.MaxRetries = 2
-	if _, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil); err == nil {
+	if _, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil, nil); err == nil {
 		t.Fatal("expected error")
 	}
 	if calls.Load() != 2 {
@@ -194,7 +194,7 @@ func TestMaxRetriesConfigurable(t *testing.T) {
 
 	calls.Store(0)
 	c.MaxRetries = 1
-	if _, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil); err == nil {
+	if _, _, err := c.Stream(context.Background(), Request{Model: "m"}, nil, nil, nil); err == nil {
 		t.Fatal("expected error")
 	}
 	if calls.Load() != 1 {
@@ -214,7 +214,7 @@ func TestRetryEventCarriesMax(t *testing.T) {
 	c.MaxRetries = 3
 	var evs []RetryEvent
 	c.OnRetry = func(ev RetryEvent) { evs = append(evs, ev) }
-	_, _, _ = c.Stream(context.Background(), Request{Model: "m"}, nil, nil)
+	_, _, _ = c.Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
 	if len(evs) != 2 {
 		t.Fatalf("events: %d, want 2", len(evs))
 	}
@@ -257,7 +257,7 @@ func TestRetryRespectsCancellation(t *testing.T) {
 	go func() { time.Sleep(50 * time.Millisecond); cancel() }()
 
 	start := time.Now()
-	_, _, err := New(srv.URL, "k").Stream(ctx, Request{Model: "m"}, nil, nil)
+	_, _, err := New(srv.URL, "k").Stream(ctx, Request{Model: "m"}, nil, nil, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}

--- a/internal/tui/toolcall_stream_test.go
+++ b/internal/tui/toolcall_stream_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// A tool call streaming from the model renders a queued row before execution;
+// when execution starts, the same tool-call id's running row replaces it
+// rather than appending a duplicate.
+func TestToolCallQueuedRowReplacedOnStart(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 24))
+
+	m.Update(toolCallMsg{id: "c1", name: "bash", args: `{"command":"make"}`})
+	if len(m.blocks) == 0 || m.blocks[len(m.blocks)-1].kind != blockToolQueued {
+		t.Fatal("toolCallMsg should append a queued row")
+	}
+	row := m.blocks[len(m.blocks)-1]
+	if !strings.Contains(ansi.Strip(row.render(m.width)), "bash") {
+		t.Fatalf("queued row should name the tool, got %q", ansi.Strip(row.render(m.width)))
+	}
+
+	before := len(m.blocks)
+	m.Update(toolStartMsg{id: "c1", name: "bash", args: `{"command":"make"}`})
+	if len(m.blocks) != before {
+		t.Fatalf("toolStart should replace the queued row, not append (before=%d after=%d)", before, len(m.blocks))
+	}
+	last := m.blocks[len(m.blocks)-1]
+	if last.kind != blockToolRun || !last.toolRunning {
+		t.Fatalf("after toolStart the row should be a running row, got kind=%v running=%v", last.kind, last.toolRunning)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -58,6 +58,10 @@ type (
 	textMsg       string
 	toolStartMsg  struct{ id, name, args string }
 	toolEndMsg    struct{ id, name, result string }
+	// toolCallMsg is a tool call still streaming from the model (args may be
+	// partial): renders a dim "queued" row that toolStartMsg replaces when
+	// execution begins.
+	toolCallMsg   struct{ id, name, args string }
 	toolOutputMsg struct{ id, text string } // partial output for a running tool row
 	steeredMsg    string
 )
@@ -1015,6 +1019,7 @@ const (
 	blockAssistant                  // raw markdown: re-render through glamour
 	blockTool                       // raw tool result: collapsed preview, expandable
 	blockToolRun                    // a running tool call: verb line, collapses on completion
+	blockToolQueued                 // a tool call still streaming from the model; replaced by blockToolRun on start
 )
 
 // toolPreviewLines is how many lines of a tool result show when collapsed.
@@ -1692,9 +1697,26 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case toolCallMsg:
+		// a tool call still streaming from the model: show a dim queued row so
+		// the user sees it before execution starts. toolStartMsg swaps it for
+		// the live running row (matched by tool-call id).
+		row := dimStyle.Render("⋯ " + msg.name + " " + firstLine(msg.args))
+		m.blocks = append(m.blocks, block{kind: blockToolQueued, text: row, toolID: msg.id})
+		m.refreshVP()
+		return m, nil
+
 	case toolStartMsg:
 		m.flushThink()
 		m.flushCurrent()
+		// replace the queued row for this id (if the tool call streamed in)
+		// rather than appending a second row for the same call.
+		for i := len(m.blocks) - 1; i >= 0; i-- {
+			if m.blocks[i].kind == blockToolQueued && m.blocks[i].toolID == msg.id {
+				m.blocks = slices.Delete(m.blocks, i, i+1)
+				break
+			}
+		}
 		args := msg.args
 		if msg.name == "browser_exec" || msg.name == "computer_exec" {
 			// Surface the step label (the code's first # comment) as the row
@@ -3242,6 +3264,10 @@ func (m *model) submitTurn(text string, authored bool) (tea.Model, tea.Cmd) {
 				send(toolStartMsg{id, n, a})
 			},
 			OnToolEnd: func(id, n, r string) { send(toolEndMsg{id, n, r}) },
+			// tool call still streaming from the model: show a queued row
+			// before execution. Detached send like OnToolOutput — args arrive
+			// in deltas and a parked p.Send must not wedge the stream.
+			OnToolCall: func(id, n, a string) { go send(toolCallMsg{id, n, a}) },
 			// Detached send: snapshots are lossy progress, and a parked
 			// p.Send must never wedge bashrun's ticker goroutine (the ABBA
 			// lesson from docs/concurrency.md — same rule as sendTaskMsg).

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -55,9 +55,9 @@ var (
 
 // messages sent from the agent goroutine
 type (
-	textMsg       string
-	toolStartMsg  struct{ id, name, args string }
-	toolEndMsg    struct{ id, name, result string }
+	textMsg      string
+	toolStartMsg struct{ id, name, args string }
+	toolEndMsg   struct{ id, name, result string }
 	// toolCallMsg is a tool call still streaming from the model (args may be
 	// partial): renders a dim "queued" row that toolStartMsg replaces when
 	// execution begins.
@@ -1015,11 +1015,11 @@ func buildAgent(cfg *config.Config, modelName, provName, sysPrompt string) (*age
 type blockKind int
 
 const (
-	blockText      blockKind = iota // already-styled line(s): re-wrap on resize
-	blockAssistant                  // raw markdown: re-render through glamour
-	blockTool                       // raw tool result: collapsed preview, expandable
-	blockToolRun                    // a running tool call: verb line, collapses on completion
-	blockToolQueued                 // a tool call still streaming from the model; replaced by blockToolRun on start
+	blockText       blockKind = iota // already-styled line(s): re-wrap on resize
+	blockAssistant                   // raw markdown: re-render through glamour
+	blockTool                        // raw tool result: collapsed preview, expandable
+	blockToolRun                     // a running tool call: verb line, collapses on completion
+	blockToolQueued                  // a tool call still streaming from the model; replaced by blockToolRun on start
 )
 
 // toolPreviewLines is how many lines of a tool result show when collapsed.
@@ -1711,7 +1711,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.flushCurrent()
 		// replace the queued row for this id (if the tool call streamed in)
 		// rather than appending a second row for the same call.
-		for i := len(m.blocks) - 1; i >= 0; i-- {
+		for i := range slices.Backward(m.blocks) {
 			if m.blocks[i].kind == blockToolQueued && m.blocks[i].toolID == msg.id {
 				m.blocks = slices.Delete(m.blocks, i, i+1)
 				break


### PR DESCRIPTION
## What
Renders tool calls in the transcript the moment they stream in from the model — before execution starts — as a dim `⋯ name args` queued row, replaced in place by the running row when execution begins.

## Why
Roadmap item: "Render tool calls as they stream, before execution starts (pi: `message_update` spawns `ToolExecutionComponent` keyed by tool-call id)." Today a tool call only appears once it runs; on slow streams the transcript looks idle while the model is already emitting calls. A pending row makes the agent's intent visible immediately.

## How
- `internal/llm`: `Client.Stream` / `streamOnce` gain an `onToolCall(id, name, args)` callback, fired per streaming delta once the call has an id (args may be partial mid-stream; each delta re-fires with the current snapshot).
- `internal/agent`: new `Events.OnToolCall` field, fanned out via `FanIn` and the background-task emitter; `Turn` passes it through.
- `internal/tui`: a `toolCallMsg` → `blockToolQueued` row; `toolStartMsg` deletes the queued row for the same tool-call id before appending the running row (no duplicate). The send is detached (`go send(...)`) like `OnToolOutput`, so argument deltas never wedge the stream on a parked `p.Send`.

Distinct from `OnToolStart`/`OnToolEnd`, which fire at run/finish time — this is the stream-time signal.

## Test plan
- `TestStreamOnToolCallFiresPerDelta` (internal/llm) — callback fires per delta once an id exists, every snapshot carries the id, final snapshot has assembled name+args; nil callback doesn't panic
- `TestToolCallQueuedRowReplacedOnStart` (internal/tui) — queued row appears, then is replaced (not duplicated) by the running row
- existing `internal/llm` Stream tests updated for the new signature
- `go build ./...`, `go vet`, `gofmt -s`, golangci-lint, `-race` all clean
