### PR TITLE
feat(tui): per-turn tokens, cost, and context size in the rewind picker

### DIFF
--- a/internal/tui/rewind.go
+++ b/internal/tui/rewind.go
@@ -268,10 +268,121 @@ func (m *model) rewindView() string {
 		} else {
 			b.WriteString("  " + e.text)
 		}
-		b.WriteString("\n    " + dimStyle.Render(rewindWhen(e.when)))
+		b.WriteString("\n    " + m.rewindTurnMeta(row))
 	}
 	fmt.Fprintf(&b, "\n%s", dimStyle.Render(fmt.Sprintf("  (%d/%d) ↑ older · ↓ newer", r.sel+1, len(r.entries))))
 	return b.String()
+}
+
+// turnUsage sums the usage of the turn that starts at conversation index cut
+// (the authored user message): every assistant message up to the next user
+// message. A tool-looping turn is several API calls, so the sum is the turn's
+// total burn. last is the final assistant message's usage: its prompt size is
+// the chat's size when the turn ended, which is how the user watches context
+// grow turn over turn. ok is false when the turn recorded no usage at all.
+func (m *model) turnUsage(cut int) (sum, last llm.Usage, ok bool) {
+	for i := cut + 1; i < len(m.agent.Messages)+len(m.future); i++ {
+		msg := m.messageAt(i)
+		if msg.Role == "user" {
+			break // the turn ends where the next submission begins
+		}
+		if msg.Role == "assistant" && msg.Usage != nil {
+			ok = true
+			last = *msg.Usage
+			sum.PromptTokens += msg.Usage.PromptTokens
+			sum.CompletionTokens += msg.Usage.CompletionTokens
+			if c := msg.Usage.Cached(); c > 0 {
+				if sum.PromptTokensDetails == nil {
+					sum.PromptTokensDetails = &struct {
+						CachedTokens int `json:"cached_tokens"`
+					}{}
+				}
+				sum.PromptTokensDetails.CachedTokens += c
+			}
+		}
+	}
+	return sum, last, ok
+}
+
+// rewindTurnMeta renders an entry's second line: the timestamp, then the
+// turn's token flow and cost, then the context's size at turn end —
+// "when · turn 1.3M in (1.1M cached) / 4.7k out · $x · context 67.8k".
+// The turn figure sums every round (a tool-looping turn is several API
+// calls); the context figure is the final round's prompt, i.e. how big the
+// conversation had grown, with the growth since the previous entry in green
+// ("context 75.6k (+7.5k)"). Cost is summed per message at that message's own
+// model rates; hidden when nothing contributing is priced. row is the entry's
+// index in the picker (growth diffs against the row above).
+func (m *model) rewindTurnMeta(row int) string {
+	e := m.rew.entries[row]
+	meta := dimStyle.Render(rewindWhen(e.when))
+	sum, last, ok := m.turnUsage(e.cut)
+	if !ok {
+		return meta
+	}
+	meta += dimStyle.Render(" · turn " + fmtTurn(sum))
+	if cost, ok := m.turnCost(e.cut); ok {
+		meta += dimStyle.Render(" · " + fmtCost(cost))
+	}
+	ctxSeg := " · context " + fmtTok(last.PromptTokens)
+	if prev, ok := m.prevContextTokens(row); ok {
+		if delta := last.PromptTokens - prev; delta > 0 {
+			ctxSeg += growStyle.Render(fmt.Sprintf(" (+%s)", fmtTok(delta)))
+		}
+	}
+	return meta + dimStyle.Render(ctxSeg)
+}
+
+// prevContextTokens finds the context size recorded by the picker row above
+// this one (its last round's prompt), skipping rows whose turn recorded no
+// usage. ok is false for the first usable row — there is nothing to diff.
+func (m *model) prevContextTokens(row int) (int, bool) {
+	for i := row - 1; i >= 0; i-- {
+		if _, last, ok := m.turnUsage(m.rew.entries[i].cut); ok {
+			return last.PromptTokens, true
+		}
+	}
+	return 0, false
+}
+
+// fmtTurn renders a turn's token flow in words — "1.3M in (1.1M cached) /
+// 4.7k out". The status line's bare in(cached)/out shape is fine where space
+// is tight and the format is always visible; on a picker row the words earn
+// their width.
+func fmtTurn(u llm.Usage) string {
+	in := fmtTok(u.PromptTokens) + " in"
+	if c := u.Cached(); c > 0 {
+		in += fmt.Sprintf(" (%s cached)", fmtTok(c))
+	}
+	return fmt.Sprintf("%s / %s out", in, fmtTok(u.CompletionTokens))
+}
+
+// turnCost prices the turn starting at cut by summing each assistant
+// message's usage at its own recorded model's advertised rates.
+func (m *model) turnCost(cut int) (float64, bool) {
+	total := 0.0
+	for i := cut + 1; i < len(m.agent.Messages)+len(m.future); i++ {
+		msg := m.messageAt(i)
+		if msg.Role == "user" {
+			break
+		}
+		if msg.Role != "assistant" || msg.Usage == nil {
+			continue
+		}
+		// msg.Model is "id @ provider"; pre-field messages (and providers
+		// without a pricing catalog) contribute nothing.
+		modelID, prov, _ := strings.Cut(msg.Model, " @ ")
+		cat, ok := m.catalogs[prov]
+		if !ok {
+			continue
+		}
+		in, out, cacheRead, ok := cat.Pricing(modelID)
+		if !ok {
+			continue
+		}
+		total += llm.SessionCost(*msg.Usage, in, out, cacheRead)
+	}
+	return total, total > 0
 }
 
 // rewindWhen renders an entry's submission time for the picker. Pre-SentAt

