### PR TITLE
Claude-style tool rows: Verb(subject) headers + colored line-numbered diffs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -291,12 +291,24 @@ relay: full device login + key mint, store round-trip, key validation),
   within a 2-second window**, so a stray ctrl+c can't nuke the session. The
   hint `press ctrl+c again to quit` shows while armed.
   Tests: `quit_confirm_test.go`.
-- **Collapsible tool results.** Tool results store raw output in a `blockTool`
-  transcript block and render collapsed to 5 lines with a `… +N lines` hint.
-  `ctrl+e` toggles the most recent; clicking a block expands/collapses it
-  (each block tracks its rendered line range `y0`/`y1` so the click row maps
-  through the viewport offset). Blocks re-render at the current width on
-  terminal resize. Tests: `tool_expand_test.go`, `resize_test.go`.
+- **Collapsible tool results, claude-style.** A completed call renders as a
+  `● Verb(subject)` header (`internal/tui/toolrow.go` — `Update(path)`,
+  `Bash(cmd)`, `Subagent(description)`; the collapse never loses what the call
+  was about) over its result in a `blockTool` block: first line under a `⎿`
+  marker, collapsed to 5 lines with a `… +N lines` hint, red when the result
+  is an error. **Write/edit results render their diff**: the tools emit
+  line-numbered fenced diffs (`editDiff` with a startLine; `write` diffs
+  overwrites against the old content from line 1), and the TUI shows
+  `⎿ Added N lines, removed M lines` over red/green full-width bands with
+  absolute line numbers — the diff IS the collapsed view (capped at 30 rows),
+  and trailing LSP diagnostics stay visible under it. Resumed sessions
+  re-render call headers and diffs from the stored messages. `ctrl+e` toggles
+  the most recent; clicking a block expands/collapses it (each block tracks
+  its rendered line range `y0`/`y1` so the click row maps through the
+  viewport offset). Blocks re-render at the current width on terminal resize.
+  Tests: `tool_expand_test.go`, `resize_test.go`, `toolrow_test.go`
+  (headers, extract/counts, colored diff render, preview cap, resume),
+  `tools_test.go` — `TestEditDiffLineNumbers`, `TestWriteToolDiffOnOverwrite`.
 - **Markdown.** Assistant messages render through glamour; streamed in-flight
   text stays plain and renders on flush. `markdown.go`.
 - **Clickable links (OSC 8).** URLs and existing local file paths in the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,8 +40,8 @@ parallel tool calls and background subagents).
 ## Transcript & rendering
 
 - [x] Markdown rendering for assistant messages (glamour, hardcoded dark style — no OSC background query; finalized segments + resumed transcripts render rich, in-flight streaming stays plain text; right-padding stripped, body aligned under the "● " marker)
-- [x] Diff view for `edit` tool results (pi edit tool returns `details: {diff, patch, firstChangedLine}` — `packages/agent/src/harness/tools/edit.ts`; opencode picks split vs unified by terminal width >120)
-- [x] Tool rows: icon + present-participle verb while running ("Reading file…"), collapse to one line on completion, red + expandable on failure (opencode `routes/session/index.tsx:1836`, `util/collapse-tool-output.ts` — 19 lines)
+- [x] Diff view for `edit` tool results (pi edit tool returns `details: {diff, patch, firstChangedLine}` — `packages/agent/src/harness/tools/edit.ts`; opencode picks split vs unified by terminal width >120) — claude-style: line-numbered diffs from the tools (`edit` and overwriting `write`), rendered with red/green bands under a "⎿ Added N lines, removed M lines" summary; diffs re-render on resume
+- [x] Tool rows: icon + present-participle verb while running ("Reading file…"), collapse on completion to a claude-style `● Verb(subject)` header that keeps the path/command visible, result under a `⎿` marker, red on failure (opencode `routes/session/index.tsx:1836`; claude-code header/summary shape)
 - [x] Render tool calls as they stream, before execution starts (pi: `message_update` spawns `ToolExecutionComponent` keyed by tool-call id)
 - [x] Spinner with elapsed time + token count (% of context window) in status line (opencode `routes/session/footer.tsx`) — cost part done (status line shows session spend when the provider advertises pricing)
 - [ ] Toast-style transient notifications for command success/failure (opencode `ui/toast.tsx` — 102 lines)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -252,6 +252,8 @@ func writeTool() Tool {
 			if deny := checkGate("write", a.Path); deny != "" {
 				return "", errors.New(deny)
 			}
+			// old content (if any) so an overwrite reports what changed
+			old, oldErr := os.ReadFile(a.Path)
 			//nolint:gosec // workspace files get the user default perms
 			if err := os.MkdirAll(filepath.Dir(a.Path), 0o755); err != nil {
 				return "", err
@@ -260,7 +262,16 @@ func writeTool() Tool {
 			if err := os.WriteFile(a.Path, []byte(a.Content), 0o644); err != nil {
 				return "", err
 			}
-			return fmt.Sprintf("Wrote %d bytes to %s", len(a.Content), a.Path) + lspDiagnostics(ctx, a.Path), nil
+			out := fmt.Sprintf("Wrote %d bytes to %s", len(a.Content), a.Path)
+			// overwrites carry a diff so the change is reviewable (a fresh file
+			// is all-new — the content itself is right above in the call args).
+			// The whole file diffs from line 1, so the numbers are absolute.
+			if oldErr == nil {
+				if d := editDiff(string(old), a.Content, 1); d != "" {
+					out += "\n```diff\n" + d + "\n```"
+				}
+			}
+			return out + lspDiagnostics(ctx, a.Path), nil
 		},
 	}
 }
