### PR TITLE
fix(tui): keep status-line spend visible on long paths

### DIFF
--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
@@ -34,11 +35,12 @@ func TestStatusLineAlwaysShown(t *testing.T) {
 			t.Errorf("status line should show %q\n--- view tail ---\n%s", want, tailLines(v, 6))
 		}
 	}
-	// the directory is present (compacted to its last segments) — assert
-	// against the actual cwd via shortCWD, not a hardcoded checkout name:
-	// tests run from internal/tui regardless of the repo folder's name.
-	if dir := shortCWD(); !strings.Contains(v, dir) {
-		t.Errorf("status line should show the working directory %q\n%s", dir, tailLines(v, 6))
+	// the directory is present (compacted to its last segments). On a narrow
+	// terminal the cwd is the segment that yields to keep the spend visible,
+	// so assert the last path segment survives, not the full string.
+	base := path.Base(cwd())
+	if !strings.Contains(v, base) {
+		t.Errorf("status line should show the working directory's last segment %q\n%s", base, tailLines(v, 6))
 	}
 }
 

--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -139,6 +139,31 @@ func tailLines(s string, n int) string {
 
 // Cost appears in the spend segment when the provider's catalog advertises
 // pricing for the current model, and is hidden otherwise.
+// On a narrow terminal the cwd is the segment that yields, not the spend: the
+// completion-token count and provider must survive even when the path is too
+// long to fit. Regression for the whole-line truncation that dropped them.
+func TestStatusLineTruncatesCWDNotSpend(t *testing.T) {
+	m := statusModel()
+	m.modelName = "kimi-k3-fast"
+	m.provName = "inference"
+	m.agent.Effort = "high"
+	m.agent.AddUsage(llm.Usage{PromptTokens: 45230, CompletionTokens: 3120})
+	// Wide enough for the fixed segments (model+provider+spend) but not the
+	// full path: the cwd must shrink or vanish before the spend is touched.
+	m.width = 58
+
+	v := m.statusView()
+	if !strings.Contains(v, "3.1k") {
+		t.Errorf("completion tokens must survive cwd truncation, got %q", v)
+	}
+	if !strings.Contains(v, "45.2k") {
+		t.Errorf("prompt tokens must survive cwd truncation, got %q", v)
+	}
+	if !strings.Contains(v, "inference") {
+		t.Errorf("provider must survive cwd truncation, got %q", v)
+	}
+}
+
 func TestStatusLineShowsCost(t *testing.T) {
 	m := statusModel()
 	m.modelName = "m"

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3882,7 +3882,16 @@ func (m *model) statusView() string {
 	if cost, ok := m.sessionCost(); ok {
 		spend += " · " + fmtCost(cost)
 	}
-	line := fmt.Sprintf(" %s   %s   %s   %s", shortCWD(), model, m.provName, spend)
+	// Cap the cwd so the model/provider/spend always survive: the old code
+	// truncated the whole assembled line from the right, which dropped the
+	// completion-token count whenever the path was long. Truncate the cwd
+	// segment to what's left after the fixed segments instead.
+	right := fmt.Sprintf("   %s   %s   %s", model, m.provName, spend)
+	dir := shortCWD()
+	if budget := max(m.width, 0) - len(" ") - len(right); len(dir) > budget && budget > 1 {
+		dir = "…" + dir[len(dir)-budget+1:]
+	}
+	line := fmt.Sprintf(" %s%s", dir, right)
 	return dimStyle.Render(truncLine(line, max(m.width, 0)))
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3882,14 +3882,21 @@ func (m *model) statusView() string {
 	if cost, ok := m.sessionCost(); ok {
 		spend += " · " + fmtCost(cost)
 	}
-	// Cap the cwd so the model/provider/spend always survive: the old code
-	// truncated the whole assembled line from the right, which dropped the
-	// completion-token count whenever the path was long. Truncate the cwd
-	// segment to what's left after the fixed segments instead.
+	// The fixed segments (model/provider/spend) are the data that matters; the
+	// cwd is what yields. Old code truncated the whole assembled line from the
+	// right, dropping the completion-token count whenever the path was long.
+	// Instead give the cwd only the space left after the fixed segments —
+	// truncating it to its tail, then dropping it entirely — so the spend
+	// survives whenever the fixed segments fit at all.
 	right := fmt.Sprintf("   %s   %s   %s", model, m.provName, spend)
 	dir := shortCWD()
-	if budget := max(m.width, 0) - len(" ") - len(right); len(dir) > budget && budget > 1 {
-		dir = "…" + dir[len(dir)-budget+1:]
+	switch budget := max(m.width, 0) - len(" ") - len(right); {
+	case len(dir) <= budget:
+		// fits as-is
+	case budget > 1:
+		dir = "…" + dir[len(dir)-budget+1:] // keep the tail, the recognizable part
+	default:
+		dir = "" // no room for the path at all; show only the fixed segments
 	}
 	line := fmt.Sprintf(" %s%s", dir, right)
 	return dimStyle.Render(truncLine(line, max(m.width, 0)))


### PR DESCRIPTION
## What
Fixes the status line dropping the completion-token count (and cost) when the working-directory path is long enough to overflow the terminal width.

## Root cause
`statusView` assembled the full line (` cwd   model   provider   spend `) and then truncated the *whole line* from the right with `truncLine`. On a long path, that cut off the spend — the most useful data on the line.

## Fix
Give the cwd only the space left after the fixed segments (model/provider/spend): truncate the cwd to its tail when it partially fits, drop it entirely when there's no room at all. The spend survives whenever the fixed segments fit at all.

Also fixes the test that masked this: `TestStatusLineAlwaysShown` asserted the full `shortCWD()` string was present, which bakes in "path always fits" and fails on any long checkout path (e.g. a `whip-wt-sampling` worktree). It now asserts the last path segment survives.

## Test plan
- `TestStatusLineTruncatesCWDNotSpend` (new) — narrow width: spend + provider survive while the cwd yields; statusView coverage 93.8%
- existing status tests updated and passing
- `go build ./...`, `go vet`, `gofmt -s`, golangci-lint, `-race` all clean
