### PR TITLE
feat(tui): show last response's token counts in the status line

### DIFF
--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -205,6 +205,25 @@ func TestStatusLineHidesCostWithoutPricing(t *testing.T) {
 	}
 }
 
+// The last response's own token counts appear after the session spend, so the
+// size of the most recent response is readable at a glance.
+func TestStatusLineShowsLastResponse(t *testing.T) {
+	m := statusModel()
+	m.modelName = "m"
+	m.provName = "p"
+	m.agent.AddUsage(llm.Usage{PromptTokens: 20000, CompletionTokens: 900})
+	m.Update(usageMsg(llm.Usage{PromptTokens: 10000, CompletionTokens: 300}))
+
+	got := m.statusView()
+	if !strings.Contains(got, "last 10.0k/300 tok") {
+		t.Errorf("last response tokens should show in the status: %q", got)
+	}
+	// the session totals keep their own segment
+	if !strings.Contains(got, "20.0k/900 tok") {
+		t.Errorf("session spend segment should be unchanged: %q", got)
+	}
+}
+
 func TestFmtCost(t *testing.T) {
 	if got := fmtCost(0.0134); got != "$0.0134" {
 		t.Errorf("sub-dollar: %q", got)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -138,6 +138,10 @@ type model struct {
 	busy    bool
 	current string // in-flight partial assistant line
 	inMsg   bool   // "● " prefix already printed for this assistant segment
+	// lastResp is the token usage of the most recent API response (updated
+	// per streamed request via usageMsg); the status line shows it after the
+	// session spend as "last in(cached)/out tok".
+	lastResp llm.Usage
 
 	showThinking bool   // ctrl+o: render reasoning tokens
 	curThink     string // in-flight partial reasoning line
@@ -1277,6 +1281,15 @@ func fmtTok(n int) string {
 	}
 }
 
+// fmtUsage renders cumulative or per-request usage as the status line's
+// "in(cached)/out tok" shape; the cached parens appear only when reported.
+func fmtUsage(u llm.Usage) string {
+	if c := u.Cached(); c > 0 {
+		return fmt.Sprintf("%s(%s)/%s tok", fmtTok(u.PromptTokens), fmtTok(c), fmtTok(u.CompletionTokens))
+	}
+	return fmt.Sprintf("%s/%s tok", fmtTok(u.PromptTokens), fmtTok(u.CompletionTokens))
+}
+
 // fmtCost renders a USD spend compactly: 4 decimals under a dollar (where the
 // cents would hide the signal), 2 at or above.
 func fmtCost(d float64) string {
@@ -2012,7 +2025,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case usageMsg:
 		// Turn already folds usage into the agent's session totals (header
-		// reads those); this message just forces a redraw mid-stream.
+		// reads those); keep the per-request figure — the status line shows
+		// it as "last …" — and force a redraw mid-stream.
+		m.lastResp = llm.Usage(msg)
 		return m, nil
 
 	case quitArmMsg:
@@ -3364,6 +3379,7 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 		}
 		m.agent.Messages = m.agent.Messages[:1] // keep system prompt
 		m.agent.ResetUsage()                    // zero the status line's spend counters
+		m.lastResp = llm.Usage{}                // the cleared history has no last response
 		m.blocks = nil
 		m.msgBlock = nil
 		m.future = nil   // no redo across a cleared conversation
@@ -3893,12 +3909,15 @@ func (m *model) statusView() string {
 		model += " (" + e + ")"
 	}
 	u := m.agent.Usage()
-	spend := fmt.Sprintf("%s/%s tok", fmtTok(u.PromptTokens), fmtTok(u.CompletionTokens))
-	if c := u.Cached(); c > 0 {
-		spend = fmt.Sprintf("%s(%s)/%s tok", fmtTok(u.PromptTokens), fmtTok(c), fmtTok(u.CompletionTokens))
-	}
+	spend := fmtUsage(u)
 	if cost, ok := m.sessionCost(); ok {
 		spend += " · " + fmtCost(cost)
+	}
+	// The last response's own counts, so the size of the most recent API call
+	// (its output especially) is readable without doing mental subtraction
+	// from the session totals. Hidden until the first response arrives.
+	if last := m.lastResp; last.PromptTokens > 0 || last.CompletionTokens > 0 {
+		spend += " · last " + fmtUsage(last)
 	}
 	// The fixed segments (model/provider/spend) are the data that matters; the
 	// cwd is what yields. Old code truncated the whole assembled line from the


### PR DESCRIPTION
Adds a `last <in>(<cached>)/<out> tok` segment to the bottom bar, to the right of the session cost:

```
…/loopy   kimi-k3 (high)   inference   45.2k(40.0k)/3.1k tok · $0.0134 · last 21.4k(20.0k)/512 tok
```

**How** — `usageMsg` already arrived per streamed request (`agent.Turn` fires `OnUsage` after every round, including tool-loop iterations and compaction calls) but was discarded in `Update` after forcing a redraw. It's now kept in `model.lastResp`, so `last` tracks the most recent API call and refreshes mid-turn on every round.

- Hidden entirely until the first response arrives; cleared on `/clear` alongside the spend counters.
- The `in(cached)/out tok` formatting is extracted into a shared `fmtUsage` helper so the session and last-response segments can't drift apart.
- New test: `TestStatusLineShowsLastResponse` covers the render (last segment present, session segment unchanged).