### PR TITLE
fix(startup): refresh catalogs and retry once on launch-time "unknown model"

### DIFF
--- a/cmd/whip/acp.go
+++ b/cmd/whip/acp.go
@@ -29,6 +29,7 @@ import (
 	"github.com/context-labs/whip/internal/skills"
 	"github.com/context-labs/whip/internal/tools"
 	"github.com/context-labs/whip/internal/tools/bashrun"
+	"github.com/context-labs/whip/internal/tui"
 )
 
 func acpCLI(args []string) error {
@@ -48,7 +49,7 @@ func acpCLI(args []string) error {
 	if err != nil {
 		return err
 	}
-	prov, mdl, apiID, err := cfg.Resolve(*modelFlag, *providerFlag)
+	prov, mdl, apiID, err := tui.ResolveWithRefresh(cfg, *modelFlag, *providerFlag)
 	if err != nil {
 		return err
 	}

--- a/cmd/whip/run.go
+++ b/cmd/whip/run.go
@@ -72,7 +72,7 @@ func runCLI(args []string) error {
 	if err != nil {
 		return err
 	}
-	prov, mdl, apiID, err := cfg.Resolve(*modelFlag, *providerFlag)
+	prov, mdl, apiID, err := tui.ResolveWithRefresh(cfg, *modelFlag, *providerFlag)
 	if err != nil {
 		return err
 	}

--- a/docs/models-providers.md
+++ b/docs/models-providers.md
@@ -32,6 +32,15 @@ flowchart LR
   (`-p` / `/model <name> <provider>`) to disambiguate.
 - Newly announced models appear in the `/model` picker dimmed, marked
   `(new)`, after `/model refresh` or the next TTL cycle.
+- **Retry-on-miss at startup.** If launch-time resolution reports an unknown
+  model — the default model has no config entry and the cached catalog is
+  missing or stale (deleted `~/.whip/models.json`, or a model announced after
+  the last fetch) — whip synchronously force-refreshes the configured
+  providers' catalogs and retries resolution once before failing. The happy
+  path never pays for this: a successful first resolve performs no fetch, so
+  normal and offline starts are unaffected. Applies to every entrypoint
+  (`whip`, `whip run`, `whip acp`); a genuinely unknown model still errors,
+  after exactly one refresh attempt.
 - `/model` persists the switch as the saved default. `/model-for-session`
   switches the active model identically but leaves the saved default
   untouched, so the next launch still opens on the configured model.

--- a/internal/config/catalog_resolve_test.go
+++ b/internal/config/catalog_resolve_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -127,5 +128,32 @@ func TestResolveCatalogFallbackMisses(t *testing.T) {
 	}
 	if _, _, _, err := cfg.Resolve("phantom-model", ""); err == nil {
 		t.Fatal("catalog for an unconfigured provider must not resolve")
+	}
+}
+
+// A total miss (neither config nor any catalog) is typed *UnknownModelError
+// so startup entrypoints can force-refresh the catalogs and retry once; the
+// other Resolve failures (unknown provider, ambiguous catalog id) stay
+// untyped so they never trigger a pointless refresh.
+func TestResolveUnknownModelErrorTyping(t *testing.T) {
+	catalogFixture(t, "inference", ModelInfoLite{ID: "kimi-k3"})
+	cfg := cfgWithProviders("inference")
+	cfg.Models["glm-5.2-fast"] = Model{Providers: []string{"inference"}}
+
+	_, _, _, err := cfg.Resolve("nope", "")
+	var unknown *UnknownModelError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("miss should be *UnknownModelError, got %T (%v)", err, err)
+	}
+	if unknown.Model != "nope" {
+		t.Errorf("error should carry the missed name, got %q", unknown.Model)
+	}
+	want := `unknown model "nope" (models: glm-5.2-fast)`
+	if err.Error() != want {
+		t.Errorf("message changed: got %q want %q", err.Error(), want)
+	}
+
+	if _, _, _, err = cfg.Resolve("glm-5.2-fast", "ghost"); errors.As(err, &unknown) {
+		t.Error("unknown provider must not be typed as a refreshable miss")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -489,6 +489,19 @@ func (c *Config) Resolve(model, provider string) (Provider, Model, string, error
 	return p, m, id, nil
 }
 
+// UnknownModelError flags a Resolve miss the caller may recover from by
+// refreshing the provider catalogs and retrying: the model is absent from
+// both cfg.Models and every provider's cached /models list, which a stale
+// (or deleted) ~/.whip/models.json causes even for live models.
+type UnknownModelError struct {
+	Model string
+	known string // config model names, for the message
+}
+
+func (e *UnknownModelError) Error() string {
+	return fmt.Sprintf("unknown model %q (models: %s)", e.Model, e.known)
+}
+
 // resolveFromCatalog synthesizes a Model for an id advertised in a provider's
 // cached /models catalog but absent from cfg.Models. Capabilities (context,
 // max output, vision) come from the catalog entry; the provider routing is the
@@ -513,7 +526,7 @@ func (c *Config) resolveFromCatalog(model, provider string) (Model, string, erro
 		}
 	}
 	if len(hits) == 0 {
-		return Model{}, "", fmt.Errorf("unknown model %q (models: %s)", model, keys(c.Models))
+		return Model{}, "", &UnknownModelError{Model: model, known: keys(c.Models)}
 	}
 	if len(hits) > 1 {
 		names := make([]string, len(hits))

--- a/internal/tui/startup_refresh_test.go
+++ b/internal/tui/startup_refresh_test.go
@@ -1,0 +1,159 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/context-labs/whip/internal/config"
+)
+
+// modelsServer serves GET /models with the given ids and counts requests.
+// whip's own Provider.ResolveKey takes over for api.inference.net base URLs
+// (machine-key fallback), so test providers must use the httptest URL.
+func modelsServer(t *testing.T, hits *atomic.Int32, ids ...string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if hits != nil {
+			hits.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data":[`)
+		for i, id := range ids {
+			if i > 0 {
+				fmt.Fprint(w, ",")
+			}
+			fmt.Fprintf(w, `{"id":%q,"context_length":1000000}`, id)
+		}
+		fmt.Fprintf(w, `]}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// (a) The reported scenario: default model kimi-k3 has no config entry and
+// the catalog cache is missing; startup resolution force-refreshes the
+// provider's /models and resolves it on the retry instead of aborting.
+func TestBuildAgentWithRefreshRecoversFromMissingCatalog(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir()) // no models.json at all
+	var hits atomic.Int32
+	srv := modelsServer(t, &hits, "kimi-k3")
+	cfg := &config.Config{
+		DefaultModel:    "kimi-k3",
+		DefaultProvider: "inference-net",
+		Providers: map[string]config.Provider{
+			"inference-net": {BaseURL: srv.URL, API: "openai-completions", APIKey: "k"},
+		},
+		Models: map[string]config.Model{},
+	}
+
+	ag, mn, pn, err := buildAgentWithRefresh(cfg, "", "", "")
+	if err != nil {
+		t.Fatalf("refresh-and-retry should recover the launch: %v", err)
+	}
+	if mn != "kimi-k3" || pn != "inference-net" {
+		t.Errorf("route: %s@%s", mn, pn)
+	}
+	if ag == nil || ag.Model != "kimi-k3" {
+		t.Errorf("agent should run the catalog id, got %+v", ag)
+	}
+	if ag.ContextLimit != 1000000 {
+		t.Errorf("context limit should come from the refreshed catalog, got %d", ag.ContextLimit)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("want exactly 1 refresh fetch, got %d", n)
+	}
+	// The refresh persisted the catalog, so a later plain resolve hits the cache.
+	if _, _, _, err := cfg.Resolve("kimi-k3", ""); err != nil {
+		t.Errorf("catalog should be cached after the refresh: %v", err)
+	}
+}
+
+// (b) Happy path: the first resolve succeeds, so no network fetch happens.
+func TestBuildAgentWithRefreshSkipsFetchWhenResolveSucceeds(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	var hits atomic.Int32
+	srv := modelsServer(t, &hits, "kimi-k3")
+	cfg := &config.Config{
+		DefaultModel:    "glm-5.2-fast",
+		DefaultProvider: "inference-net",
+		Providers: map[string]config.Provider{
+			"inference-net": {BaseURL: srv.URL, API: "openai-completions", APIKey: "k"},
+		},
+		Models: map[string]config.Model{
+			"glm-5.2-fast": {Providers: []string{"inference-net"}},
+		},
+	}
+
+	if _, _, _, err := buildAgentWithRefresh(cfg, "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if n := hits.Load(); n != 0 {
+		t.Errorf("successful resolve must not fetch, got %d requests", n)
+	}
+}
+
+// (c) A genuinely unknown model still errors after exactly one refresh
+// attempt, and the ORIGINAL "unknown model" error is what surfaces.
+func TestBuildAgentWithRefreshStillErrorsForUnknownModel(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	var hits atomic.Int32
+	srv := modelsServer(t, &hits, "kimi-k3")
+	cfg := &config.Config{
+		DefaultModel:    "nope",
+		DefaultProvider: "inference-net",
+		Providers: map[string]config.Provider{
+			"inference-net": {BaseURL: srv.URL, API: "openai-completions", APIKey: "k"},
+		},
+		Models: map[string]config.Model{},
+	}
+
+	_, _, _, err := buildAgentWithRefresh(cfg, "", "", "")
+	var unknown *config.UnknownModelError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("persistent miss should surface the original typed error, got %T (%v)", err, err)
+	}
+	if !strings.Contains(err.Error(), `unknown model "nope"`) {
+		t.Errorf("original message lost: %v", err)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("want exactly 1 refresh attempt, got %d", n)
+	}
+}
+
+// The headless wrapper (whip run / whip acp) gets the same retry-on-miss.
+func TestResolveWithRefreshRecoversFromMissingCatalog(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	var hits atomic.Int32
+	srv := modelsServer(t, &hits, "kimi-k3")
+	cfg := &config.Config{
+		DefaultModel:    "kimi-k3",
+		DefaultProvider: "inference-net",
+		Providers: map[string]config.Provider{
+			"inference-net": {BaseURL: srv.URL, API: "openai-completions", APIKey: "k"},
+		},
+		Models: map[string]config.Model{},
+	}
+
+	prov, mdl, id, err := ResolveWithRefresh(cfg, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "kimi-k3" || prov.BaseURL != srv.URL {
+		t.Errorf("route: id=%q base=%q", id, prov.BaseURL)
+	}
+	if mdl.Context != 1000000 {
+		t.Errorf("synthetic model should carry catalog context, got %+v", mdl)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("want exactly 1 refresh fetch, got %d", n)
+	}
+}

--- a/internal/tui/startup_refresh_test.go
+++ b/internal/tui/startup_refresh_test.go
@@ -117,8 +117,8 @@ func TestBuildAgentWithRefreshStillErrorsForUnknownModel(t *testing.T) {
 	}
 
 	_, _, _, err := buildAgentWithRefresh(cfg, "", "", "")
-	var unknown *config.UnknownModelError
-	if !errors.As(err, &unknown) {
+	_, ok := errors.AsType[*config.UnknownModelError](err)
+	if !ok {
 		t.Fatalf("persistent miss should surface the original typed error, got %T (%v)", err, err)
 	}
 	if !strings.Contains(err.Error(), `unknown model "nope"`) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -287,7 +287,7 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 		return "", errors.New("folder not trusted")
 	}
 
-	ag, mn, pn, err := buildAgent(cfg, modelName, provName, sysPrompt)
+	ag, mn, pn, err := buildAgentWithRefresh(cfg, modelName, provName, sysPrompt)
 	if err != nil {
 		return "", err
 	}
@@ -602,16 +602,15 @@ func catalogLites(infos []llm.ModelInfo) []config.ModelInfoLite {
 	return lites
 }
 
-// fetchCatalogs refreshes each provider's cached model list in the background
-// and sends the merged result to the UI. force bypasses the 24h TTL
-// (/model refresh) so newly announced models appear immediately.
-func (m *model) fetchCatalogs(force bool) {
+// refreshCatalogs synchronously refreshes the cached model list of every
+// configured provider that needs it (missing/stale cache, or any provider
+// when force) and persists the result. Fetch or key failures skip that
+// provider, keeping its stale cache; it returns the merged catalogs (never
+// nil) whether or not anything was written.
+func refreshCatalogs(cfg *config.Config, force bool) map[string]config.Catalog {
 	cats := config.LoadCatalogs()
-	if cats == nil { // defensive; LoadCatalogs already returns non-nil
-		cats = map[string]config.Catalog{}
-	}
 	dirty := false
-	for name, prov := range m.cfg.Providers {
+	for name, prov := range cfg.Providers {
 		if c, ok := cats[name]; ok && !force && !c.Stale() && c.BaseURL == prov.BaseURL {
 			continue
 		}
@@ -637,9 +636,54 @@ func (m *model) fetchCatalogs(force bool) {
 	if dirty {
 		_ = config.SaveCatalogs(cats) // best-effort; the TUI still gets the fresh data
 	}
+	return cats
+}
+
+// fetchCatalogs refreshes each provider's cached model list in the background
+// and sends the merged result to the UI. force bypasses the 24h TTL
+// (/model refresh) so newly announced models appear immediately.
+func (m *model) fetchCatalogs(force bool) {
+	cats := refreshCatalogs(m.cfg, force)
 	if m.prog != nil { // nil in tests that drive the command dispatch directly
 		m.prog.Send(catalogsMsg(cats))
 	}
+}
+
+// buildAgentWithRefresh retries a launch-time buildAgent once when the model
+// misses: an "unknown model" may only mean the provider's cached catalog is
+// stale or absent (deleted ~/.whip/models.json, or a model announced after
+// the last fetch), so it force-refreshes the catalogs and retries. The happy
+// path performs no network fetch; a persistent failure surfaces the ORIGINAL
+// error (the refresh's failures are already logged by refreshCatalogs).
+func buildAgentWithRefresh(cfg *config.Config, modelName, provName, sysPrompt string) (*agent.Agent, string, string, error) {
+	ag, mn, pn, err := buildAgent(cfg, modelName, provName, sysPrompt)
+	var unknown *config.UnknownModelError
+	if !errors.As(err, &unknown) {
+		return ag, mn, pn, err
+	}
+	config.LogEvent("catalog.fetch", fmt.Sprintf("startup resolve missed %q — force-refreshing catalogs", unknown.Model))
+	refreshCatalogs(cfg, true)
+	if ag, mn, pn, rerr := buildAgent(cfg, modelName, provName, sysPrompt); rerr == nil {
+		return ag, mn, pn, nil
+	}
+	return nil, "", "", err
+}
+
+// ResolveWithRefresh is the same retry-on-miss wrapper for the headless
+// entrypoints (whip run, whip acp), which call cfg.Resolve directly instead
+// of building an agent.
+func ResolveWithRefresh(cfg *config.Config, modelName, provName string) (config.Provider, config.Model, string, error) {
+	prov, mdl, id, err := cfg.Resolve(modelName, provName)
+	var unknown *config.UnknownModelError
+	if !errors.As(err, &unknown) {
+		return prov, mdl, id, err
+	}
+	config.LogEvent("catalog.fetch", fmt.Sprintf("startup resolve missed %q — force-refreshing catalogs", unknown.Model))
+	refreshCatalogs(cfg, true)
+	if prov, mdl, id, rerr := cfg.Resolve(modelName, provName); rerr == nil {
+		return prov, mdl, id, nil
+	}
+	return config.Provider{}, config.Model{}, "", err
 }
 
 // resume replaces the conversation with a stored session.


### PR DESCRIPTION
## Problem

Deleting `~/.whip/models.json` (or holding a stale cache) aborted launch with:

```
whip: unknown model "kimi-k3" (models: deepseek-v4-flash-0731, glm-5.2-fast, kimi-k3-fast)
```

The default model lived only in the provider's `GET /models` catalog, and the launch-time `Resolve` ran strictly before the background `fetchCatalogs` goroutine — so a missing/stale cache was a hard startup error even when the provider was reachable.

## Fix

Retry-on-miss at startup:

- `(*Config).Resolve`'s total miss is now typed (`*config.UnknownModelError`, same message text). Other failures (unknown provider, ambiguous catalog id) stay untyped and never trigger a refresh.
- `internal/tui`: the existing `fetchCatalogs` body is extracted as `refreshCatalogs(cfg, force)` (unchanged semantics — 24h TTL, per-provider failure keeps stale cache); `buildAgentWithRefresh` and `ResolveWithRefresh` wrap resolution: on the typed miss, synchronously force-refresh all configured providers' catalogs and retry **once**; a persistent failure surfaces the **original** error.
- All entrypoints covered: `whip` (tui.Run), `whip run`, `whip acp`. No provider-name special-casing — inference.net and OpenRouter providers alike.
- **Happy path unchanged**: a successful first resolve performs no network fetch (asserted by test), so normal and offline starts keep their latency; the background TTL refresh is untouched.

## Tests

New `internal/tui/startup_refresh_test.go` (httptest `/models` server with a hit counter):
- (a) missing cache + catalog-only default model → exactly 1 fetch, launch succeeds, catalog persisted (the reported scenario)
- (b) successful first resolve → zero HTTP requests
- (c) genuinely unknown model → errors after exactly one refresh, original typed error preserved
- headless `ResolveWithRefresh` recovery

`internal/config/catalog_resolve_test.go`: added `TestResolveUnknownModelErrorTyping`; existing tests pass unchanged (including the `kimi-k3` catalog-resolve test and `TestLoadCatalogsAlwaysNonNil`).

`go build ./...` clean; `go test ./...` green (except pre-existing `TestPortProbeSquatterTriggersFallback` env flake — fails on clean tree when Chrome holds port 9223).

Docs: `docs/models-providers.md` routing section documents retry-on-miss at startup.