### PR TITLE
feat(config): per-model sampling params (temperature, top_p)

### DIFF
--- a/docs/models-providers.md
+++ b/docs/models-providers.md
@@ -89,8 +89,8 @@ re-keys in place, including the live session's routing when it's already on
 the openrouter provider.
 
 Per-model overrides still compose: add an entry under `"models"` in
-config.json (with `"providers": ["openrouter"]`) to pin context, maxOut, or
-vision for a specific id.
+config.json (with `"providers": ["openrouter"]`) to pin context, maxOut,
+vision, or sampling params for a specific id.
 
 ## Token bookkeeping
 
@@ -100,10 +100,13 @@ Three numbers with distinct meanings:
 |---|---|---|
 | `context` | model's **input** window | header % full, proactive compaction threshold |
 | `maxOut` | optional **output** cap | request `max_completion_tokens` |
+| `samplingParams` | optional `{temperature, top_p}` knobs | sent on outbound requests for this model; omitted when unset |
 | provider `context_length` | advertised limit | overrides `context` when present |
 
 The old `maxTokens` field still parses (it always meant the context window)
-but is superseded by `context`.
+but is superseded by `context`. A model whose config entry sets
+`"samplingParams": {"temperature": 0.2}` sends those params on every request
+to that model; unset params are omitted so the provider applies its defaults.
 
 ## Cost tracking
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,7 +87,7 @@ parallel tool calls and background subagents).
 - [ ] `anthropic-messages` API style alongside `openai-completions` (pi: `packages/ai/src/api/`)
 - [x] `"$VAR"` / `"!cmd"` resolution for apiKey/header values in config (pi models.json value resolution) — shipped with secrets-by-reference (internal/config/secret.go), resolved at point of use
 - [x] Reasoning effort: `/effort [off|low|medium|high]` (bare opens the selector), tab-completes, clickable `⚡` control in the header top-right; sent as `reasoning_effort`, inherited by subagents, survives model switches
