### PR TITLE
fix(tui): drag-to-select works in tmux

### DIFF
--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -25,8 +25,9 @@ import (
 // The copy goes to the system clipboard via OSC 52 (works locally and over
 // SSH/tmux, subject to the terminal's clipboard-osc52 setting); pbcopy /
 // wl-copy / xclip is the fallback for terminals that ignore OSC 52
-// (Terminal.app). tmux users keep the applyTmuxMouseFix copy-mode binding —
-// tmux swallows the drag before whip ever sees it.
+// (Terminal.app). Inside tmux the drag reaches whip too (tmux forwards it
+// because mouse_any_flag is set), so this same selection works there — no
+// copy-mode override.
 //
 // ponytail: selection is only tracked over the transcript viewport (the common
 // case: copying agent output). The header/dock/input rows aren't selectable,

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -306,9 +305,9 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 	// alone makes most terminals (Ghostty, kitty) suppress their native
 	// drag-selection without sending the drag to anyone. With capture off,
 	// tmux's WheelUpPane binding sees mouse_any_flag=0 and runs 'copy-mode -e',
-	// scrolling tmux's own scrollback instead of the transcript. In tmux the
-	// drag never reaches whip, so applyTmuxMouseFix routes MouseDrag1Pane to
-	// copy-mode for drag-to-copy there. Explicit config wins.
+	// scrolling tmux's own scrollback instead of the transcript. Inside tmux,
+	// tmux forwards the drag to whip (mouse_any_flag is set), so whip's own
+	// selection handles drag-to-copy there too. Explicit config wins.
 	mouseOn := true
 	if cfg.Mouse != nil {
 		mouseOn = *cfg.Mouse
@@ -429,7 +428,6 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 	fmt.Fprint(os.Stdout, "\x1b[9999;1H")
 	if m.mouseOn {
 		enableClickWheelMouse(os.Stdout)
-		applyTmuxMouseFix()
 	}
 	// pick the glamour style that matches the pick/detection resolution;
 	// keep how detection resolved so /report can name the source
@@ -564,25 +562,11 @@ func disableClickWheelMouse(w *os.File) {
 	fmt.Fprint(w, "\x1b[?1002l\x1b[?1000l\x1b[?1006l")
 }
 
-// applyTmuxMouseFix makes plain drag-to-copy work inside tmux while whip
-// captures the mouse for wheel/clicks. tmux's default MouseDrag1Pane binding
-// checks mouse_any_flag (set by our ?1000/?1002) and forwards the drag to the
-// app — but tmux itself never forwards drag bytes from a terminal, so whip's
-// own selection (select.go) can't see them. Rebinding it to copy-mode -M
-// (only when the pane isn't already in a mode and isn't full mouse-tracking)
-// makes the drag open tmux copy-mode selection instead, restoring drag-to-copy.
-// Wheel still reaches whip: WheelUpPane stays bound to send -M. No-op outside
-// tmux or if tmux isn't available.
-func applyTmuxMouseFix() {
-	if os.Getenv("TMUX") == "" {
-		return
-	}
-	// Only override when the pane can still use copy-mode: not in alt-screen,
-	// not already in a mode, and not full/all mouse tracking (in which case the
-	// app genuinely wants the drag). Then select via copy-mode -M.
-	_ = exec.CommandContext(context.Background(), "tmux", "bind-key", "-T", "root", "MouseDrag1Pane", "if-shell", "-F",
-		"#{||:#{alternate_on},#{pane_in_mode},#{mouse_all_flag}}", "send-keys -M", "copy-mode -M").Run()
-}
+// (No applyTmuxMouseFix: inside tmux the drag IS forwarded to whip — tmux's
+// factory MouseDrag1Pane binding checks mouse_any_flag, which our ?1002 sets,
+// and sends every press/motion/release into the pane (verified live). whip's
+// own selection (select.go) paints and copies, exactly like Claude Code. The
+// old copy-mode override was what made "tmux capture kick in".)
 
 // catalogLites converts llm model records into the catalog-cache shape.
 func catalogLites(infos []llm.ModelInfo) []config.ModelInfoLite {
@@ -3497,12 +3481,10 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 			m.append(errStyle.Render("config save failed: " + err.Error()))
 		}
 		m.append(dimStyle.Render("mouse capture: " + onOff(m.mouseOn) + " (on = wheel scroll + ⚡ clicks, the default, drag to select/copy; off = native drag-to-copy, but tmux captures the wheel)"))
-		// We manage click/wheel reporting directly (no motion ?1002), so toggle
-		// the escape ourselves rather than tea.EnableMouseCellMotion (which would
-		// turn motion back on and break native drag-to-copy).
+		// We manage mouse reporting directly, so toggle the escape ourselves
+		// rather than tea.EnableMouseCellMotion.
 		if m.mouseOn {
 			enableClickWheelMouse(os.Stdout)
-			applyTmuxMouseFix()
 		} else {
 			disableClickWheelMouse(os.Stdout)
 		}


### PR DESCRIPTION
## Problem
In tmux, click-and-drag text selection fell into tmux's copy-mode ("tmux capture kicks in") instead of highlighting text, so you couldn't drag-select beyond whip's output. In Claude Code the same drag works natively.

## Root cause
`applyTmuxMouseFix` rebound tmux's `MouseDrag1Pane` to check `mouse_all_flag` (the `?1003` mode). whip enables button-motion `?1002`, which sets `mouse_button_flag` but **not** `mouse_all_flag` — so the binding took the `copy-mode -M` branch and swallowed the drag. Claude Code enables `?1003` (`mouse_all_flag=1`), so the same binding forwards the drag to claude, which paints its own selection.

## Fix
tmux's **factory** `MouseDrag1Pane` binding already checks `mouse_any_flag` — which whip's `?1002` *does* set — and forwards every press/motion/release byte into the pane (verified live with a probe app). So whip's existing in-app selection (`select.go`, the same code that handles drag-to-copy on bare mac terminals) works in tmux unchanged.

The override was never needed. This PR **deletes** `applyTmuxMouseFix` and its two call sites, letting whip's in-app selection handle the drag in tmux — exactly like Claude Code.

## Verification
- Live-tested in a tmux pane: injected a press+drag+release as SGR mouse events into a running whip and confirmed whip paints a reverse-video highlight and copies, with the factory binding.
- Full `internal/tui` test suite passes; `go vet` clean.

## Note
Whip also accidentally unbound the factory `MouseDown1Pane` (click-to-switch-pane) during earlier probing — restored to default (`select-pane -t = ; send-keys -M`).