### PR TITLE
feat(tui): /fork mid-turn — copy now, switch at turn end

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -400,10 +400,17 @@ inline name prompt prefilled with `<title> (fork #N)` (`Store.ForkTitle`
 increments past existing forks and unwraps nested suffixes, opencode's
 `getForkedTitle`). **`f` in the rewind picker** forks from the selected
 message instead — one picker, two destinations. Forking while rewound pulls
-the redo stack up to the picked point into the copy. **`/rename [title]`**
-retitles the current session (`Store.SetTitle`); bare opens the same inline
-prompt prefilled with the current title. Both prompts stash and restore any
-in-progress draft. All three refuse to run mid-turn. Palette entries:
+the redo stack up to the picked point into the copy. **Mid-turn** (`busyFork`)
+the copy of the stored rows lands immediately — the confirmation prints the
+`whip --resume <id>` line so the clone can be opened in another whip process
+right away — and the switch defers to `turnDoneMsg` (`pendingForkID` →
+`switchToForked`), since the turn goroutine owns `Agent.Messages` and the
+session id until then; the original keeps the finished turn, queued messages
+are dropped (they named the old conversation), and the goal carries over via
+the copy's stamped row. **`/rename [title]`** retitles the current session
+(`Store.SetTitle`); bare opens the same inline prompt prefilled with the
+current title. Both prompts stash and restore any in-progress draft. /rename
+refuses to run mid-turn; /fork never queues. Palette entries:
 "Rewind conversation", "Fork session", "Rename session" under Session.
 
 Tests: `rewind_test.go` — double-esc opens/cancels, busy esc still
@@ -412,7 +419,8 @@ partial-rewind DB prefix, tool-call-pair safety, stale esc-arm across modal
 dismiss, draft preservation, resume-after-rewind. `fork_test.go` (session) —
 prefix/full copy, fork-title numbering, rename, DeleteFrom. `fork_test.go`
 (tui) — fork with arg, bare prompt suggestion + cancel, fork from the picker,
-fork while rewound into the redo stack, rename both paths.
+fork while rewound into the redo stack, busy fork (immediate copy + deferred
+switch + double-fork refusal + nothing-persisted case), rename both paths.
 
 ## MCP
 

--- a/internal/tui/fork.go
+++ b/internal/tui/fork.go
@@ -2,13 +2,21 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/context-labs/whip/internal/agent"
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools/bashrun"
 )
 
 // /fork copies the conversation (whole, or up to a rewind-picker selection)
 // into a NEW session with a chosen title and switches to it — "copy
 // conversation with new name"; the original stays untouched and /resume-able
 // (opencode's Session.fork, packages/opencode/src/session/session.ts:691).
+// Mid-turn the copy lands immediately and the switch defers to turn end
+// (busyFork/pendingForkID): the point of forking while the model works is
+// that the copy is resume-able in another whip process right away.
 // /rename retitles the current session. Both share one inline prompt: the
 // input box is repurposed with a prefixed label, enter commits, esc cancels.
 
@@ -83,8 +91,14 @@ func (m *model) openForkPrompt(cut int, picker bool, suggest ...string) {
 }
 
 // fork copies the history through conversation index cut (inclusive) into a