-- [ ] Per-model sampling params in config (`samplingParams: {temperature, top_p}`)
+- [x] Per-model sampling params in config (`samplingParams: {temperature, top_p}`)
 
 ## MCP
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -42,8 +42,12 @@ type Agent struct {
 	Provider  string // config provider name
 	MaxTokens int
 	Effort    string // reasoning effort: "" = parameter omitted from requests
-	Tools     []tools.Tool
-	Messages  []llm.Message
+	// Temperature/TopP are optional per-model sampling knobs for outbound
+	// requests. nil omits the field, preserving provider defaults.
+	Temperature *float64
+	TopP        *float64
+	Tools       []tools.Tool
+	Messages    []llm.Message
 
 	// ContextLimit is the model's context window in tokens, as advertised by
 	// the provider's GET /models (0 when unadvertised — proactive compaction
@@ -325,6 +329,8 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 			Messages:        msgs,
 			Tools:           tools.Defs(a.AllTools()),
 			ReasoningEffort: a.Effort,
+			Temperature:     a.Temperature,
+			TopP:            a.TopP,
 		}, ev.OnText, ev.OnThink, ev.OnToolCall)
 		a.Client.OnRetry = nil
 		a.AddUsage(usage)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,18 @@ type Model struct {
 	// gets a pointer note instead, so a text-only model isn't sent a request it
 	// would reject. A provider-advertised input_modalities entry overrides this.
 	Vision bool `json:"vision,omitempty"`
+	// SamplingParams are optional per-model sampling knobs (temperature, top_p)
+	// applied to outbound chat-completion requests for this model. Fields are
+	// omitted from requests when unset, so provider defaults are preserved.
+	SamplingParams *SamplingParams `json:"samplingParams,omitempty"`
+}
+
+// SamplingParams holds optional per-model sampling knobs sent on outbound
+// chat-completion requests. Pointer fields: a 0.0 temperature/top_p is a
+// legitimate value, and nil means "don't send" (provider default).
+type SamplingParams struct {
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"top_p,omitempty"`
 }
 
 // ContextWindow returns the model's context (input) size, honoring the legacy

--- a/internal/config/sampling_test.go
+++ b/internal/config/sampling_test.go
@@ -1,0 +1,28 @@
+package config
+
+import "testing"
+
+// samplingParams in a model entry parses into the struct, survives a
+// round-trip, and stays nil (omitted) when absent — the wire depends on the
+// nil-vs-set distinction to omit unset params from requests.
+func TestSamplingParamsParse(t *testing.T) {
+	var c Config
+	err := parseJSONC([]byte(`{
+		// a comment, because config is JSONC
+		"providers": {"p": {"baseURL": "http://x"}},
+		"models": {
+			"with": {"providers": ["p"], "samplingParams": {"temperature": 0.2, "top_p": 0.9}},
+			"without": {"providers": ["p"]}
+		}
+	}`), &c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := c.Models["with"].SamplingParams
+	if sp == nil || sp.Temperature == nil || *sp.Temperature != 0.2 || sp.TopP == nil || *sp.TopP != 0.9 {
+		t.Fatalf("samplingParams did not parse: %+v", sp)
+	}
+	if c.Models["without"].SamplingParams != nil {
+		t.Fatalf("model without samplingParams should have nil, got %+v", c.Models["without"].SamplingParams)
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -354,10 +354,10 @@ type Request struct {
 	// Temperature and TopP are optional per-model sampling knobs. Pointers so
 	// 0.0 (a legitimate value) is distinguishable from unset; nil omits the
 	// field from the request, preserving provider defaults.
-	Temperature *float64 `json:"temperature,omitempty"`
-	TopP        *float64 `json:"top_p,omitempty"`
-	Stream      bool     `json:"stream"`
-	StreamOptions   *struct {
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"top_p,omitempty"`
+	Stream        bool     `json:"stream"`
+	StreamOptions *struct {
 		IncludeUsage bool `json:"include_usage"`
 	} `json:"stream_options,omitempty"`
 }

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -351,7 +351,12 @@ type Request struct {
 	Tools           []Tool    `json:"tools,omitempty"`
 	MaxTokens       int       `json:"max_tokens,omitempty"`
 	ReasoningEffort string    `json:"reasoning_effort,omitempty"`
-	Stream          bool      `json:"stream"`
+	// Temperature and TopP are optional per-model sampling knobs. Pointers so
+	// 0.0 (a legitimate value) is distinguishable from unset; nil omits the
+	// field from the request, preserving provider defaults.
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"top_p,omitempty"`
+	Stream      bool     `json:"stream"`
 	StreamOptions   *struct {
 		IncludeUsage bool `json:"include_usage"`
 	} `json:"stream_options,omitempty"`

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -256,6 +256,18 @@ func TestReasoningEffortSerialized(t *testing.T) {
 	}
 }
 
+func TestSamplingParamsSerialized(t *testing.T) {
+	temp, topP := 0.2, 0.9
+	b, _ := json.Marshal(Request{Model: "m", Temperature: &temp, TopP: &topP})
+	if !strings.Contains(string(b), `"temperature":0.2`) || !strings.Contains(string(b), `"top_p":0.9`) {
+		t.Fatalf("missing sampling params: %s", b)
+	}
+	b, _ = json.Marshal(Request{Model: "m"})
+	if strings.Contains(string(b), "temperature") || strings.Contains(string(b), "top_p") {
+		t.Fatalf("unset sampling params must be omitted: %s", b)
+	}
+}
+
 func TestComplete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -967,6 +967,9 @@ func buildAgent(cfg *config.Config, modelName, provName, sysPrompt string) (*age
 	ag := agent.New(client, apiID, maxOut, sysPrompt)
 	ag.ModelName, ag.Provider = modelName, provName
 	ag.ContextLimit = ctxLimit
+	if sp := mdl.SamplingParams; sp != nil {
+		ag.Temperature, ag.TopP = sp.Temperature, sp.TopP
+	}
 	// Native browser subsystem: install the shared manager once; screenshots
 	// steer back into the conversation as image parts on vision models.
 	ag.BrowserDisabled = cfg.Browser.Enabled != nil && !*cfg.Browser.Enabled


### PR DESCRIPTION
## What
Adds optional per-model `samplingParams: {temperature, top_p}` to model entries in `~/.whip/config.json`, applied to every outbound chat-completion request for that model.

## Why
Roadmap item (Models & providers): "Per-model sampling params in config (`samplingParams: {temperature, top_p}`)." Some models behave better with a pinned temperature (e.g. deterministic code edits vs. creative exploration); today that requires editing the request builder.

## How
- `internal/config`: `Model.SamplingParams *SamplingParams` with `*float64` fields (`omitempty`) — a 0.0 temperature is a legitimate value and must stay distinguishable from "unset", and unset params are omitted so the provider applies its own defaults.
- `internal/llm`: `Request.Temperature`/`TopP` (`*float64`, `omitempty`).
- `internal/tui`: `buildAgent` copies the model's `samplingParams` onto the agent; `Turn` sends them on each request.

No behavior change for any config that doesn't set `samplingParams`.

## Test plan
- `TestSamplingParamsParse` (internal/config) — JSONC model entry parses into the struct; a model without the key stays nil
- `TestSamplingParamsSerialized` (internal/llm) — set params serialize into the request body; unset are omitted
- `go build ./...`, `go vet`, `gofmt -s`, golangci-lint, `-race` all clean
