### PR TITLE
fix(update): deflake TestFetchLatestGitHub under -race on CI

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -27,13 +27,18 @@ const (
 	noticeFile = "update.json"
 	// checkTTL caps the network check at once per day; a pending notice for
 	// a release not yet installed suppresses re-checks entirely.
-	checkTTL     = 24 * time.Hour
-	fetchTimeout = 2 * time.Second
+	checkTTL = 24 * time.Hour
 )
 
 // latestURL is the GitHub releases endpoint. A var so tests can point it at a
 // mock server.
 var latestURL = "https://api.github.com/repos/context-labs/whip/releases/latest"
+
+// fetchTimeout bounds the update check. A var so tests can relax it: the
+// hardcoded 2s is fine for a fire-and-forget startup check against GitHub, but
+// races under `-race -shuffle=on` on a loaded CI runner when the test server
+// is on the same box. Tests set this to a generous value.
+var fetchTimeout = 2 * time.Second
 
 // Notice is ~/.whip/update.json: the last check's outcome. Latest is set
 // only when a newer release exists; Acknowledged is flipped by `whip

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -229,6 +229,12 @@ func TestPendingAndAcknowledge(t *testing.T) {
 func TestFetchLatestGitHub(t *testing.T) {
 	orig := latestURL
 	defer func() { latestURL = orig }()
+	// Relax the fetch timeout: the 2s production bound races under
+	// `-race -shuffle=on` on a loaded CI runner (a localhost request took
+	// 2.1s and flaked the suite).
+	origTimeout := fetchTimeout
+	fetchTimeout = 30 * time.Second
+	defer func() { fetchTimeout = origTimeout }()
 
 	t.Run("ok", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What
Deflakes `TestFetchLatestGitHub`, which failed on CI with `context deadline exceeded`.

## Root cause
The test (added in #38) hit the production `fetchTimeout = 2s`. That's the right bound for a fire-and-forget startup update-check against GitHub, but too tight under `-race -shuffle=on` on a loaded CI runner — a localhost request took 2.1s and failed the suite. This made PR #37's `test` job fail (the others passed only because the test happened to win the race there).

## Fix
- `fetchTimeout`: `const` → `var`, so tests can relax it.
- The test sets it to 30s (restored after), so the suite no longer depends on a 2s wall-clock against a same-box server.

No production behavior change.

## Test plan
- `go test -race -shuffle=on -count=1 ./internal/update/` × 5 → all green
- `go build ./...`, `go vet`, `gofmt -s` clean
