### PR TITLE
lint: adopt prealloc and goimports from awesome-go-linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - mirror # wrong bytes/strings mirror patterns
     - canonicalheader # http.Header.Get("...") with non-canonical header names
     - gocheckcompilerdirectives # malformed //go: directives silently ignored
+    - prealloc # slice grown in a range loop without a capacity hint
     # --- idiomatic modernization (Go 1.22+; go.mod is 1.27) ---
     - intrange # range-over-int instead of C-style for loops
     - modernize # min/max, slices/maps/strings helpers, range-over-func
@@ -94,6 +95,9 @@ linters:
     - promlinter # no Prometheus metrics in this codebase
     - protogetter # no protobuf
     - spancheck # no OpenTelemetry
+    # Considered from golangci/awesome-go-linters and rejected:
+    - nakedret # only fires on long functions; funlen/gocyclo already rejected, 0 hits anyway
+    - dogsled # 2 hits, both deliberate `_, _, _ =` drain calls in tests
 
   settings:
     errcheck:
@@ -126,7 +130,7 @@ linters:
       # tests legitimately use os.Setenv/os.MkdirTemp where t.* equivalents
       # are awkward; usetesting is on via staticcheck-adjacent checks anyway.
       - path: _test\.go
-        linters: [errcheck, gosec]
+        linters: [errcheck, gosec, prealloc]
       # internal/browser drives Chromium over a websocket; noctx/bodyclose
       # false-positive on chromedp/rod plumbing.
       - path: internal/browser
@@ -141,6 +145,7 @@ linters:
 formatters:
   enable:
     - gofumpt # superset of gofmt -s; matches `task check`'s gofmt -s gate
+    - goimports # unused imports + stdlib/local grouping; gofumpt's formatting is a superset of gofmt's, so no conflict
   settings:
     gofumpt:
       extra:

--- a/internal/computer/policy.go
+++ b/internal/computer/policy.go
@@ -86,7 +86,7 @@ func (p *Policy) Deny(app string) {
 func (p *Policy) Summary() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	var out []string
+	out := make([]string, 0, len(p.allow)+len(p.sessionAllow))
 	for a := range p.allow {
 		out = append(out, a)
 	}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -449,7 +449,7 @@ func (m *Manager) publish(key, uri string, version int, diags []Diagnostic) {
 func (m *Manager) Statuses() []Status {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var out []Status
+	out := make([]Status, 0, len(m.specs))
 	names := make([]string, 0, len(m.specs))
 	for n := range m.specs {
 		names = append(names, n)

--- a/internal/tui/complete.go
+++ b/internal/tui/complete.go
@@ -20,8 +20,9 @@ var commands = completionTable()
 // completionTable derives the tab-completion table from the registry, so a
 // command can never be dispatchable but uncompletable (or vice versa).
 func completionTable() []cand {
-	var out []cand
-	for _, e := range slashRegistry() {
+	reg := slashRegistry()
+	out := make([]cand, 0, len(reg))
+	for _, e := range reg {
 		out = append(out, cand{e.Name, e.Hint})
 	}
 	return out

--- a/internal/tui/context_doctor.go
+++ b/internal/tui/context_doctor.go
@@ -54,7 +54,7 @@ func (m *model) doctorReport() string {
 		dir  string // the skills dir the SKILL.md lives under
 		n    int
 	}
-	var per []sc
+	per := make([]sc, 0, len(sk))
 	for _, s := range sk {
 		n := len(s.Name) + min(len(s.Description), 300) + len(s.Path) + 8
 		per = append(per, sc{s.Name, filepath.Dir(filepath.Dir(s.Path)), n})

--- a/internal/tui/effort.go
+++ b/internal/tui/effort.go
@@ -1,8 +1,10 @@
 package tui
 
-import "slices"
+import (
+	"slices"
 
-import "github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/config"
+)
 
 // defaultEfforts are the fallback levels when the provider doesn't advertise
 // supported reasoning efforts; "" means off (parameter omitted from requests).

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -998,7 +998,7 @@ func buildAgent(cfg *config.Config, modelName, provName, sysPrompt string) (*age
 	}
 	if modelSupportsVision(cfg, modelName, apiID, config.LoadCatalogs(), provName) {
 		tools.ScreenshotSink = func(jpegs [][]byte) {
-			var parts []llm.ContentPart
+			parts := make([]llm.ContentPart, 0, len(jpegs))
 			for _, j := range jpegs {
 				parts = append(parts, llm.ImagePart("jpg", j))
 			}


### PR DESCRIPTION
## What

Triaged [golangci/awesome-go-linters](https://github.com/golangci/awesome-go-linters) against the repo's lint policy (low false-positive rate, correctness-first — the bar documented in `.golangci.yml`). Most of that list is historical: tools absorbed into staticcheck/govet, dead projects (gometalinter, gas→gosec, maligned, interfacer), or already in the `disable` list with measured reasons. Two earn their keep:

### Adopted

- **`prealloc`** (linter) — found 5 true positives in prod code: slices grown in a range loop without a capacity hint (`computer/policy.go`, `lsp/manager.go`, `tui/complete.go`, `tui/context_doctor.go`, `tui/tui.go`). All fixed with `make([]T, 0, len(...))`. Excluded in tests, where capacity hints are fixture noise. Zero false positives, so it meets the config's bar.
- **`goimports`** (formatter) — catches unused imports and duplicate/ungrouped import blocks that the gofumpt gate misses; immediately cleaned up a real wart in `internal/tui/effort.go` (two separate single-import blocks). gofumpt is a superset of gofmt's formatting, so the existing `gofmt -s` CI gate stays green.

### Measured and rejected (recorded in the `disable` list, per the config's convention)

- **`nakedret`** — 0 hits, and its target (long functions) is funlen/gocyclo territory, already rejected.
- **`dogsled`** — 2 hits, both deliberate `_, _, _ = c.Stream(...)` drain calls in tests; would need exclusions to stay silent, i.e. noise by definition here.

Not touched: the list's cloud-services section (GolangCI SaaS, GopherCI, CodeClimate…) is dead-or-redundant — the self-hosted CI gate already does the job for free.

## Verification

- `task lint` → 0 issues (includes the two new checks against the whole repo)
- `gofmt -s -l .` → clean
- `go test ./internal/computer ./internal/lsp ./internal/tui` → all pass