### PR TITLE
fix(tui): update queued tool-call row in place per args delta

### DIFF
--- a/internal/tui/toolcall_stream_test.go
+++ b/internal/tui/toolcall_stream_test.go
@@ -33,3 +33,42 @@ func TestToolCallQueuedRowReplacedOnStart(t *testing.T) {
 		t.Fatalf("after toolStart the row should be a running row, got kind=%v running=%v", last.kind, last.toolRunning)
 	}
 }
+
+// onToolCall fires per args delta with the cumulative snapshot; each delta for
+// the same tool-call id must update the queued row in place, not stack one row
+// per fragment (long commands would flood the transcript otherwise).
+func TestToolCallQueuedRowUpdatesInPlace(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 24))
+
+	deltas := []string{
+		`{"command": "`,
+		`{"command": "mkdir`,
+		`{"command": "mkdir -p`,
+		`{"command": "mkdir -p ~/.config/k9s"}`,
+	}
+	for _, args := range deltas {
+		m.Update(toolCallMsg{id: "c1", name: "bash", args: args})
+	}
+
+	var queued int
+	for _, b := range m.blocks {
+		if b.kind == blockToolQueued {
+			queued++
+		}
+	}
+	if queued != 1 {
+		t.Fatalf("expected 1 queued row after %d deltas, got %d", len(deltas), queued)
+	}
+	row := m.blocks[len(m.blocks)-1]
+	got := ansi.Strip(row.render(m.width))
+	if !strings.Contains(got, deltas[len(deltas)-1]) {
+		t.Fatalf("queued row should show the latest args snapshot, got %q", got)
+	}
+
+	// a second tool call streaming concurrently gets its own row
+	m.Update(toolCallMsg{id: "c2", name: "read", args: `{"path":"/tmp/x"}`})
+	if n := len(m.blocks); n != 2 {
+		t.Fatalf("a different tool-call id should append its own row, blocks=%d", n)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1707,9 +1707,18 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case toolCallMsg:
 		// a tool call still streaming from the model: show a dim queued row so
-		// the user sees it before execution starts. toolStartMsg swaps it for
-		// the live running row (matched by tool-call id).
+		// the user sees it before execution starts. onToolCall fires per args
+		// delta with the cumulative snapshot, so update the row for this id in
+		// place — appending per delta would stack one row per fragment.
+		// toolStartMsg swaps it for the live running row (matched by id).
 		row := dimStyle.Render("⋯ " + msg.name + " " + firstLine(msg.args))
+		for i := len(m.blocks) - 1; i >= 0; i-- {
+			if m.blocks[i].kind == blockToolQueued && m.blocks[i].toolID == msg.id {
+				m.blocks[i].text, m.blocks[i].stale = row, true
+				m.refreshVP()
+				return m, nil
+			}
+		}
 		m.blocks = append(m.blocks, block{kind: blockToolQueued, text: row, toolID: msg.id})
 		m.refreshVP()
 		return m, nil


### PR DESCRIPTION
## Problem

Since #34 (render tool calls as they stream), a long tool call — e.g. a multi-part bash command — floods the transcript with dozens of `⋯ bash {"command": "mkdir -p…` rows, each one fragment longer than the last.

**Cause:** `OnToolCall` fires per streaming args delta with the *cumulative* snapshot (`internal/llm/openai.go`), but the `toolCallMsg` handler **appended a new queued block on every delta**. One row per JSON fragment.

## Fix

`toolCallMsg` now scans for an existing `blockToolQueued` with the same tool-call id and **updates it in place** (marking the render cache stale) — the same pattern `toolOutputMsg` already uses for running rows. Only the first delta for an id appends; concurrent calls with different ids still get their own rows, and `toolStartMsg` still swaps the queued row for the running row.

## Test

`TestToolCallQueuedRowUpdatesInPlace` replays 4 cumulative deltas for one id, asserts exactly one queued row showing the latest snapshot, and asserts a second id gets its own row. Full suite green locally; gofmt -s / go vet / golangci-lint clean.