-// new session and switches to it.
+// new session. Mid-turn it hands off to busyFork (the turn goroutine owns
+// Agent.Messages and the session id, so only the copy happens now); idle it
+// switches to the copy immediately.
 func (m *model) fork(cut int, title string) {
+	if m.busy {
+		m.busyFork(title)
+		return
+	}
 	title = strings.TrimSpace(title)
 	if title == "" {
 		m.append(errStyle.Render("fork needs a name"))
@@ -126,6 +140,95 @@ func (m *model) fork(cut int, title string) {
 	m.saved = cut + 1
 	m.rebuildTranscript()
 	m.append(dimStyle.Render(fmt.Sprintf("⑂ forked %q → %q (%s) — the original is under /resume", oldTitle, title, newID)))
+}
+
+// busyFork copies the stored conversation into a new session NOW (the reason
+// /fork runs mid-turn: the copy is immediately resumable in another whip
+// process — whip --resume <id>) and marks it for the switch, which turnDoneMsg
+// performs once the turn goroutine stops owning Agent.Messages, the session
+// id, and the workspace snapshots. It touches none of those.
+func (m *model) busyFork(title string) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		m.append(errStyle.Render("fork needs a name"))
+		return
+	}
+	if m.sessionID == "" { // nothing persisted yet — nothing to copy
+		m.append(dimStyle.Render("(nothing to fork yet — the first turn hasn't been saved; /fork again after this turn)"))
+		return
+	}
+	if m.pendingForkID != "" {
+		m.append(dimStyle.Render("(already forked — switching to the copy when this turn ends)"))
+		return
+	}
+	oldTitle := m.sessionID
+	if meta, _, err := m.store.Load(m.sessionID); err == nil && meta.Title != "" {
+		oldTitle = meta.Title
+	}
+	// Full copy: the stored rows run through the last completed exchange
+	// (mid-turn appends live only in the turn goroutine's Messages until the
+	// turn persists), so no cut applies.
+	newID, err := m.store.Fork(m.sessionID, 1<<30, title)
+	if err != nil {
+		m.append(errStyle.Render("fork failed: " + err.Error()))
+		return
+	}
+	m.pendingForkID = newID
+	m.append(dimStyle.Render(fmt.Sprintf("⑂ forked %q → %q (%s) — open it in another session now: whip --resume %s · whip switches to the copy when this turn ends", oldTitle, title, newID, newID)))
+}
+
+// switchToForked moves the live conversation onto the fork created mid-turn.
+// The turn has ended (final persist and snapshot bookkeeping are done), so
+// rebuilding the agent from the copy is safe; the original keeps the
+// finished turn and survives untouched under /resume. Modeled on resume(),
+// minus cross-session restores that don't cross a fork (task dock, todos,
+// snapshots stay; the fork's workspace IS the current one).
+func (m *model) switchToForked(id string) {
+	meta, msgs, err := m.store.Load(id)
+	if err != nil {
+		m.append(errStyle.Render("fork switch failed: " + err.Error()))
+		return
+	}
+	m.flushThink()
+	m.flushCurrent()
+	m.queue, m.queueSel = nil, -1 // queued lines name the old conversation
+	m.future = nil                // the copy's branch point is its tail; no redo across
+	oldID := m.sessionID
+	// Prefer the session's model/provider; fall back to the current agent.
+	if ag, mn, pn, err := buildAgent(m.cfg, meta.Model, meta.Provider, m.sysPrompt); err == nil {
+		m.agent, m.modelName, m.provName = ag, mn, pn
+	} else {
+		m.agent = agent.New(m.agent.Client, m.agent.Model, m.agent.MaxTokens, m.sysPrompt)
+		m.agent.ModelName, m.agent.Provider = m.modelName, m.provName
+		m.agent.ContextLimit = m.contextLimitFor(m.provName, m.agent.Model)
+	}
+	m.applyCompactModel()
+	m.applyTaskModel()
+	m.agent.CompactThreshold = compactThresholdFor(m.cfg)
+	m.wireTasks() // also publishes the new session id for task records
+	// The fork's effort column carried over from the source; "" means the row
+	// pre-dates per-session effort — keep the agent's current default then.
+	if meta.Effort != "" && slices.Contains(m.effortsFor(), meta.Effort) {
+		m.agent.Effort = meta.Effort
+	}
+	if meta.UsageIn > 0 || meta.UsageOut > 0 {
+		u := llm.Usage{PromptTokens: meta.UsageIn, CompletionTokens: meta.UsageOut}
+		if meta.UsageCached > 0 {
+			u.PromptTokensDetails = &struct {
+				CachedTokens int `json:"cached_tokens"`
+			}{CachedTokens: meta.UsageCached}
+		}
+		m.agent.SetUsage(u)
+	}
+	m.sessionID = meta.ID
+	bashrun.SetMarkers(meta.ID, m.agent.Model)
+	m.agent.Messages = append(m.agent.Messages, msgs...)
+	m.saved = len(m.agent.Messages)
+	m.goal = meta.Goal
+	m.goalRounds = 0
+	m.titled = true // the fork was named at creation; no auto-title attempt
+	m.rebuildTranscript()
+	m.append(dimStyle.Render(fmt.Sprintf("⑂ switched to the fork %q (%s) — the original %s kept the finished turn and is under /resume", meta.Title, meta.ID, oldID)))
 }
 
 // renameCommand implements /rename [title].