--- a/internal/tui/rewind_test.go
+++ b/internal/tui/rewind_test.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/context-labs/whip/internal/agent"
+	"github.com/context-labs/whip/internal/config"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/session"
 )
@@ -280,6 +282,96 @@ func TestRewindPickerShowsTimestamps(t *testing.T) {
 		}
 		if strings.Contains(ln, "q3-old") && !strings.Contains(lines[i+1], "—") {
 			t.Errorf("q3-old (no SentAt) should show a dash below it\n%s", view)
+		}
+	}
+}
+
+// The picker's second line per entry carries the chat's size at the end of
+// the turn (the final round's full prompt — how big the conversation has
+// grown) plus the turn's own usage and cost, summed across every assistant
+// reply of that turn and priced at each message's own recorded model. Turns
+// without recorded usage — and costs without pricing — leave those segments
+// out entirely.
+func TestRewindPickerShowsTurnUsageAndCost(t *testing.T) {
+	cached8k := &struct {
+		CachedTokens int `json:"cached_tokens"`
+	}{CachedTokens: 8000}
+	cached21k := &struct {
+		CachedTokens int `json:"cached_tokens"`
+	}{CachedTokens: 21000}
+	m := rewindModel(t,
+		// turn 1: two assistant rounds (tool loop) priced on m1. The second
+		// round's prompt is the whole grown chat.
+		llm.Message{Role: "user", Content: "q1", Authored: true},
+		llm.Message{Role: "assistant", Content: "a1a", Model: "m1 @ p1",
+			Usage: &llm.Usage{PromptTokens: 10000, CompletionTokens: 500, PromptTokensDetails: cached8k}},
+		llm.Message{Role: "assistant", Content: "a1b", Model: "m1 @ p1",
+			Usage: &llm.Usage{PromptTokens: 23000, CompletionTokens: 300, PromptTokensDetails: cached21k}},
+		// turn 2: usage recorded but the model is unpriced
+		llm.Message{Role: "user", Content: "q2", Authored: true},
+		llm.Message{Role: "assistant", Content: "a2", Model: "m2 @ p2",
+			Usage: &llm.Usage{PromptTokens: 1000, CompletionTokens: 100}},
+		// turn 3: legacy row, no usage at all
+		llm.Message{Role: "user", Content: "q3-old", Authored: true},
+		// turn 4: usage again; its growth must diff against q2 (skipping q3)
+		llm.Message{Role: "user", Content: "q4", Authored: true},
+		llm.Message{Role: "assistant", Content: "a4", Model: "m2 @ p2",
+			Usage: &llm.Usage{PromptTokens: 2500, CompletionTokens: 120}},
+	)
+	m.catalogs = map[string]config.Catalog{
+		"p1": {Models: []config.ModelInfoLite{{ID: "m1", InPrice: 1e-6, OutPrice: 5e-6, CacheReadPrice: 1e-7}}},
+		"p2": {Models: []config.ModelInfoLite{{ID: "m2"}}}, // no prices
+	}
+	press(t, m, esc(m))
+	press(t, m, esc(m))
+
+	// turn 1 sum: (10k-8k)*1e-6 + 8k*1e-7 + 500*5e-6 = 0.0053 for round one,
+	// + (23k-21k)*1e-6 + 21k*1e-7 + 300*5e-6 = 0.0056 → 0.0109
+	sum1, last1, ok := m.turnUsage(1)
+	if !ok {
+		t.Fatal("turn 1 should have usage")
+	}
+	if sum1.PromptTokens != 33000 || sum1.CompletionTokens != 800 || sum1.Cached() != 29000 {
+		t.Errorf("turn 1 sum: %+v", sum1)
+	}
+	if last1.PromptTokens != 23000 || last1.Cached() != 21000 {
+		t.Errorf("turn 1 chat size should come from the last round: %+v", last1)
+	}
+	if got, ok := m.turnCost(1); !ok || got != 0.0109 {
+		t.Errorf("turn 1 cost = %v (ok=%v), want 0.0109", got, ok)
+	}
+
+	view := m.rewindView()
+	if !strings.Contains(view, "turn 33.0k in (29.0k cached) / 800 out · $0.0109 · context 23.0k") {
+		t.Errorf("q1's line should show the turn's flow and cost, then the context size\n%s", view)
+	}
+	if !strings.Contains(view, "turn 1.0k in / 100 out") {
+		t.Errorf("q2's line should show usage without cost\n%s", view)
+	}
+	// growth: q1 is the first usable row (no previous → no delta); q2 shrank
+	// (1.0k < 23.0k → no delta shown); q4 grew 1.5k over q2, skipping q3's
+	// usage-less turn. The marker runs through the green growStyle, so strip
+	// styling before asserting on the digits.
+	plain := ansi.Strip(view)
+	lines := strings.Split(plain, "\n")
+	for i, ln := range lines {
+		switch {
+		case strings.Contains(ln, "q1"):
+			if strings.Contains(lines[i+1], "(+") {
+				t.Errorf("q1 has no previous row — no growth marker\n%s", plain)
+			}
+		case strings.Contains(ln, "q2"):
+			if strings.Contains(lines[i+1], "(+") {
+				t.Errorf("q2 shrank the context — no growth marker\n%s", plain)
+			}
+		case strings.Contains(ln, "q3-old"):
+			if strings.Contains(lines[i+1], "turn") {
+				t.Errorf("q3-old (no usage) should show no turn segment\n%s", plain)
+			}
+		case strings.Contains(ln, "q4"):
+			if !strings.Contains(lines[i+1], "context 2.5k (+1.5k)") {
+				t.Errorf("q4 should show growth over q2 (skipping usage-less q3)\n%s", plain)
+			}
 		}
 	}
 }