@@ -301,7 +312,13 @@ func editTool() Tool {
 				return "", err
 			}
 			out := fmt.Sprintf("Replaced %d occurrence(s) in %s", n, a.Path)
-			if d := editDiff(a.OldString, a.NewString); d != "" {
+			// line numbers are only meaningful for a single occurrence; a
+			// replace_all diff renders unnumbered (startLine 0)
+			startLine := 0
+			if n == 1 {
+				startLine = 1 + strings.Count(string(data)[:strings.Index(string(data), a.OldString)], "\n")
+			}
+			if d := editDiff(a.OldString, a.NewString, startLine); d != "" {
 				out += "\n```diff\n" + d + "\n```"
 			}
 			return out + lspDiagnostics(ctx, a.Path), nil
@@ -312,7 +329,13 @@ func editTool() Tool {
 // editDiff renders the changed region of an edit as a compact unified-ish
 // diff: one line of common context on each side of the first/last changed
 // lines, "- old"/"+ new" pairs in between. "" when old and new are identical.
-func editDiff(oldS, newS string) string {
+//
+// startLine is the 1-based file line the old snippet starts on; when > 0
+// every row is prefixed with its absolute line number ("1528 - old",
+// "1528 + new", "1527   ctx" — removed lines numbered in the old file, added
+// lines in the new one). 0 renders the unnumbered form ("- old" / "+ new").
+// The diff is capped at editDiffMaxLines rows; the marker names the rest.
+func editDiff(oldS, newS string, startLine int) string {
 	o := strings.Split(strings.TrimSuffix(oldS, "\n"), "\n")
 	n := strings.Split(strings.TrimSuffix(newS, "\n"), "\n")
 	p := 0
@@ -327,23 +350,40 @@ func editDiff(oldS, newS string) string {
 		return ""
 	}
 	var b strings.Builder
-	ctxLine := func(prefix, line string) {
+	rows := 0
+	row := func(num int, mark, line string) {
+		rows++
+		if rows > editDiffMaxLines {
+			return
+		}
 		if len(line) > 200 {
 			line = line[:200] + "…"
 		}
-		b.WriteString(prefix + line + "\n")
+		if startLine > 0 {
+			fmt.Fprintf(&b, "%d %s %s\n", num, mark, line)
+		} else {
+			fmt.Fprintf(&b, "%s %s\n", mark, line)
+		}
 	}
 	if p > 0 {
-		ctxLine(" ", o[p-1])
+		row(startLine+p-1, " ", o[p-1])
 	}
-	for _, l := range o[p : len(o)-s] {
-		ctxLine("-", l)
+	for i, l := range o[p : len(o)-s] {
+		row(startLine+p+i, "-", l)
 	}
-	for _, l := range n[p : len(n)-s] {
-		ctxLine("+", l)
+	for i, l := range n[p : len(n)-s] {
+		row(startLine+p+i, "+", l)
 	}
 	if s > 0 {
-		ctxLine(" ", o[len(o)-1])
+		row(startLine+len(o)-1, " ", o[len(o)-1])
 	}
-	return strings.TrimSuffix(b.String(), "\n")
+	out := strings.TrimSuffix(b.String(), "\n")
+	if rows > editDiffMaxLines {
+		out += fmt.Sprintf("\n… +%d more lines", rows-editDiffMaxLines)
+	}
+	return out
 }
+
+// editDiffMaxLines bounds a diff so a whole-file rewrite can't flood the tool
+// result (the full content is already in the call args).
+const editDiffMaxLines = 200

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -182,3 +182,41 @@ func TestBashToolInteractiveHook(t *testing.T) {
 		t.Fatalf("non-interactive output wrong: %q", out)
 	}
 }
+
+// editDiff numbers rows from the file's absolute line when startLine > 0,
+// renders unnumbered rows at 0, and caps runaway diffs.
+func TestEditDiffLineNumbers(t *testing.T) {
+	d := editDiff("ctx\nold\ntail", "ctx\nnew\ntail", 10)
+	want := "10   ctx\n11 - old\n11 + new\n12   tail"
+	if d != want {
+		t.Fatalf("numbered diff:\n%s\nwant:\n%s", d, want)
+	}
+	if d := editDiff("old", "new", 0); d != "- old\n+ new" {
+		t.Fatalf("unnumbered diff: %q", d)
+	}
+	if editDiff("same", "same", 5) != "" {
+		t.Fatal("identical strings should yield no diff")
+	}
+	big := strings.Repeat("x\n", editDiffMaxLines+50)
+	if d := editDiff("", big, 1); !strings.Contains(d, "more lines") {
+		t.Fatal("oversized diff should carry the cap marker")
+	}
+}
+
+// An overwrite carries an absolute-numbered diff; a fresh file does not.
+func TestWriteToolDiffOnOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	w := writeTool()
+	out, err := w.Run(context.Background(), json.RawMessage(`{"path":"`+p+`","content":"a\nb\n"}`))
+	if err != nil || strings.Contains(out, "```diff") {
+		t.Fatalf("fresh write should carry no diff: %q, %v", out, err)
+	}
+	out, err = w.Run(context.Background(), json.RawMessage(`{"path":"`+p+`","content":"a\nc\n"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "```diff") || !strings.Contains(out, "2 - b") || !strings.Contains(out, "2 + c") {
+		t.Fatalf("overwrite should diff with absolute line numbers: %q", out)
+	}
+}

--- a/internal/tui/no_truncation_test.go
+++ b/internal/tui/no_truncation_test.go
@@ -51,7 +51,7 @@ func TestResumedToolCallNotTruncated(t *testing.T) {
 	var found bool
 	for _, b := range m.blocks {
 		rendered := ansi.Strip(b.render(m.width))
-		if !strings.Contains(rendered, "⚒ bash") {
+		if !strings.Contains(rendered, "Bash(") {
 			continue
 		}
 		found = true

--- a/internal/tui/toolrow.go
+++ b/internal/tui/toolrow.go
@@ -1,0 +1,203 @@
+// toolrow.go: rendering for completed tool calls — a bold "Verb(subject)"
+// header row, and for file mutations a "⎿ Added N lines, removed M lines"
+// summary over a colored, line-numbered diff. The shape follows claude-code's
+// tool output: the header keeps the call's subject (path, command) visible
+// after completion, and a write's diff is the collapsed view, not something
+// hidden behind an expand.
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+var (
+	toolHeadStyle = lipgloss.NewStyle().Bold(true)
+	// diff bands: colored background across the full row, terminal-default
+	// foreground on top (legible on both themes).
+	diffAddStyle = lipgloss.NewStyle().Background(lipgloss.AdaptiveColor{Light: "194", Dark: "22"})
+	diffDelStyle = lipgloss.NewStyle().Background(lipgloss.AdaptiveColor{Light: "224", Dark: "52"})
+)
+
+// toolHeaderName maps a tool to its header verb ("Update" over "edit" — the
+// row reads as what happened, not which function ran).
+func toolHeaderName(name string) string {
+	switch name {
+	case "edit":
+		return "Update"
+	case "write":
+		return "Write"
+	case "read":
+		return "Read"
+	case "bash":
+		return "Bash"
+	case "subagent":
+		return "Subagent"
+	case "subagent_steer":
+		return "Steer"
+	case "todowrite":
+		return "Plan"
+	case "remember":
+		return "Remember"
+	case "forget":
+		return "Forget"
+	case "browser_exec":
+		return "Browser"
+	case "computer_exec":
+		return "Computer"
+	}
+	return name
+}
+
+// toolSubject extracts the human subject from a call's raw JSON args: the
+// path for file tools, the command for bash, the description for subagents.
+// Unknown shapes fall back to the compacted args.
+func toolSubject(name, args string) string {
+	var m map[string]any
+	_ = json.Unmarshal([]byte(args), &m)
+	get := func(k string) string { s, _ := m[k].(string); return s }
+	s := ""
+	switch name {
+	case "bash":
+		// the whole command, whitespace-collapsed but NEVER truncated — whip's
+		// no-truncation rule for commands; the row wraps or truncates at
+		// render time depending on where it appears
+		s = strings.Join(strings.Fields(get("command")), " ")
+	case "read", "write", "edit":
+		s = get("path")
+	case "subagent":
+		if s = get("description"); s == "" {
+			s = firstLine(get("prompt"))
+		}
+	case "subagent_steer":
+		s = get("id")
+	case "browser_exec", "computer_exec":
+		s = browserStepLabel(args)
+	}
+	if s == "" {
+		s = truncLine(oneLine(args), 60)
+	}
+	return s
+}
+
+// toolHeaderRow renders the completed call's header: "● Update(path)".
+func toolHeaderRow(name, args string, failed bool) string {
+	head := toolHeaderName(name) + "(" + toolSubject(name, args) + ")"
+	if failed {
+		return errStyle.Render("● " + head)
+	}
+	return toolStyle.Render("● ") + toolHeadStyle.Render(toolHeaderName(name)) + "(" + toolSubject(name, args) + ")"
+}
+
+// extractDiff splits a tool result into its fenced ```diff block and the
+// text around it. diff is "" when the result carries none.
+func extractDiff(result string) (diff, rest string) {
+	before, tail, found := strings.Cut(result, "\n```diff\n")
+	if !found {
+		return "", result
+	}
+	body, after, found := strings.Cut(tail, "\n```")
+	if !found {
+		return "", result
+	}
+	rest = before
+	if after = strings.TrimPrefix(after, "\n"); after != "" {
+		rest += "\n" + after
+	}
+	return body, rest
+}
+
+// diffLineKind classifies an editDiff row as added '+', removed '-', or
+// context ' ', tolerating the optional leading line number.
+func diffLineKind(line string) byte {
+	rest := strings.TrimLeft(line, "0123456789")
+	if rest != line {
+		rest = strings.TrimPrefix(rest, " ")
+	}
+	switch {
+	case strings.HasPrefix(rest, "+ ") || rest == "+":
+		return '+'
+	case strings.HasPrefix(rest, "- ") || rest == "-":
+		return '-'
+	}
+	return ' '
+}
+
+// diffCounts tallies the added/removed rows of an editDiff body.
+func diffCounts(diff string) (added, removed int) {
+	for l := range strings.SplitSeq(diff, "\n") {
+		switch diffLineKind(l) {
+		case '+':
+			added++
+		case '-':
+			removed++
+		}
+	}
+	return added, removed
+}
+
+// diffSummary words the counts: "Added 7 lines, removed 7 lines".
+func diffSummary(added, removed int) string {
+	plural := func(n int) string {
+		if n == 1 {
+			return "line"
+		}
+		return "lines"
+	}
+	switch {
+	case added > 0 && removed > 0:
+		return fmt.Sprintf("Added %d %s, removed %d %s", added, plural(added), removed, plural(removed))
+	case added > 0:
+		return fmt.Sprintf("Added %d %s", added, plural(added))
+	case removed > 0:
+		return fmt.Sprintf("Removed %d %s", removed, plural(removed))
+	}
+	return "No lines changed"
+}
+
+// diffPreviewRows caps the collapsed diff body; expand shows everything.
+const diffPreviewRows = 30
+
+// renderDiffResult renders a diff-carrying tool result: the ⎿ summary, the
+// colored diff (capped unless expanded), then any trailing result text (LSP
+// diagnostics ride there — they must stay visible).
+func renderDiffResult(diff, rest string, expanded bool, width int) string {
+	added, removed := diffCounts(diff)
+	var b strings.Builder
+	b.WriteString(dimStyle.Render("  ⎿ ") + diffSummary(added, removed))
+	rows := strings.Split(diff, "\n")
+	shown := rows
+	if !expanded && len(rows) > diffPreviewRows {
+		shown = rows[:diffPreviewRows]
+	}
+	for _, l := range shown {
+		b.WriteString("\n" + renderDiffLine(l, width))
+	}
+	if n := len(rows) - len(shown); n > 0 {
+		b.WriteString(dimStyle.Render(fmt.Sprintf("\n    … +%d more (ctrl+e or click to expand)", n)))
+	}
+	// the text after the fence (e.g. LSP diagnostics); the first line before
+	// it ("Replaced 1 occurrence…") is bookkeeping the summary already covers
+	if trail := strings.TrimSpace(strings.Join(strings.Split(rest, "\n")[1:], "\n")); trail != "" {
+		b.WriteString("\n" + wrap(dimStyle.Render("  "+strings.ReplaceAll(trail, "\n", "\n  ")), width))
+	}
+	return b.String()
+}
+
+// renderDiffLine paints one editDiff row: added rows on a green band, removed
+// on red, context dim — the band runs the full width, the row truncates
+// rather than wraps (the raw result behind expand keeps the full text).
+func renderDiffLine(l string, width int) string {
+	row := ansi.Truncate("    "+l, max(width, 8), "…")
+	switch diffLineKind(l) {
+	case '+':
+		return diffAddStyle.Render(row + strings.Repeat(" ", max(width-lipgloss.Width(row), 0)))
+	case '-':
+		return diffDelStyle.Render(row + strings.Repeat(" ", max(width-lipgloss.Width(row), 0)))
+	}
+	return dimStyle.Render(row)
+}

--- a/internal/tui/toolrow_test.go
+++ b/internal/tui/toolrow_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/context-labs/whip/internal/llm"
+)
+
+func TestToolHeaderRowSubjects(t *testing.T) {
+	cases := []struct{ name, args, want string }{
+		{"edit", `{"path":"internal/tui/tui.go"}`, "Update(internal/tui/tui.go)"},
+		{"write", `{"path":"a.go","content":"x"}`, "Write(a.go)"},
+		{"read", `{"path":"a.go"}`, "Read(a.go)"},
+		{"bash", `{"command":"git  status"}`, "Bash(git status)"},
+		{"subagent", `{"description":"probe the repo","prompt":"p"}`, "Subagent(probe the repo)"},
+		{"subagent_steer", `{"id":"sub-3","message":"m"}`, "Steer(sub-3)"},
+	}
+	for _, c := range cases {
+		if got := ansi.Strip(toolHeaderRow(c.name, c.args, false)); got != "● "+c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, "● "+c.want)
+		}
+	}
+	if got := ansi.Strip(toolHeaderRow("bash", `{"command":"false"}`, true)); got != "● Bash(false)" {
+		t.Errorf("failed header: %q", got)
+	}
+}
+
+func TestExtractDiffAndCounts(t *testing.T) {
+	result := "Replaced 1 occurrence(s) in a.go\n```diff\n11   ctx\n12 - old\n12 + new\n13 + more\n14   ctx\n```\na.go:12: some diagnostic"
+	diff, rest := extractDiff(result)
+	if diff == "" || !strings.Contains(rest, "diagnostic") || strings.Contains(rest, "```") {
+		t.Fatalf("extract: diff=%q rest=%q", diff, rest)
+	}
+	add, del := diffCounts(diff)
+	if add != 2 || del != 1 {
+		t.Fatalf("counts: +%d -%d", add, del)
+	}
+	// unnumbered rows classify too, and the cap marker is context
+	if diffLineKind("- x") != '-' || diffLineKind("+ x") != '+' || diffLineKind("… +3 more lines") != ' ' {
+		t.Fatal("diffLineKind misclassifies")
+	}
+}
+
+// An edit result renders claude-style: header row keeps the path, the result
+// block shows the ⎿ summary, the colored diff, and the trailing diagnostics.
+func TestEditResultRendersDiff(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 24))
+	m.Update(toolStartMsg{id: "e1", name: "edit", args: `{"path":"a.go","old_string":"x","new_string":"y"}`})
+	m.Update(toolEndMsg{
+		id: "e1", name: "edit",
+		result: "Replaced 1 occurrence(s) in a.go\n```diff\n3   ctx\n4 - x\n4 + y\n```\na.go:4: unused variable",
+	})
+
+	run := m.blocks[len(m.blocks)-2]
+	if got := ansi.Strip(run.render(m.width)); got != "● Update(a.go)" {
+		t.Fatalf("run row: %q", got)
+	}
+	res := ansi.Strip(m.blocks[len(m.blocks)-1].render(m.width))
+	for _, want := range []string{"⎿ Added 1 line, removed 1 line", "4 - x", "4 + y", "unused variable"} {
+		if !strings.Contains(res, want) {
+			t.Fatalf("result block missing %q:\n%s", want, res)
+		}
+	}
+}
+
+// A long diff caps collapsed and expands in full.
+func TestDiffPreviewCapAndExpand(t *testing.T) {
+	var rows []string
+	for range diffPreviewRows + 5 {
+		rows = append(rows, "+ added")
+	}
+	b := block{kind: blockTool, text: "Wrote 1 bytes to a.go\n```diff\n" + strings.Join(rows, "\n") + "\n```"}
+	out := ansi.Strip(b.render(80))
+	if !strings.Contains(out, "… +5 more") {
+		t.Fatalf("collapsed diff should cap:\n%s", out)
+	}
+	b.expanded, b.stale = true, true
+	if out := ansi.Strip(b.render(80)); strings.Contains(out, "more (ctrl+e") {
+		t.Fatal("expanded diff should show everything")
+	}
+}
+
+// Resumed sessions re-render write/edit diffs from the stored tool results.
+func TestSeedTranscriptShowsDiffs(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 24))
+	call := llm.Message{Role: "assistant"}
+	var tc llm.ToolCall
+	tc.Function.Name = "edit"
+	tc.Function.Arguments = `{"path":"a.go"}`
+	call.ToolCalls = []llm.ToolCall{tc}
+	res := llm.Message{Role: "tool", Name: "edit", Content: "Replaced 1 occurrence(s) in a.go\n```diff\n4 - x\n4 + y\n```"}
+	m.seedTranscript([]llm.Message{call, res}, 1)
+
+	var joined strings.Builder
+	for i := range m.blocks {
+		joined.WriteString(ansi.Strip(m.blocks[i].render(m.width)) + "\n")
+	}
+	for _, want := range []string{"● Update(a.go)", "Added 1 line, removed 1 line", "4 + y"} {
+		if !strings.Contains(joined.String(), want) {
+			t.Fatalf("resumed transcript missing %q:\n%s", want, joined.String())
+		}
+	}
+}

--- a/internal/tui/toolrun_test.go
+++ b/internal/tui/toolrun_test.go
@@ -30,14 +30,24 @@ func TestToolRowCollapsesOnCompletion(t *testing.T) {
 	if row.toolRunning {
 		t.Fatal("completion should stop the run state")
 	}
-	if got := ansi.Strip(row.render(m.width)); strings.Count(got, "\n") > 0 {
+	got := ansi.Strip(row.render(m.width))
+	if strings.Count(got, "\n") > 0 {
 		t.Fatalf("completed row should collapse to one line, got %q", got)
 	}
-	if !row.toggle() {
-		t.Fatal("ctrl+e should expand the collapsed row")
+	// the collapse keeps the call visible, claude-style: Verb(subject)
+	if !strings.Contains(got, "Read(foo.go)") {
+		t.Fatalf("completed row should keep the call header, got %q", got)
 	}
-	if got := ansi.Strip(row.render(m.width)); !strings.Contains(got, "file body") {
-		t.Fatalf("expanded row should show the result, got %q", got)
+	// the result renders in the blockTool below, tied by the ⎿ marker
+	res := m.blocks[len(m.blocks)-1]
+	if res.kind != blockTool {
+		t.Fatal("the result block should follow the run row")
+	}
+	if got := ansi.Strip(res.render(m.width)); !strings.Contains(got, "⎿ file body") {
+		t.Fatalf("result block should show the result under ⎿, got %q", got)
+	}
+	if !row.toggle() {
+		t.Fatal("ctrl+e should still toggle the collapsed row")
 	}
 }
 
@@ -56,8 +66,12 @@ func TestToolRowFailureIsRed(t *testing.T) {
 	if run == nil || !run.toolFailed {
 		t.Fatal("a failed tool should mark the collapsed row")
 	}
-	if got := run.render(m.width); !strings.Contains(got, "31") && !strings.Contains(got, "Error") {
-		// errStyle is red (ansi 31) in most themes; at minimum the text shows
-		t.Fatalf("failed row should render the error, got %q", got)
+	if got := ansi.Strip(run.render(m.width)); !strings.Contains(got, "Bash(false)") {
+		t.Fatalf("failed row should keep the call header, got %q", got)
+	}
+	// the error text renders red in the result block below
+	res := m.blocks[len(m.blocks)-1]
+	if got := ansi.Strip(res.render(m.width)); !strings.Contains(got, "Error: exit status 1") {
+		t.Fatalf("result block should carry the error text, got %q", got)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -771,14 +771,20 @@ func (m *model) seedTranscript(msgs []llm.Message, base int) {
 				m.blocks = append(m.blocks, block{kind: blockAssistant, text: strings.TrimRight(msg.TextContent(), "\n")})
 			}
 			for _, tc := range msg.ToolCalls {
-				m.blocks = append(m.blocks, block{kind: blockText, text: toolStyle.Render("⚒ "+tc.Function.Name+" ") + dimStyle.Render(tc.Function.Arguments)})
+				m.blocks = append(m.blocks, block{kind: blockText, text: toolHeaderRow(tc.Function.Name, tc.Function.Arguments, false)})
 			}
 		case "tool":
 			// Synthetic results synthesized at load for interrupted calls get
-			// an inline row so the user sees what the model sees; real tool
-			// results stay folded under their assistant block.
-			if strings.HasPrefix(msg.Content, "Error: tool call interrupted") {
+			// an inline row so the user sees what the model sees; diffs from
+			// write/edit results re-render so a resumed transcript still shows
+			// what changed; other results stay folded under their call row.
+			switch {
+			case strings.HasPrefix(msg.Content, "Error: tool call interrupted"):
 				m.blocks = append(m.blocks, block{kind: blockText, text: errStyle.Render("⚒ "+msg.Name+" ") + dimStyle.Render("— interrupted: session ended before a result was recorded")})
+			default:
+				if diff, _ := extractDiff(strings.TrimRight(msg.Content, "\n")); diff != "" {
+					m.blocks = append(m.blocks, block{kind: blockTool, text: msg.Content})
+				}
 			}
 		}
 		for len(m.msgBlock) <= base+i {
@@ -1048,6 +1054,11 @@ type block struct {
 	toolID      string
 	toolRunning bool
 	toolFailed  bool
+	// toolName/toolArgs are the raw call, kept so the completed row can render
+	// the claude-style "Verb(subject)" header (the collapse must not lose the
+	// path/command the call was about).
+	toolName string
+	toolArgs string
 	// live is the latest partial-output snapshot for a running bash call,
 	// rendered under the verb line; cleared when the tool ends.
 	live string
@@ -1086,43 +1097,36 @@ func (b block) render(width int) string {
 		body := indentLines(renderMarkdown(b.text, w), 2)
 		return botStyle.Render("● ") + strings.TrimPrefix(body, "  ")
 	case blockTool:
+		// A result carrying a fenced diff (write/edit) renders claude-style:
+		// "⎿ Added N lines, removed M lines" over a colored, line-numbered
+		// diff — the change IS the collapsed view, not hidden behind expand.
+		if diff, rest := extractDiff(strings.TrimRight(b.text, "\n")); diff != "" {
+			return renderDiffResult(diff, rest, b.expanded, width)
+		}
 		lines := strings.Split(strings.TrimRight(b.text, "\n"), "\n")
+		lines[0] = "⎿ " + lines[0] // tie the result to its header row above
+		style := dimStyle
+		if strings.HasPrefix(b.text, "Error") {
+			style = errStyle // failures read at a glance, like the red header
+		}
 		if b.expanded || len(lines) <= toolPreviewLines {
-			return wrap(dimStyle.Render("  "+strings.Join(lines, "\n  ")), width)
+			return wrap(style.Render("  "+strings.Join(lines, "\n  ")), width)
 		}
 		preview := lines[:toolPreviewLines]
-		// An edit-style result carries a fenced diff at the tail; surface its
-		// -/+ lines in the collapsed preview so the change shows without
-		// expanding.
-		if strings.HasSuffix(lines[len(lines)-1], "```") {
-			var diffs []string
-			for _, l := range lines {
-				if strings.HasPrefix(l, "-") || strings.HasPrefix(l, "+") {
-					diffs = append(diffs, l)
-				}
-			}
-			if len(diffs) > 0 {
-				preview = append(preview, diffs...)
-			}
-		}
-		out := dimStyle.Render("  " + strings.Join(preview, "\n  "))
+		out := style.Render("  " + strings.Join(preview, "\n  "))
 		hint := fmt.Sprintf("\n  … +%d lines (ctrl+e or click to expand)", len(lines)-toolPreviewLines)
 		return wrap(out+dimStyle.Render(hint), width)
 	case blockToolRun:
 		// While running, the verb line shows in full with the live output
 		// tail under it. On completion the same block collapses in place to
-		// one line (red on failure); ctrl+e expands.
+		// its header row ("● Update(path)" — styles baked in by toolEndMsg).
 		if b.toolRunning || b.expanded {
 			if b.live != "" && b.toolRunning {
 				return wrap(b.text, width) + "\n" + wrap(dimStyle.Render("  "+b.live), width)
 			}
 			return wrap(b.text, width)
 		}
-		line := ansi.Truncate(b.text, width, "…")
-		if b.toolFailed {
-			return wrap(errStyle.Render(line), width)
-		}
-		return wrap(dimStyle.Render(line), width)
+		return ansi.Truncate(b.text, width, "…")
 	default:
 		return wrap(b.text, width)
 	}
@@ -1733,7 +1737,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// command being run is always fully visible). On toolEndMsg the same
 		// block collapses in place to one line.
 		row := toolStyle.Render("⚒ "+toolVerb(msg.name)+" ") + dimStyle.Render(args)
-		m.blocks = append(m.blocks, block{kind: blockToolRun, text: row, toolID: msg.id, toolRunning: true})
+		m.blocks = append(m.blocks, block{kind: blockToolRun, text: row, toolID: msg.id, toolRunning: true, toolName: msg.name, toolArgs: msg.args})
 		m.refreshVP()
 		return m, nil
 
@@ -1766,7 +1770,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				b.toolRunning = false
 				b.toolFailed = strings.HasPrefix(msg.result, "Error:")
 				b.live = ""
-				b.text = toolStyle.Render("⚒ "+msg.name+" ") + dimStyle.Render(firstLine(msg.result))
+				// the completed row keeps the call visible ("Update(path)",
+				// "Bash(cmd)") — the result renders in the blockTool below it
+				b.text = toolHeaderRow(msg.name, b.toolArgs, b.toolFailed)
 				b.stale = true
 				break
 			}


### PR DESCRIPTION
## What

Adopts claude-code's tool-output shape so writes are unmissable and their diffs are the first thing you see (per Abe's screenshots).

**Before**: a completed call collapsed to `⚒ edit Replaced 1 occurrence(s) in …` (the path/command vanished), followed by an all-dim preview block; `write` showed no diff at all.

**After**:

```
● Update(internal/tui/tui.go)
  ⎿ Added 7 lines, removed 7 lines
    1528 - // renders as the last dockRows rows above the input box…   ← red band
    1528 + // renders below the input as the last dockRows rows…       ← green band
    1529   // context                                                  ← dim
```

- **Headers keep the call visible**: `● Update(path)`, `● Write(path)`, `● Bash(cmd)`, `● Subagent(description)` — bold verb, amber dot, red on failure. Bash commands are never truncated at build time (whip's no-truncation rule); width handling stays at render time.
- **Diffs are the collapsed view** for write/edit: `⎿ Added N lines, removed M lines` summary, red/green full-width bands (adaptive light/dark), absolute line numbers, 30-row preview with expand. Trailing LSP diagnostics stay visible under the diff. Error results render red under `⎿`.
- **Tools emit richer results**: `editDiff` gains absolute line numbers (unnumbered for `replace_all`, where numbers would lie) and a 200-row cap; `write` now diffs overwrites against the old content (fresh files stay diff-free — the content is already in the call args).
- **Resume parity**: `seedTranscript` re-renders call headers and write/edit diffs from stored messages, so `--resume` shows what changed too.

## Tests

`toolrow_test.go` (header subjects, extract/counts/classify, colored diff render end-to-end, preview cap + expand, resumed diffs), `TestEditDiffLineNumbers`, `TestWriteToolDiffOnOverwrite`; existing tool-row tests updated to the new contract. `-race` green on tui/tools; lint 0 issues; coverage 90.6%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)