### PR TITLE
feat(tui): /model-for-session switches model without persisting the default

### DIFF
--- a/docs/models-providers.md
+++ b/docs/models-providers.md
@@ -32,6 +32,9 @@ flowchart LR
   (`-p` / `/model <name> <provider>`) to disambiguate.
 - Newly announced models appear in the `/model` picker dimmed, marked
   `(new)`, after `/model refresh` or the next TTL cycle.
+- `/model` persists the switch as the saved default. `/model-for-session`
+  switches the active model identically but leaves the saved default
+  untouched, so the next launch still opens on the configured model.
 
 ## Key resolution
 

--- a/internal/tui/auth_cmd_test.go
+++ b/internal/tui/auth_cmd_test.go
@@ -276,7 +276,7 @@ func TestAuthMakesCatalogModelsPickable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.openModelPicker()
+	m.openModelPicker(false)
 	if m.mpicker == nil {
 		t.Fatal("picker should open on a non-empty catalog")
 	}

--- a/internal/tui/complete.go
+++ b/internal/tui/complete.go
@@ -48,9 +48,9 @@ func completions(val string, models, providers, skillCands, efforts []cand) (hea
 	switch {
 	case strings.HasPrefix(val, "/") && len(fields) == 0:
 		cands = filterPrefix(commands, token)
-	case len(fields) == 1 && fields[0] == "/model":
+	case len(fields) == 1 && (fields[0] == "/model" || fields[0] == "/model-for-session"):
 		cands = filterFuzzy(append([]cand{{"refresh", "refetch provider model catalogs"}}, models...), token)
-	case len(fields) == 2 && fields[0] == "/model" && fields[1] != "refresh":
+	case len(fields) == 2 && (fields[0] == "/model" || fields[0] == "/model-for-session") && fields[1] != "refresh":
 		cands = filterFuzzy(providers, token)
 	case len(fields) == 1 && fields[0] == "/effort":
 		cands = filterPrefix(efforts, token)

--- a/internal/tui/complete_test.go
+++ b/internal/tui/complete_test.go
@@ -20,7 +20,7 @@ func TestCompletions(t *testing.T) {
 
 	// slash commands
 	head, cs := completions("/m", models, provs, nil, nil)
-	if head != "" || len(cs) != 5 || cs[0].Text != "/mcp" || cs[1].Text != "/me" || cs[2].Text != "/memory" || cs[3].Text != "/model" || cs[4].Text != "/mouse" {
+	if head != "" || len(cs) != 6 || cs[0].Text != "/mcp" || cs[1].Text != "/me" || cs[2].Text != "/memory" || cs[3].Text != "/model" || cs[4].Text != "/model-for-session" || cs[5].Text != "/mouse" {
 		t.Fatalf("command completion: %q %v", head, texts(cs))
 	}
 	// every slash command in the switch must be completable — the "I can't

--- a/internal/tui/menu_key_test.go
+++ b/internal/tui/menu_key_test.go
@@ -38,14 +38,14 @@ func TestTabCompletesSkillName(t *testing.T) {
 }
 
 // Tab cycles through candidates with preview: each press inserts the next
-// candidate, wrapping at both ends. ("/e" matches /effort only, so use /m:
-// /mcp, /model, /mouse.)
+// candidate, wrapping at both ends. ("/e" matches /effort only, so use /mode:
+// /model, /model-for-session.)
 func TestTabCyclesWithPreview(t *testing.T) {
 	m := modelCmdModel()
-	m = typeStr(t, m, "/mo") // /model, /mouse — two candidates, deterministic order
+	m = typeStr(t, m, "/mode") // /model, /model-for-session — two candidates, deterministic order
 	m = pressKey(m, tea.KeyTab)
 	first := m.input.Value()
-	if first != "/model" && first != "/mouse" {
+	if first != "/model" && first != "/model-for-session" {
 		t.Fatalf("tab should preview a candidate, got %q", first)
 	}
 	m = pressKey(m, tea.KeyTab)

--- a/internal/tui/model_cmd_test.go
+++ b/internal/tui/model_cmd_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -77,6 +78,73 @@ func TestModelPaletteEnterOpensPicker(t *testing.T) {
 	}
 	if len(pp.items) == 0 {
 		t.Fatal("model panel should list the configured routes")
+	}
+}
+
+// /model-for-session switches the active model but leaves the saved default
+// untouched, so the next launch still opens on the configured model.
+// (compactCmdModel: switchModel carries history, so the fixture needs a real
+// agent — modelCmdModel's bare &agent.Agent{} has no system prompt to keep.)
+func TestModelForSessionDoesNotPersist(t *testing.T) {
+	m := compactCmdModel()
+	m.command("/model-for-session glm-5.2-fast")
+	if m.modelName != "glm-5.2-fast" {
+		t.Fatalf("session switch should change the active model, got %q", m.modelName)
+	}
+	if m.cfg.DefaultModel != "kimi-k3-fast" {
+		t.Errorf("saved default must not move, got %q", m.cfg.DefaultModel)
+	}
+	last := m.blocks[len(m.blocks)-1].text
+	if !strings.Contains(last, "this session only") {
+		t.Errorf("session-only switch should say so, got %q", last)
+	}
+}
+
+// The same switch through /model persists as the new default.
+func TestModelPersists(t *testing.T) {
+	m := compactCmdModel()
+	m.command("/model glm-5.2-fast")
+	if m.cfg.DefaultModel != "glm-5.2-fast" {
+		t.Fatalf("/model should store the switch as the default, got %q", m.cfg.DefaultModel)
+	}
+}
+
+// Bare /model-for-session opens the picker flagged session-only, and a picker
+// selection still doesn't persist.
+func TestModelForSessionPicker(t *testing.T) {
+	m := compactCmdModel()
+	m.command("/model-for-session")
+	if m.mpicker == nil {
+		t.Fatal("bare /model-for-session should open the picker")
+	}
+	if !m.mpicker.sessionOnly {
+		t.Fatal("picker should be flagged session-only")
+	}
+	p := m.mpicker
+	p.idx = 0 // items are sorted; glm-5.2-fast precedes kimi-k3-fast
+	if p.items[p.idx].model != "glm-5.2-fast" {
+		p.idx = 1
+	}
+	tm, _ := m.modelPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = tm.(*model)
+	if m.modelName != "glm-5.2-fast" {
+		t.Fatalf("picker enter should switch the active model, got %q", m.modelName)
+	}
+	if m.cfg.DefaultModel != "kimi-k3-fast" {
+		t.Errorf("session-only picker must not move the saved default, got %q", m.cfg.DefaultModel)
+	}
+}
+
+// /model-for-session completes model names like /model.
+func TestModelForSessionCompletion(t *testing.T) {
+	m := modelCmdModel()
+	_, cs := completions("/model-for-session glm", m.modelCands(), m.providerCands(), nil, nil)
+	if len(cs) != 1 || cs[0].Text != "glm-5.2-fast" {
+		t.Fatalf("model names should complete under /model-for-session, got %+v", cs)
+	}
+	_, cs = completions("/model-for-session glm-5.2-fast inf", m.modelCands(), m.providerCands(), nil, nil)
+	if len(cs) != 1 || cs[0].Text != "inference" {
+		t.Fatalf("providers should complete as the second arg, got %+v", cs)
 	}
 }
 

--- a/internal/tui/modelpicker.go
+++ b/internal/tui/modelpicker.go
@@ -32,6 +32,9 @@ type modelPicker struct {
 	query      string      // type-to-filter text
 	idx        int
 	staleHints []string // providers whose cached catalog is past its TTL
+	// sessionOnly marks a picker opened by /model-for-session: the selection
+	// switches the model without persisting it as the new default.
+	sessionOnly bool
 }
 
 // view returns the items the picker is currently showing.
@@ -193,13 +196,13 @@ func staleCatalogs(cfg *config.Config, cats map[string]config.Catalog) []string 
 	return out
 }
 
-func (m *model) openModelPicker() {
+func (m *model) openModelPicker(sessionOnly bool) {
 	items := buildModelItems(m.cfg)
 	if len(items) == 0 {
 		m.append(errStyle.Render("no models configured in ~/.whip/config.json"))
 		return
 	}
-	mp := &modelPicker{items: items, staleHints: staleCatalogs(m.cfg, config.LoadCatalogs())}
+	mp := &modelPicker{items: items, staleHints: staleCatalogs(m.cfg, config.LoadCatalogs()), sessionOnly: sessionOnly}
 	for i, it := range items { // start on the active route
 		if it.model == m.modelName && it.provider == m.provName {
 			mp.idx = i
@@ -234,8 +237,9 @@ func (m *model) modelPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		it := v[p.idx]
+		sessionOnly := p.sessionOnly
 		m.mpicker = nil
-		m.switchModel(it.model, it.provider)
+		m.switchModel(it.model, it.provider, !sessionOnly)
 	case tea.KeyRunes, tea.KeySpace:
 		p.query += string(msg.Runes)
 		p.applyQuery()

--- a/internal/tui/modelpicker_catalog_test.go
+++ b/internal/tui/modelpicker_catalog_test.go
@@ -69,7 +69,7 @@ func TestModelPickerViewMarksCatalogAndStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := &model{cfg: cfg, modelName: "kimi-k3-fast", provName: "inference"}
-	m.openModelPicker()
+	m.openModelPicker(false)
 	if m.mpicker == nil {
 		t.Fatal("picker should open")
 	}
@@ -99,7 +99,7 @@ func TestModelPickerSelectsCatalogRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := compactCmdModel() // cfg providers carry an API key; switchModel needs it
-	m.openModelPicker()
+	m.openModelPicker(false)
 	p := m.mpicker
 	// walk to the catalog route
 	for p.idx < len(p.items)-1 && !p.items[p.idx].fromCatalog {

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -608,7 +608,7 @@ func (m *model) panelKey(msg tea.KeyMsg, pp *ppanel) (tea.Model, tea.Cmd) {
 			m.previewModel(pp.items[pp.idx])
 		case tea.KeyEnter:
 			it := pp.items[pp.idx]
-			m.switchModel(it.model, it.provider)
+			m.switchModel(it.model, it.provider, true)
 			pop()
 		}
 

--- a/internal/tui/registry.go
+++ b/internal/tui/registry.go
@@ -39,6 +39,7 @@ var registry = []registryEntry{
 	{Name: "/me", Hint: "— edit your standing instructions (~/.whip/me.md) in $EDITOR", Category: "Agent"},
 	{Name: "/memory", Hint: "[n] [session] — saved memories: list what's injected each turn, mark entry n done", Category: "Session"},
 	{Name: "/model", Hint: "<name> [provider] — switch model (any provider-catalog model works; refresh pulls new announcements)", Category: "Agent"},
+	{Name: "/model-for-session", Hint: "<name> [provider] — switch model for this session only (doesn't change the saved default)", Category: "Agent"},
 	{Name: "/mouse", Hint: "— toggle mouse capture (on = wheel scroll + clicks, drag to copy)", Category: "Display"},
 	{Name: "/pwd", Hint: "— print working directory", Category: "Session"},
 	{Name: "/quit", Hint: "— exit", Keybind: "ctrl+c ctrl+c", Category: "App"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2809,7 +2809,9 @@ func (m *model) tasksView() string {
 }
 
 // switchModel rebuilds the agent on a new model/provider, carrying history.
-func (m *model) switchModel(name, prov string) {
+// persist=false (/model-for-session) leaves the saved default untouched, so the
+// next whip launch still opens on the configured model.
+func (m *model) switchModel(name, prov string, persist bool) {
 	ag, mn, pn, err := buildAgent(m.cfg, name, prov, m.sysPrompt)
 	if err != nil {
 		m.append(errStyle.Render(err.Error()))
@@ -2825,11 +2827,15 @@ func (m *model) switchModel(name, prov string) {
 	if !slices.Contains(m.effortsFor(), ag.Effort) {
 		m.resetEffort("") // the new model doesn't support the current level
 	}
-	m.cfg.DefaultModel, m.cfg.DefaultProvider = mn, pn // store the switch as the new default
-	if err := m.cfg.Save(); err != nil {
-		m.append(errStyle.Render("config save failed: " + err.Error()))
+	if persist {
+		m.cfg.DefaultModel, m.cfg.DefaultProvider = mn, pn // store the switch as the new default
+		if err := m.cfg.Save(); err != nil {
+			m.append(errStyle.Render("config save failed: " + err.Error()))
+		}
+		m.append(dimStyle.Render("→ " + mn + " @ " + pn))
+	} else {
+		m.append(dimStyle.Render("→ " + mn + " @ " + pn + " (this session only)"))
 	}
-	m.append(dimStyle.Render("→ " + mn + " @ " + pn))
 }
 
 // pickerKey handles keys while the /resume browser is open.
@@ -3624,9 +3630,10 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 		m.append(dimStyle.Render(helpText()))
 	case "/auth":
 		m.authCommand(fields[1:])
-	case "/model":
+	case "/model", "/model-for-session":
+		persist := fields[0] == "/model"
 		if len(fields) < 2 {
-			m.openModelPicker()
+			m.openModelPicker(!persist)
 			break
 		}
 		if fields[1] == "refresh" {
@@ -3653,7 +3660,7 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 			m.append(errStyle.Render("unknown model " + name))
 			return m, nil
 		}
-		m.switchModel(resolved, prov)
+		m.switchModel(resolved, prov, persist)
 	default:
 		m.append(errStyle.Render("unknown command " + fields[0]))
 	}


### PR DESCRIPTION
## What

`/model` stores the switch as the saved default (`cfg.DefaultModel` + `Save`), so a one-off experiment quietly becomes every future session's model. `/model-for-session` runs the identical switch — direct arg with fuzzy resolve, or bare for the interactive picker — but skips the config write, so the next launch still opens on the configured model.

```
/model-for-session glm-5.2-fast   # → glm-5.2-fast @ inference (this session only)
/model-for-session                # opens the picker, flagged session-only
```

## How

- `switchModel` gains a `persist` param; the `modelPicker` carries a `sessionOnly` flag so a picker opened by `/model-for-session` doesn't persist on enter
- Registry entry makes `/help`, tab completion, and the palette pick it up automatically; model/provider/`refresh` arg completion mirrors `/model`
- The ctrl+p Model panel keeps persisting (unchanged behavior)

## Tests

- `TestModelForSessionDoesNotPersist` — active model switches, `cfg.DefaultModel` untouched, transcript says "this session only"
- `TestModelPersists` — `/model` still stores the new default (no regression)
- `TestModelForSessionPicker` — bare command opens a session-flagged picker; enter switches without persisting
- `TestModelForSessionCompletion` — model + provider arg completion
- Fixed two ordering-sensitive tests (`TestCompletions`, `TestTabCyclesWithPreview`) that hardcoded the `/m…` command set

Full `go test ./...`, `go vet`, `gofmt -s`, and `golangci-lint` pass locally.