--- a/internal/tui/rewind_test.go
+++ b/internal/tui/rewind_test.go
@@ -303,20 +303,28 @@ func TestRewindPickerShowsTurnUsageAndCost(t *testing.T) {
 		// turn 1: two assistant rounds (tool loop) priced on m1. The second
 		// round's prompt is the whole grown chat.
 		llm.Message{Role: "user", Content: "q1", Authored: true},
-		llm.Message{Role: "assistant", Content: "a1a", Model: "m1 @ p1",
-			Usage: &llm.Usage{PromptTokens: 10000, CompletionTokens: 500, PromptTokensDetails: cached8k}},
-		llm.Message{Role: "assistant", Content: "a1b", Model: "m1 @ p1",
-			Usage: &llm.Usage{PromptTokens: 23000, CompletionTokens: 300, PromptTokensDetails: cached21k}},
+		llm.Message{
+			Role: "assistant", Content: "a1a", Model: "m1 @ p1",
+			Usage: &llm.Usage{PromptTokens: 10000, CompletionTokens: 500, PromptTokensDetails: cached8k},
+		},
+		llm.Message{
+			Role: "assistant", Content: "a1b", Model: "m1 @ p1",
+			Usage: &llm.Usage{PromptTokens: 23000, CompletionTokens: 300, PromptTokensDetails: cached21k},
+		},
 		// turn 2: usage recorded but the model is unpriced
 		llm.Message{Role: "user", Content: "q2", Authored: true},
-		llm.Message{Role: "assistant", Content: "a2", Model: "m2 @ p2",
-			Usage: &llm.Usage{PromptTokens: 1000, CompletionTokens: 100}},
+		llm.Message{
+			Role: "assistant", Content: "a2", Model: "m2 @ p2",
+			Usage: &llm.Usage{PromptTokens: 1000, CompletionTokens: 100},
+		},
 		// turn 3: legacy row, no usage at all
 		llm.Message{Role: "user", Content: "q3-old", Authored: true},
 		// turn 4: usage again; its growth must diff against q2 (skipping q3)
 		llm.Message{Role: "user", Content: "q4", Authored: true},
-		llm.Message{Role: "assistant", Content: "a4", Model: "m2 @ p2",
-			Usage: &llm.Usage{PromptTokens: 2500, CompletionTokens: 120}},
+		llm.Message{
+			Role: "assistant", Content: "a4", Model: "m2 @ p2",
+			Usage: &llm.Usage{PromptTokens: 2500, CompletionTokens: 120},
+		},
 	)
 	m.catalogs = map[string]config.Catalog{
 		"p1": {Models: []config.ModelInfoLite{{ID: "m1", InPrice: 1e-6, OutPrice: 5e-6, CacheReadPrice: 1e-7}}},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -48,6 +48,7 @@ var (
 	toolStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "136", Dark: "11"})           // amber
 	dimStyle  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "240", Dark: "245"})          // mid gray
 	errStyle  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "124", Dark: "9"})            // red