--- a/internal/tui/fork_test.go
+++ b/internal/tui/fork_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/context-labs/whip/internal/agent"
+	"github.com/context-labs/whip/internal/config"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/session"
 )
@@ -24,6 +26,17 @@ func forkModel(t *testing.T) *model {
 		agent:    &agent.Agent{},
 		store:    st,
 		queueSel: -1,
+		// routable config: the busy-fork turn-end switch rebuilds the agent
+		// through buildAgent (model "m" on provider "p", matching the session
+		// rows Create/Save stamp below)
+		cfg: &config.Config{
+			DefaultModel:    "m",
+			DefaultProvider: "p",
+			Providers:       map[string]config.Provider{"p": {BaseURL: "https://x", APIKey: "k"}},
+			Models:          map[string]config.Model{"m": {Providers: []string{"p"}}},
+		},
+		modelName: "m",
+		provName:  "p",
 	}
 	m.width = 80
 	m.input.SetWidth(m.width - 2)
@@ -163,6 +176,239 @@ func TestForkWhileRewoundIntoFuture(t *testing.T) {
 	// point with no forward tail
 	if len(m.future) != 0 {
 		t.Fatalf("remaining future: %+v", m.future)
+	}
+}
+
+// TestForkWhileBusyCopiesImmediatelyAndDefersSwitch covers the reported
+// behavior: mid-turn /fork must create the copy right away (resumable from
+// another whip process) instead of queueing, then switch to it at turn end.
+func TestForkWhileBusyCopiesImmediatelyAndDefersSwitch(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+	origID := m.sessionID
+
+	m.command("/fork experiment")
+
+	// the copy exists NOW, with the full stored conversation and the title
+	if m.pendingForkID == "" {
+		t.Fatalf("busy fork should mark a pending switch; blocks=%v", m.blocks)
+	}
+	meta, msgs, err := m.store.Load(m.pendingForkID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Title != "experiment" || meta.ForkedFrom != origID || len(msgs) != 4 {
+		t.Fatalf("copy: %+v (%d msgs)", meta, len(msgs))
+	}
+	// nothing about the live window moved yet
+	if m.sessionID != origID || len(m.agent.Messages) != 5 {
+		t.Fatalf("live session should be untouched until turn end: %s (%d msgs)", m.sessionID, len(m.agent.Messages))
+	}
+	if !strings.Contains(tailBlock(m), "whip --resume "+m.pendingForkID) {
+		t.Fatalf("the confirmation should tell the user how to open the copy: %q", tailBlock(m))
+	}
+	// a second mid-turn fork is refused — one pending switch at a time
+	m.command("/fork another")
+	meta2, _, _ := m.store.Load(m.pendingForkID)
+	if meta2.Title != "experiment" {
+		t.Fatalf("second fork should not replace the pending one: %+v", meta2)
+	}
+	if recent, _ := m.store.Recent(10); len(recent) != 2 {
+		t.Fatalf("the refused fork must not create a session: %+v", recent)
+	}
+
+	// turn end: whip moves onto the copy
+	tm, _ := m.Update(turnDoneMsg{})
+	m = tm.(*model)
+	if m.busy {
+		t.Fatal("turnDoneMsg should clear busy")
+	}
+	if m.pendingForkID != "" || m.sessionID == origID {
+		t.Fatalf("switch should have happened: pending=%q session=%q", m.pendingForkID, m.sessionID)
+	}
+	meta, msgs, err = m.store.Load(m.sessionID)
+	if err != nil || meta.Title != "experiment" {
+		t.Fatalf("live session should be the fork: %+v %v", meta, err)
+	}
+	if len(m.agent.Messages) != 5 || len(msgs) != 4 {
+		t.Fatalf("the fork's conversation should be live: msgs=%d stored=%d", len(m.agent.Messages), len(msgs))
+	}
+	// the original kept its rows — the switch didn't take them away
+	if _, origMsgs, err := m.store.Load(origID); err != nil || len(origMsgs) != 4 {
+		t.Fatalf("original should survive untouched: %v %d", err, len(origMsgs))
+	}
+	if !strings.Contains(tailBlock(m), "⑂ switched to the fork") {
+		t.Fatalf("switch confirmation: %q", tailBlock(m))
+	}
+}
+
+// TestForkWhileBusyBareOpensPrompt: bare /fork mid-turn still names the copy
+// inline; enter commits and the copy lands immediately.
+func TestForkWhileBusyBareOpensPrompt(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+
+	m.command("/fork")
+	if m.namePrompt == nil || m.input.Value() != "q1 (fork #1)" {
+		t.Fatalf("prompt: %+v input=%q", m.namePrompt, m.input.Value())
+	}
+	m.input.SetValue("mid-turn")
+	press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.namePrompt != nil {
+		t.Fatal("enter should close the prompt")
+	}
+	if m.pendingForkID == "" {
+		t.Fatal("the committed name should fork immediately, even while busy")
+	}
+	meta, msgs, err := m.store.Load(m.pendingForkID)
+	if err != nil || meta.Title != "mid-turn" || len(msgs) != 4 {
+		t.Fatalf("copy: %+v %v (%d msgs)", meta, err, len(msgs))
+	}
+}
+
+// TestForkWhileBusyWithoutStoredSession: the very first turn hasn't persisted
+// anything, so there is nothing to copy — report it instead of forking air.
+func TestForkWhileBusyWithoutStoredSession(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+	m.sessionID = "" // simulate the never-persisted first turn
+
+	m.command("/fork too-early")
+	if m.pendingForkID != "" {
+		t.Fatal("nothing stored yet — no fork should land")
+	}
+	if !strings.Contains(tailBlock(m), "nothing to fork yet") {
+		t.Fatalf("explanation: %q", tailBlock(m))
+	}
+}
+
+// TestEnterWhileBusyForksImmediately drives the REAL user path: with a turn
+// in flight, typing /fork + enter must run the command (not queue it as a
+// chat message for the model).
+func TestEnterWhileBusyForksImmediately(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+	_, m.cancel = context.WithCancel(context.Background()) // busy models carry one
+	m.queueSel = -1
+
+	m.input.SetValue("/fork typed-mid-turn")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if len(m.queue) != 0 {
+		t.Fatalf("/fork must never enter the chat queue: %v", m.queue)
+	}
+	if m.pendingForkID == "" {
+		t.Fatal("enter on /fork while busy should fork immediately")
+	}
+	meta, _, err := m.store.Load(m.pendingForkID)
+	if err != nil || meta.Title != "typed-mid-turn" {
+		t.Fatalf("copy: %+v %v", meta, err)
+	}
+	if m.hist[len(m.hist)-1] != "/fork typed-mid-turn" {
+		t.Fatalf("the command belongs in input recall: %v", m.hist)
+	}
+}
+
+// TestForkSwitchClearsQueue: messages queued for the OLD conversation must
+// not drain into the fork after the switch — they were typed in its context.
+func TestForkSwitchClearsQueue(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+	m.queue = []string{"follow up for the old conversation"}
+	m.queueSel = -1
+
+	m.command("/fork clean-slate")
+	if m.pendingForkID == "" {
+		t.Fatal("fork should be pending")
+	}
+
+	tm, _ := m.Update(turnDoneMsg{})
+	m = tm.(*model)
+	if len(m.queue) != 0 {
+		t.Fatalf("the switch must drop queued messages: %v", m.queue)
+	}
+	if m.busy {
+		t.Fatal("nothing should submit after the switch — the turn is over")
+	}
+}
+
+// TestForkSwitchKeepsTurnOnOriginal: a turn that was mid-flight when the fork
+// was created persists its completion to the ORIGINAL session — the fork
+// branched off before it. The live window converges onto the fork anyway.
+func TestForkSwitchKeepsTurnOnOriginal(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+	origID := m.sessionID
+	m.command("/fork branch-point")
+
+	// The turn completes. A real turn's final messages arrive via the turn
+	// goroutine before turnDoneMsg; here the turn is simulated, so append
+	// them while nothing owns Messages (busy is about to flip) and let
+	// turnDoneMsg's persist write them to the ORIGINAL — it runs before the
+	// switch and m.sessionID still names the source session.
+	m.busy = false // the append below stands in for the turn goroutine's
+	m.agent.Messages = append(m.agent.Messages,
+		llm.Message{Role: "assistant", Content: "finished answer"})
+	m.busy = true
+	tm, _ := m.Update(turnDoneMsg{})
+	m = tm.(*model)
+
+	if _, msgs, err := m.store.Load(origID); err != nil || len(msgs) != 5 {
+		t.Fatalf("the original should have kept the finished turn: %v %d", err, len(msgs))
+	}
+	_, forkMsgs, err := m.store.Load(m.sessionID)
+	if err != nil || len(forkMsgs) != 4 {
+		t.Fatalf("the fork branched before the turn ended: %v %d", err, len(forkMsgs))
+	}
+	if len(m.agent.Messages) != 5 { // system + the fork's 4 stored rows
+		t.Fatalf("the live window is the fork: %d", len(m.agent.Messages))
+	}
+}
+
+// TestForkSwitchThenNextTurnLandsOnFork: after the switch, the next turn
+// continues INSIDE the fork (that's the clone the user keeps). The turn is
+// driven synchronously through Agent.Turn on the switched fork's own agent —
+// the same primitive submitTurn wraps in a goroutine — so there's no live
+// goroutine to race when persist() writes the result.
+func TestForkSwitchThenNextTurnLandsOnFork(t *testing.T) {
+	m := forkModel(t)
+	m.busy = true
+	origID := m.sessionID
+	m.command("/fork continuation")
+	tm, _ := m.Update(turnDoneMsg{})
+	m = tm.(*model)
+
+	tm, _ = m.Update(turnDoneMsg{}) // no-op guard: a stray turnDone must not re-switch
+	m = tm.(*model)
+	if m.sessionID == origID || m.pendingForkID != "" {
+		t.Fatal("the switch is one-shot")
+	}
+
+	// the next turn on the switched fork: Agent.Turn appends the authored
+	// user row and the stub's assistant reply, exactly as production
+	m.agent.Client = stubLLM()
+	m.busy = false // the switch is done; the window is idle like a real turn start
+	if _, err := m.agent.Turn(context.Background(), "next question", agent.Events{}); err != nil {
+		t.Fatal(err)
+	}
+	m.persist() // what turnDoneMsg does when the goroutine reports back
+
+	_, msgs, err := m.store.Load(m.sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, msg := range msgs {
+		if msg.Role == "user" && msg.Content == "next question" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the new turn should persist on the fork: %+v", msgs[len(msgs)-2:])
+	}
+	if _, origMsgs, _ := m.store.Load(origID); len(origMsgs) != 4 {
+		t.Fatalf("the original must not grow after the switch: %d", len(origMsgs))
 	}
 }
 

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -188,9 +188,7 @@ func (m *model) paletteItems() []paletteItem {
 			dynHint: func(m *model) string { return "/fork" },
 			run: func(m *model) (tea.Model, tea.Cmd) {
 				m.palette = nil
-				if !m.busy {
-					m.forkCommand("")
-				}
+				m.forkCommand("") // works mid-turn: copies now, switches at turn end
 				return m, nil
 			},
 		},

--- a/internal/tui/queue_test.go
+++ b/internal/tui/queue_test.go
@@ -130,12 +130,13 @@ func TestQueueSelResetsOnSteer(t *testing.T) {
 }
 
 // TestBusyCmdAllowList pins which commands run mid-turn (and which /goal
-// forms do) — anything else must queue as a message.
+// forms do) — anything else must queue as a message. /fork runs mid-turn by
+// design: it only copies stored rows (busyFork), never the live conversation.
 func TestBusyCmdAllowList(t *testing.T) {
 	runs := []string{
 		"/help", "/theme", "/theme dark", "/mouse", "/effort", "/effort high",
 		"/tasks", "/tasks abc123", "/goal", "/goal clear", "/goal rounds 5",
-		"/cd", "/cd /tmp", "/pwd",
+		"/cd", "/cd /tmp", "/pwd", "/fork", "/fork experiment",
 	}
 	for _, c := range runs {
 		if !busyCmd(c) {
@@ -144,7 +145,7 @@ func TestBusyCmdAllowList(t *testing.T) {
 	}
 	queues := []string{
 		"/goal resume", "/goal ship the release", "/model", "/model x",
-		"/compact", "/clear", "/fork", "/rename", "/resume", "/quit",
+		"/compact", "/clear", "/rename", "/resume", "/quit",
 		"/bogus", "hello",
 	}
 	for _, c := range queues {

--- a/internal/tui/registry.go
+++ b/internal/tui/registry.go
@@ -31,7 +31,7 @@ var registry = []registryEntry{
 	{Name: "/context-doctor", Hint: "— audit what a fresh session injects (skills, MCP, tool schemas) and its token cost", Category: "Session"},
 	{Name: "/effort", Hint: "[level] — reasoning effort: off·low·medium·high (bare opens selector)", Category: "Agent"},
 	{Name: "/export", Hint: "[path] — write the transcript to a markdown file (default ./whip-transcript-<session>.md)", Category: "Session"},
-	{Name: "/fork", Hint: "[name] — copy the conversation into a new session (pick a point in the rewind picker with f)", Category: "Session"},
+	{Name: "/fork", Hint: "[name] — copy the conversation into a new session, even mid-turn (pick a point in the rewind picker with f)", Category: "Session"},
 	{Name: "/goal", Hint: "<text> — keep working until the goal is met (resume | clear | rounds <n>|default [--global])", Category: "Session"},
 	{Name: "/goal-from-context", Hint: "[n] — formulate a goal from the last n messages (default 8) and work until it's met", Category: "Session"},
 	{Name: "/help", Hint: "— show all commands and keybindings", Category: "App"},

--- a/internal/tui/title.go
+++ b/internal/tui/title.go
@@ -32,6 +32,9 @@ func (m *model) maybeTitle() tea.Cmd {
 	if cli == nil {
 		cli = m.agent.Client
 	}
+	if cli == nil {
+		return nil // headless tests build agents without a client
+	}
 	if mdl == "" {
 		mdl = m.agent.Model
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -172,6 +172,8 @@ type model struct {
 	goalRounds int    // continuation turns spent on the current goal
 	titled     bool   // an auto-title has been attempted for this session
 
+	pendingForkID string // busy-forked copy awaiting the turn's end to switch into ("" = none)
+
 	mouseOn      bool       // runtime mouse-capture state (toggle with /mouse)
 	sel          *selection // in-flight/last drag selection over the transcript
 	selDragX     int        // last drag pointer position (edge auto-scroll re-checks it)
@@ -1948,6 +1950,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				_ = m.store.SetSnapshot(m.sessionID, msg.at, msg.snap)
 			}
 		}
+		// A mid-turn /fork: the copy landed when the command ran; now that the
+		// turn (and its persist) is done, move the live window onto the copy.
+		// This precedes the queue drain and goal loop so any follow-up turns
+		// continue inside the fork, not the abandoned original.
+		if m.pendingForkID != "" {
+			m.switchToForked(m.pendingForkID)
+			m.pendingForkID = ""
+			return m, nil
+		}
 		// codex-style follow-up: send queued messages one turn at a time;
 		// `!` shell escapes execute locally instead of starting a turn.
 		// A canceled turn also drains the queue: the empty-enter steer path
@@ -3335,14 +3346,16 @@ func (m *model) submitTurn(text string, authored bool) (tea.Model, tea.Cmd) {
 // flight. These adjust settings or views only — they never touch
 // Agent.Messages, busy, or the session — so they run immediately instead of
 // being queued as messages (queued text is submitted to the model verbatim
-// after the turn ends).
+// after the turn ends). /fork is the exception: it DOES touch the session,
+// but only through a fresh copy (busyFork) — it never mutates the in-flight
+// conversation, so it runs immediately too.
 func busyCmd(text string) bool {
 	fields := strings.Fields(text)
 	if len(fields) == 0 {
 		return false
 	}
 	switch fields[0] {
-	case "/help", "/theme", "/mouse", "/effort", "/subagents", "/tasks", "/subagent", "/cd", "/pwd", "/report", "/export":
+	case "/help", "/theme", "/mouse", "/effort", "/subagents", "/tasks", "/subagent", "/cd", "/pwd", "/report", "/export", "/fork":
 		return true
 	case "/auth": // must run now even while busy: an inline key queued as a chat message would be sent to the model
 		return true
@@ -3589,10 +3602,9 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 			return m.submit(goal)
 		}
 	case "/fork":
-		if m.busy {
-			m.append(dimStyle.Render("(busy — /fork after this turn)"))
-			return m, nil
-		}
+		// No busy guard: mid-turn /fork creates the copy right away (busyFork)
+		// and defers only the switch to turn end — the whole point is cloning
+		// the conversation while the model is still working.
 		m.forkCommand(strings.TrimSpace(strings.TrimPrefix(text, "/fork")))
 		return m, nil
 	case "/rename":


### PR DESCRIPTION
## Why

Running `/fork` while a response was streaming queued the command as a chat message — the fork only existed **after** the turn ended, which defeats the whole point: cloning the conversation to open in another session while whip is still working.

## What

`/fork` now runs mid-turn (added to the `busyCmd` allow-list) and forks in two phases:

1. **`busyFork` (mid-turn)** — copies the *stored* rows into a new session immediately via `Store.Fork` and prints the escape hatch:
   > ⑂ forked "…" → "name" (id) — open it in another session now: `whip --resume <id>` · whip switches to the copy when this turn ends

   This is race-free: the turn goroutine owns `Agent.Messages` mid-turn but never touches the session store — `persist()` only runs from the TUI goroutine. `busyFork` touches none of the shared state (messages, session id, snapshots, queue).

2. **`switchToForked` (turn end)** — `turnDoneMsg` performs the switch *before* the queue drain and goal loop, after the turn's final `persist()` (which lands on the **original** — the fork branched before it). It flushes the stream, drops queued messages (typed for the old conversation), clears the redo stack, and rebuilds the agent from the fork's row the same way `resume()` does (model/provider, effort, cumulative usage, goal). The original keeps the finished turn and stays under `/resume`. Task dock, todos, and workspace snapshots deliberately stay put — they belong to the live window.

## Edge cases

- **First turn** (nothing persisted): reports "nothing to fork yet" instead of copying air.
- **Double fork mid-turn**: refused — one pending switch at a time.
- **Named fork**: `maybeTitle` never retitles it (guard + `titled=true`); the nil-client guard there also fixes a headless-test crash the new turn-end path surfaced.
- **Palette** "Fork session" works while busy; `/rename` still refuses mid-turn.

## Tests

- `TestBusyCmdAllowList` — `/fork` moved to the runs-mid-turn list (with an arg form).
- `TestForkWhileBusyCopiesImmediatelyAndDefersSwitch` — copy exists NOW (title, `forked_from`, all rows), live window untouched until `turnDoneMsg`, resume hint printed, double-fork refused, switch lands at turn end, original untouched.
- `TestEnterWhileBusyForksImmediately` — the real user path: typed `/fork` + enter while busy runs, never queues.
- `TestForkWhileBusyBareOpensPrompt` — bare `/fork` mid-turn still names the copy inline; enter commits immediately.
- `TestForkWhileBusyWithoutStoredSession` — first-turn refusal.
- `TestForkSwitchClearsQueue` — queued messages don't drain into the fork.
- `TestForkSwitchKeepsTurnOnOriginal` — the in-flight turn's completion persists to the original; the fork branched before it.
- `TestForkSwitchThenNextTurnLandsOnFork` — after the switch the next turn continues inside the fork (driven via `Agent.Turn` synchronously, so no live goroutine races `persist()`); the original stops growing.

`forkModel` gained a routable config since the switch rebuilds the agent through `buildAgent`.

Full `internal/tui` suite passes with `-race`; `gofmt -s`, `go vet`, `golangci-lint`, `go mod tidy` no-op, and darwin/arm64 + linux/amd64 cross-compiles all clean.

## Docs

`docs/features.md` fork section updated (the "all three refuse mid-turn" claim was stale).