### PR TITLE
test(update): lift coverage back over the 90% floor

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -28,9 +28,12 @@ const (
 	// checkTTL caps the network check at once per day; a pending notice for
 	// a release not yet installed suppresses re-checks entirely.
 	checkTTL     = 24 * time.Hour
-	latestURL    = "https://api.github.com/repos/context-labs/whip/releases/latest"
 	fetchTimeout = 2 * time.Second
 )
+
+// latestURL is the GitHub releases endpoint. A var so tests can point it at a
+// mock server.
+var latestURL = "https://api.github.com/repos/context-labs/whip/releases/latest"
 
 // Notice is ~/.whip/update.json: the last check's outcome. Latest is set
 // only when a newer release exists; Acknowledged is flipped by `whip

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -3,6 +3,8 @@ package update
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -220,4 +222,44 @@ func TestPendingAndAcknowledge(t *testing.T) {
 	if !n.Acknowledged {
 		t.Error("notice lost its acknowledgement")
 	}
+}
+
+// fetchLatestGitHub parses the tag from a GitHub releases response and errors
+// on non-200 / empty tag. latestURL is swapped for a mock server.
+func TestFetchLatestGitHub(t *testing.T) {
+	orig := latestURL
+	defer func() { latestURL = orig }()
+
+	t.Run("ok", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v9.9.9"})
+		}))
+		defer srv.Close()
+		latestURL = srv.URL
+		tag, err := fetchLatestGitHub()
+		if err != nil || tag != "v9.9.9" {
+			t.Fatalf("tag=%q err=%v", tag, err)
+		}
+	})
+	t.Run("non-200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+		latestURL = srv.URL
+		if _, err := fetchLatestGitHub(); err == nil {
+			t.Fatal("expected error on 404")
+		}
+	})
+	t.Run("empty tag", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": ""})
+		}))
+		defer srv.Close()
+		latestURL = srv.URL
+		if _, err := fetchLatestGitHub(); err == nil {
+			t.Fatal("expected error on empty tag_name")
+		}
+	})
 }


### PR DESCRIPTION
## What
Adds test coverage for `fetchLatestGitHub` (the update check's network fetch), lifting total coverage from **89.9% → 90.3%**.

## Why
Main's total coverage slipped to **89.9%**, under the repo's **90% CI floor** — so *every* open PR's `test` job currently fails the `coverage floor (90%)` gate, independent of what the PR changes. This is a pre-existing main regression, not caused by those PRs.

The workflow comment says "ratchet the floor up over time… (don't lower it)", so this PR lifts coverage back over the floor instead of touching the floor.

## How
- `fetchLatestGitHub` was at 0% — the cheapest real lift.
- Make `latestURL` a `var` (was a `const`) so tests can point it at an `httptest` server.
- New `TestFetchLatestGitHub` covers the ok / non-200 / empty-tag paths.

## Test plan
- `TestFetchLatestGitHub/{ok,non-200,empty_tag}` pass
- `go build ./...`, `go vet`, `gofmt -s`, golangci-lint, `-race` all clean
- CI coverage floor passes at 90.3%

Once merged, the 5 open feature PRs (#33–37) can be rebased onto this and their `test` jobs will go green.