+	growStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "28", Dark: "10"})            // green
 	// thinkingStyle renders reasoning tokens: dim and italic so they're
 	// visually distinct from the answer.
 	thinkingStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "240", Dark: "245"}).Italic(true)


### PR DESCRIPTION
The double-esc rewind picker's second line per entry now reads:

```
❯ when we open the double-esc menu to return to a previous message…
    2026-08-27 19:39 · 37m ago · turn 1.3M in (1.1M cached) / 4.7k out · $0.7983 · context 67.8k
  BTW I still like the total…
    2026-08-27 20:16 · just now · turn 75.6k in (75.5k cached) / 268 out · $0.0269 · context 75.6k (+11.9k)
```

- **turn** — the turn's token flow summed across every assistant round (a tool-looping turn is several API calls), spelled out in words (`in`/`out`/`cached`) rather than the status line's compact `in(cached)/out` shape.
- **cost** — each assistant message priced at *its own* recorded model's rates (`msg.Model` = "id @ provider"), so a turn spanning a mid-session model switch bills correctly; hidden when nothing contributing is priced.
- **context** — the final round's full prompt, i.e. how big the conversation had grown at turn end; growth since the previous usable row shows in green (`(+11.9k)`). Shrinks and the first usable row show no marker.

All figures come from the per-message `Usage` recorded on each assistant message (persisted across session resume). Legacy rows with no recorded usage keep just the timestamp and are skipped when diffing growth.

Test: `TestRewindPickerShowsTurnUsageAndCost` covers sum vs last-round semantics, per-model pricing, unpriced and usage-less rows, and the growth marker (no previous row / shrink / positive growth skipping a usage-less row).