### PR TITLE
mcp: support ${VAR:-default} expansion and import global ~/.claude.json

### DIFF
--- a/cmd/whip/mcp_cli_test.go
+++ b/cmd/whip/mcp_cli_test.go
@@ -141,6 +141,9 @@ func mcpHome(t *testing.T, mcpBlock string) string {
 	orig := mcp.CodexPath
 	mcp.CodexPath = func() string { return filepath.Join(home, "no-codex.toml") }
 	t.Cleanup(func() { mcp.CodexPath = orig })
+	origG := mcp.ClaudeGlobalPath
+	mcp.ClaudeGlobalPath = func() string { return filepath.Join(home, "no-claude.json") }
+	t.Cleanup(func() { mcp.ClaudeGlobalPath = origG })
 
 	cfg := `{
   "defaultModel": "m1",

--- a/cmd/whip/mcp_import_test.go
+++ b/cmd/whip/mcp_import_test.go
@@ -37,6 +37,10 @@ func importFixture(t *testing.T, mcpImport string) (wd string) {
 	orig := mcp.CodexPath
 	mcp.CodexPath = func() string { return codexFile }
 	t.Cleanup(func() { mcp.CodexPath = orig })
+	// Isolate discovery from the developer's real global ~/.claude.json.
+	origG := mcp.ClaudeGlobalPath
+	mcp.ClaudeGlobalPath = func() string { return filepath.Join(wd, "absent-claude.json") }
+	t.Cleanup(func() { mcp.ClaudeGlobalPath = origG })
 	return wd
 }
 

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -131,11 +131,14 @@ func ParseToolName(name string) (srvKey, tool string, ok bool) {
 	return srvKey, tool, true
 }
 
-// Merge combines server configs by name: whip's own config wins whole-entry
-// over codex, which wins over a project's .mcp.json. No field-level merging —
-// predictable, and matches how claude/codex treat their own scopes.
-func Merge(whip, codex, claude map[string]ServerConfig) map[string]ServerConfig {
-	out := make(map[string]ServerConfig, len(whip)+len(codex)+len(claude))
+// Merge combines server configs by name, lowest precedence first: the global
+// claude config (~/.claude.json), then the project .mcp.json, then codex, and
+// whip's own config always wins whole-entry. No field-level merging —
+// predictable, and matches how claude/codex treat their own scopes (more
+// specific scope beats more general, user-scoped whip beats every import).
+func Merge(whip, codex, claude, claudeGlobal map[string]ServerConfig) map[string]ServerConfig {
+	out := make(map[string]ServerConfig, len(whip)+len(codex)+len(claude)+len(claudeGlobal))
+	maps.Copy(out, claudeGlobal)
 	maps.Copy(out, claude)
 	maps.Copy(out, codex)
 	maps.Copy(out, whip)
@@ -233,16 +236,22 @@ func setSource(src map[string]ServerConfig, path string) {
 // disabled+noted copies. whipCfg entries always pass through.
 func LoadMergedFiltered(cwd string, whipCfg map[string]ServerConfig, policy ImportPolicy) Filtered {
 	errs := map[string]error{}
+	claudeGlobalPath := ClaudeGlobalPath()
+	claudeGlobal, err := LoadClaude(claudeGlobalPath)
+	if err != nil && !os.IsNotExist(err) {
+		errs[claudeGlobalPath] = err
+	}
 	claudePath := filepath.Join(cwd, ".mcp.json")
 	claude, err := LoadClaude(claudePath)
 	if err != nil && !os.IsNotExist(err) {
-		errs[".mcp.json"] = err
+		errs[claudePath] = err
 	}
 	codexPath := CodexPath()
 	codex, err := LoadCodex(codexPath)
 	if err != nil && !os.IsNotExist(err) {
 		errs[codexPath] = err
 	}
+	setSource(claudeGlobal, claudeGlobalPath)
 	setSource(claude, claudePath)
 	setSource(codex, codexPath)
 	setSource(whipCfg, whipConfigPath())
@@ -267,11 +276,15 @@ func LoadMergedFiltered(cwd string, whipCfg map[string]ServerConfig, policy Impo
 		}
 		return kept
 	}
+	claudeGlobalKept := split(claudeGlobal, policy.Claude)
 	claudeKept := split(claude, policy.Claude)
 	codexKept := split(codex, policy.Codex)
-	sources := make(map[string]string, len(whipCfg)+len(codex)+len(claude))
+	sources := make(map[string]string, len(whipCfg)+len(codex)+len(claude)+len(claudeGlobal))
 	for name := range whipCfg {
 		sources[name] = "whip"
+	}
+	for name := range claudeGlobal { // lowest precedence: project, codex, whip all overwrite
+		sources[name] = "~/.claude.json"
 	}
 	for name := range claude {
 		sources[name] = ".mcp.json"
@@ -280,7 +293,7 @@ func LoadMergedFiltered(cwd string, whipCfg map[string]ServerConfig, policy Impo
 		sources[name] = "codex"
 	}
 	return Filtered{
-		Merged:  Merge(whipCfg, codexKept, claudeKept),
+		Merged:  Merge(whipCfg, codexKept, claudeKept, claudeGlobalKept),
 		Blocked: blocked,
 		Sources: sources,
 		Errs:    errs,
@@ -301,6 +314,11 @@ func LoadMerged(cwd string, whipCfg map[string]ServerConfig) (map[string]ServerC
 // CodexPath is the codex CLI's config file location (~/.codex/config.toml).
 // A variable so tests can point it at fixtures.
 var CodexPath = defaultCodexPath
+
+// ClaudeGlobalPath is the claude CLI's global config location
+// (~/.claude.json), which carries user-scoped mcpServers alongside the
+// project .mcp.json. A variable so tests can point it at fixtures.
+var ClaudeGlobalPath = defaultClaudeGlobalPath
 
 // whipConfigPath is whip's own config file location (~/.whip/config.json) —
 // the source of any server from the config's "mcp" block. Best-effort: ""
@@ -345,14 +363,48 @@ func defaultCodexPath() string {
 	return filepath.Join(home, ".codex", "config.toml")
 }
 
+func defaultClaudeGlobalPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude.json")
+}
+
 // expandEnv resolves "$VAR" and "${VAR}" references in config values (claude
-// does this in .mcp.json env blocks; codex expands env vars in its TOML too).
-// Missing variables expand to "".
+// does this in .mcp.json env blocks; codex expands env vars in its TOML too),
+// plus the shell-style default forms "${VAR:-default}" and "${VAR-default}".
+// Missing variables expand to "" (or the default, when the ":-" / "-" form is
+// used). os.Expand alone would treat "${VAR:-default}" as a lookup of a var
+// literally named "VAR:-default", which never resolves — so we pre-extract the
+// default ourselves.
 func expandEnv(v string) string {
 	if !strings.Contains(v, "$") {
 		return v
 	}
-	return os.Expand(v, os.Getenv)
+	return os.Expand(v, expandVar)
+}
+
+// expandVar is os.Expand's mapping func. name is the token inside "${...}" or
+// after "$". For "${VAR:-default}"/"${VAR-default}", os.Expand hands us the
+// whole "VAR:-default"/"VAR-default" string (its brace form allows any bytes
+// but '}'), so we split off the default and resolve VAR ourselves. With ":-"
+// the default also applies when VAR is set-but-empty (shell semantics); with
+// "-" only when VAR is unset.
+func expandVar(name string) string {
+	if key, def, found := strings.Cut(name, ":-"); found {
+		if val := os.Getenv(key); val != "" {
+			return val
+		}
+		return os.Expand(def, os.Getenv) // default may itself reference vars
+	}
+	if key, def, found := strings.Cut(name, "-"); found {
+		if _, ok := os.LookupEnv(key); ok {
+			return os.Getenv(key)
+		}
+		return os.Expand(def, os.Getenv)
+	}
+	return os.Getenv(name)
 }
 
 func expandEnvMap(m map[string]string) map[string]string {

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -160,13 +160,20 @@ func TestMergePrecedence(t *testing.T) {
 	disabled := false
 	whip := map[string]ServerConfig{"a": {Command: []string{"whip-a"}}, "b": {Enabled: &disabled, Command: []string{"whip-b"}}}
 	codex := map[string]ServerConfig{"a": {Command: []string{"codex-a"}}, "c": {Command: []string{"codex-c"}}}
-	claude := map[string]ServerConfig{"a": {Command: []string{"claude-a"}}, "c": {Command: []string{"claude-c"}}}
-	m := Merge(whip, codex, claude)
+	claude := map[string]ServerConfig{"a": {Command: []string{"claude-a"}}, "c": {Command: []string{"claude-c"}}, "d": {Command: []string{"claude-d"}}}
+	global := map[string]ServerConfig{"a": {Command: []string{"global-a"}}, "d": {Command: []string{"global-d"}}, "e": {Command: []string{"global-e"}}}
+	m := Merge(whip, codex, claude, global)
 	if m["a"].Command[0] != "whip-a" {
 		t.Error("whip config must win over codex and claude")
 	}
 	if m["c"].Command[0] != "codex-c" {
 		t.Error("codex must win over claude")
+	}
+	if m["d"].Command[0] != "claude-d" {
+		t.Error("project .mcp.json must win over global ~/.claude.json")
+	}
+	if m["e"].Command[0] != "global-e" {
+		t.Error("global-only entry should survive")
 	}
 	if !m["b"].Disabled() {
 		t.Error("whip-only entry should survive with enabled=false")
@@ -185,6 +192,9 @@ func TestLoadMergedDiscovery(t *testing.T) {
 	orig := CodexPath
 	CodexPath = func() string { return codexFile }
 	defer func() { CodexPath = orig }()
+	origG := ClaudeGlobalPath
+	ClaudeGlobalPath = func() string { return filepath.Join(dir, "absent-claude.json") }
+	defer func() { ClaudeGlobalPath = origG }()
 
 	merged, errs := LoadMerged(dir, map[string]ServerConfig{"mine": {Command: []string{"my-srv"}}})
 	if len(errs) != 0 {
@@ -201,11 +211,59 @@ func TestLoadMergedDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 	merged, errs = LoadMerged(dir, nil)
-	if _, ok := errs[".mcp.json"]; !ok {
-		t.Error("expected a parse error for .mcp.json")
+	if _, ok := errs[filepath.Join(dir, ".mcp.json")]; !ok {
+		t.Errorf("expected a parse error for .mcp.json, got %v", errs)
 	}
 	if _, ok := merged["cdx"]; !ok {
 		t.Error("codex servers should still merge when .mcp.json is broken")
+	}
+}
+
+// TestLoadMergedGlobalClaude covers the user's scenario: a server defined only
+// in the global ~/.claude.json mcpServers (e.g. a remote with env-expanded
+// headers) is discovered and merged, with the project .mcp.json winning on a
+// name conflict.
+func TestLoadMergedGlobalClaude(t *testing.T) {
+	t.Setenv("OFFICE_SESSION_NAME", "sess-123")
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "claude.json")
+	if err := os.WriteFile(globalFile, []byte(`{
+		"mcpServers": {
+			"inf-memory": {"type": "http", "url": "http://inf-development-office/api/mcp",
+				"headers": {"X-Office-Session": "${OFFICE_SESSION_NAME:-}"}},
+			"shared": {"command": "global-srv"}
+		}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(
+		`{"mcpServers": {"shared": {"command": "proj-srv"}}}`,
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	origG := ClaudeGlobalPath
+	ClaudeGlobalPath = func() string { return globalFile }
+	defer func() { ClaudeGlobalPath = origG }()
+	orig := CodexPath
+	CodexPath = func() string { return filepath.Join(dir, "absent-codex.toml") }
+	defer func() { CodexPath = orig }()
+
+	merged, errs := LoadMerged(dir, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected discovery errors: %v", errs)
+	}
+	mem, ok := merged["inf-memory"]
+	if !ok {
+		t.Fatal("global ~/.claude.json server should be discovered")
+	}
+	if !mem.Remote() || mem.Headers["X-Office-Session"] != "sess-123" {
+		t.Errorf("inf-memory should be remote with env-expanded header, got %+v", mem)
+	}
+	if got := merged["shared"].Command[0]; got != "proj-srv" {
+		t.Errorf("project .mcp.json must win over global on conflict, got %q", got)
+	}
+	if got := merged["inf-memory"].Source; got != globalFile {
+		t.Errorf("inf-memory.Source = %q, want %q", got, globalFile)
 	}
 }
 
@@ -229,6 +287,9 @@ func TestLoadMergedFilteredPolicy(t *testing.T) {
 	orig := CodexPath
 	CodexPath = func() string { return codexFile }
 	defer func() { CodexPath = orig }()
+	origG := ClaudeGlobalPath
+	ClaudeGlobalPath = func() string { return filepath.Join(dir, "absent-claude.json") }
+	defer func() { ClaudeGlobalPath = origG }()
 
 	// The node_repl scenario: codex source on, node_repl excluded.
 	policy := ImportPolicy{Codex: ImportSourcePolicy{
@@ -325,6 +386,9 @@ func TestManagerFromBlockedDiscovery(t *testing.T) {
 	orig := CodexPath
 	CodexPath = func() string { return codexFile }
 	defer func() { CodexPath = orig }()
+	origG := ClaudeGlobalPath
+	ClaudeGlobalPath = func() string { return filepath.Join(dir, "absent-claude.json") }
+	defer func() { ClaudeGlobalPath = origG }()
 
 	f := LoadMergedFiltered(dir, nil, ImportPolicyFrom(&config.MCPImport{
 		Codex: &config.MCPImportSource{Exclude: []string{"node_repl"}},
@@ -360,6 +424,9 @@ func TestManagerStatusSource(t *testing.T) {
 	orig := CodexPath
 	CodexPath = func() string { return codexFile }
 	defer func() { CodexPath = orig }()
+	origG := ClaudeGlobalPath
+	ClaudeGlobalPath = func() string { return filepath.Join(dir, "absent-claude.json") }
+	defer func() { ClaudeGlobalPath = origG }()
 	f := LoadMergedFiltered(dir, nil, ImportPolicyFrom(nil))
 	mgr := NewManager(f.Merged)
 	sts := mgr.Statuses()


### PR DESCRIPTION
Two fixes to MCP config handling, both surfaced by a real server (`inf-memory`) defined in a user's global claude config.

## 1. Shell-style `${VAR:-default}` env expansion

`expandEnv` used `os.Expand(v, os.Getenv)`, which treats `${OFFICE_SESSION_NAME:-}` as a lookup of a var literally named `OFFICE_SESSION_NAME:-` → always empty. So a header like `X-Office-Session: ${OFFICE_SESSION_NAME:-}` was sent empty even when the var was set, and the documented "default" never kicked in.

New `expandVar` mapping func handles `${VAR:-default}` and `${VAR-default}` with correct shell semantics:
- `:-` also fires when the var is set-but-empty
- `-` only fires when unset
- the default may itself reference other vars (`${A:-$B}`)

Applies to both claude and codex imports (both funnel through `expandEnvMap`).

## 2. Import the global `~/.claude.json` `mcpServers`

`LoadMergedFiltered` only read the project `.mcp.json` + codex + whip config, so a server defined only in the user's global `~/.claude.json` (e.g. `inf-memory`) never reached whip.

It now discovers that file too. Precedence (low → high), matching how more-specific scope wins and whip always wins:

`global ~/.claude.json`  <  project `.mcp.json`  <  codex  <  whip

A new `ClaudeGlobalPath` var (mirroring `CodexPath`) makes the location test-overridable.

## Tests
- **New `TestLoadMergedGlobalClaude`** — the exact scenario: a global-only remote with an env-expanded header, and the project `.mcp.json` winning on a name conflict.
- Extended `TestMergePrecedence` for the new global layer.
- Existing discovery/CLI tests now stub `ClaudeGlobalPath` — they were reading the developer's real `~/.claude.json` and failing locally (this is how the isolation gap surfaced).

## CI checks run locally
- `gofmt -s` clean, `go vet` clean, `golangci-lint` (v2.13.1) 0 issues
- Portable test set with `-race -shuffle=on` + coverage — all pass, total coverage **90.6%** (≥ 90% floor)
- Cross-compile `linux/amd64, linux/arm64, darwin/amd64, darwin/arm64` all build
- `go mod tidy` is a no-op

(The two `internal/tui` status test failures in the full local suite are pre-existing on base — a worktree path-length artifact — and that package is excluded from CI's test job.)