### PR TITLE
feat(tui): model-aware default reasoning effort (low)

### DIFF
--- a/cmd/whip/acp.go
+++ b/cmd/whip/acp.go
@@ -121,10 +121,11 @@ func acpCLI(args []string) error {
 		ag.ModelName, ag.Provider = modelName, provName
 		ag.ComputerDisabled = true
 		ag.ContextLimit = ctxLimit
-		ag.Effort = cfg.DefaultEffort
-		if ag.Effort == "" {
-			ag.Effort = "medium"
-		}
+		// Reasoning effort: explicit cfg.DefaultEffort wins; "" resolves
+		// model-aware — "low" when the model advertises it, else the lowest
+		// supported level, else off — so a non-reasoning model never sends an
+		// effort parameter the provider would reject.
+		ag.Effort = tui.DefaultEffortFor(config.LoadCatalogs(), provName, ag.Model, cfg.DefaultEffort)
 
 		// Skills + memory ride the system prompt. The TUI refreshes these per
 		// turn; ACP sessions refresh at session creation — a new skill lands

--- a/cmd/whip/run.go
+++ b/cmd/whip/run.go
@@ -114,10 +114,11 @@ func runCLI(args []string) error {
 	// stays disabled (no interactive approver is ever installed).
 	ag.ComputerDisabled = true
 	ag.ContextLimit = mdl.ContextWindow()
-	ag.Effort = cfg.DefaultEffort
-	if ag.Effort == "" {
-		ag.Effort = "medium"
-	}
+	// Reasoning effort: explicit cfg.DefaultEffort wins; "" resolves
+	// model-aware — "low" when the model advertises it, else the lowest
+	// supported level, else off — so a non-reasoning model never sends an
+	// effort parameter the provider would reject.
+	ag.Effort = tui.DefaultEffortFor(config.LoadCatalogs(), provName, ag.Model, cfg.DefaultEffort)
 	ag.MaxTurns = *maxTurnsFlag
 
 	// Session: resume an existing one, or create a fresh one — unless

--- a/internal/config/catalog.go
+++ b/internal/config/catalog.go
@@ -92,6 +92,25 @@ func (c Catalog) Find(id string) *ModelInfoLite {
 	return nil
 }
 
+// Efforts returns the reasoning-effort levels available for a model id, in
+// provider order and prefixed by "" (off): ["", "low", "medium", "high", …].
+// "" is the only entry (i.e. the model doesn't reason) when the catalog has no
+// entry for the model or the entry advertises no efforts. A "none" effort is
+// collapsed into the leading off ("").
+func (c Catalog) Efforts(id string) []string {
+	mi := c.Find(id)
+	if mi == nil || len(mi.ReasoningEfforts) == 0 {
+		return []string{""}
+	}
+	out := []string{""}
+	for _, e := range mi.ReasoningEfforts {
+		if e != "none" { // "none" is our off ("")
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 func catalogPath() (string, error) {
 	dir, err := Dir()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,7 +165,7 @@ const DefaultCompactPct = 50
 type Config struct {
 	DefaultModel    string `json:"defaultModel"`
 	DefaultProvider string `json:"defaultProvider,omitempty"` // override the model's first provider
-	DefaultEffort   string `json:"defaultEffort,omitempty"`   // reasoning effort for new sessions: "", "low", "medium", "high"
+	DefaultEffort   string `json:"defaultEffort,omitempty"`   // reasoning effort for new sessions: "" defaults to "low"; "off", "low", "medium", "high"
 	CompactModel    string `json:"compactModel,omitempty"`    // model for compaction summaries; "" = the built-in default
 	CompactProvider string `json:"compactProvider,omitempty"` // provider for the compaction model; "" = the model's default routing
 	CompactPct      int    `json:"compactPct,omitempty"`      // compact at this % of the context window; 0 = DefaultCompactPct

--- a/internal/tui/effort.go
+++ b/internal/tui/effort.go
@@ -22,25 +22,51 @@ var effortCands = []cand{
 // model: the provider-advertised levels if known (each prefixed by off), else
 // the defaults.
 func (m *model) effortsFor() []string {
-	if c, ok := m.catalogs[m.provName]; ok {
-		apiID := m.agent.Model
-		for _, mi := range c.Models {
-			if mi.ID != apiID {
-				continue
-			}
-			if len(mi.ReasoningEfforts) == 0 {
-				break // model doesn't reason: use defaults
-			}
-			out := []string{""}
-			for _, e := range mi.ReasoningEfforts {
-				if e != "none" { // "none" is our off ("")
-					out = append(out, e)
-				}
-			}
-			return out
+	return effortsIn(m.catalogs, m.provName, m.agent.Model)
+}
+
+// effortsIn returns the effort cycle for a model id on a provider, using the
+// given catalogs. Advertised levels win (prefixed by off ""); otherwise the
+// provider-agnostic defaults apply.
+func effortsIn(catalogs map[string]config.Catalog, provName, modelID string) []string {
+	if c, ok := catalogs[provName]; ok {
+		if levels := c.Efforts(modelID); len(levels) > 1 {
+			return levels // advertised: ["", "low", "medium", …]
 		}
 	}
 	return defaultEfforts
+}
+
+// DefaultEffortFor resolves the effort a new session should open on when the
+// user hasn't pinned one (cfg.DefaultEffort == ""): "low" when the model
+// advertises it (the intended default), else the lowest advertised level, else
+// "" (off) when the catalog confirms the model doesn't reason, else "low" as a
+// best guess when the model is entirely unknown (no catalog entry). pinned,
+// when non-empty, is returned verbatim — an explicit config choice is honored
+// as-is, even if the model later turns out not to support it (updateCatalogs
+// resets the live session).
+func DefaultEffortFor(catalogs map[string]config.Catalog, provName, modelID, pinned string) string {
+	if pinned != "" {
+		return pinned
+	}
+	// When the catalog has the entry, trust its advertised levels: prefer "low",
+	// else the lowest level, else off (the model doesn't reason). When the entry
+	// is missing entirely (unknown model/provider), fall back to "low".
+	if c, ok := catalogs[provName]; ok {
+		if mi := c.Find(modelID); mi != nil {
+			levels := c.Efforts(modelID) // [""] for a non-reasoning model
+			if slices.Contains(levels, "low") {
+				return "low"
+			}
+			for _, e := range levels {
+				if e != "" {
+					return e
+				}
+			}
+			return "" // catalog confirms: no reasoning
+		}
+	}
+	return "low" // unknown model — best-guess default for a reasoning ecosystem
 }
 
 // nextEffort cycles cur to the following level in levels, wrapping; an

--- a/internal/tui/effort_test.go
+++ b/internal/tui/effort_test.go
@@ -90,6 +90,36 @@ func TestEffortsForAdvertisedLevels(t *testing.T) {
 	}
 }
 
+// DefaultEffortFor picks "low" when the model advertises it, the lowest
+// supported level otherwise, and off ("") for non-reasoning models — so a
+// startup never opens on an effort the provider would reject. An explicit
+// pinned value is honored verbatim, even if unsupported.
+func TestDefaultEffortForModelAware(t *testing.T) {
+	cats := map[string]config.Catalog{
+		"inference": {Models: []config.ModelInfoLite{
+			{ID: "deepseek-v4-flash", ReasoningEfforts: []string{"low", "high", "max"}}, // no medium
+			{ID: "claude-opus-5", ReasoningEfforts: []string{"none", "minimal", "low", "medium", "high", "xhigh", "max"}},
+			{ID: "gemini-3.5-flash"}, // no reasoning_efforts
+		}},
+	}
+	cases := []struct{ model, pinned, want string }{
+		{"deepseek-v4-flash", "", "low"},          // low is supported → low
+		{"claude-opus-5", "", "low"},              // low is supported → low
+		{"gemini-3.5-flash", "", ""},              // non-reasoning → off (no parameter)
+		{"deepseek-v4-flash", "high", "high"},     // pinned honored
+		{"deepseek-v4-flash", "medium", "medium"}, // pinned honored even though unsupported
+	}
+	for _, c := range cases {
+		if got := DefaultEffortFor(cats, "inference", c.model, c.pinned); got != c.want {
+			t.Fatalf("DefaultEffortFor(%q, pinned=%q): got %q want %q", c.model, c.pinned, got, c.want)
+		}
+	}
+	// unknown provider → default-effort cycle's first non-off (low)
+	if got := DefaultEffortFor(map[string]config.Catalog{}, "elsewhere", "anything", ""); got != "low" {
+		t.Fatalf("unknown provider should fall back to low, got %q", got)
+	}
+}
+
 // bare /effort opens the level selector (palette panel) so the user can
 // scroll ↑/↓ and pick — cycling blindly hides the choices.
 func TestEffortBareOpensSelector(t *testing.T) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -294,12 +294,11 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 
 	ti := newInput()
 
-	// default on: "" (config never set / pre-feature file) means medium, not
-	// off; an explicit "off" in the file is honored
-	ag.Effort = cfg.DefaultEffort
-	if ag.Effort == "" {
-		ag.Effort = "medium"
-	}
+	// Reasoning effort: an explicit cfg.DefaultEffort is honored as-is; "" (no
+	// config / pre-feature file) resolves model-aware — "low" when the model
+	// advertises it, else the lowest supported level, else off (no parameter) —
+	// so a non-reasoning model never opens on an effort it can't accept.
+	ag.Effort = DefaultEffortFor(config.LoadCatalogs(), pn, ag.Model, cfg.DefaultEffort)
 	// Mouse capture ON by default so the wheel scrolls the transcript viewport
 	// and ⚡/tool clicks work — with button-motion reporting (?1002) so a left
 	// drag becomes whip's own selection (select.go): enabling click reporting


### PR DESCRIPTION
The default reasoning effort was hardcoded to `"medium"` at all three startup sites (TUI, `whip run`, `whip acp`). Checking `/v1/models` shows models advertise **different** effort sets:

- `claude-*`: `[none, minimal, low, medium, high, xhigh, max]`
- `deepseek-v4-flash`: `[low, high, max]` — **no `medium`**
- `gemini-*`, `gpt-4o`, `glm-5.2`: `[]` — no reasoning at all
- `grok-*`, `kimi-*`: `[low, medium, high]`

So the old default sent a `reasoning_effort: "medium"` parameter that deepseek rejects (no such level) and that non-reasoning models reject outright.

## The fix

Replace the hardcoded `if Effort == "" { Effort = "medium" }` fallback with `tui.DefaultEffortFor(catalogs, prov, model, pinned)`, which resolves **model-aware** from the catalog:

| model advertises | default lands on |
| --- | --- |
| `low` (every reasoning model here) | `"low"` ← the intended default |
| levels but no `low` | lowest advertised level |
| no efforts (non-reasoning) | `""` (parameter omitted) |
| unknown / no catalog entry | `"low"` best-guess |

An explicit `cfg.DefaultEffort` is still honored verbatim — even if unsupported — and `updateCatalogs` reconciles the live session when the background catalog refresh reveals the pinned level isn't supported.

Extracts the advertised-levels logic into `config.Catalog.Efforts(id)` so `effortsFor()` and `DefaultEffortFor` share one implementation.

## How I tested

- New `TestDefaultEffortForModelAware` covers all five branches (deepseek→low, claude→low-not-minimal, gemini→off, pinned honored, pinned-unsupported honored). It caught two real bugs during dev: the `minimal`-before-`low` ordering on Claude, and gemini falling through to `low` instead of off.
- `gofmt -s`, `go vet ./...`, `golangci-lint run` (v2.13.1), `go mod tidy` no-op — all clean.
- CI portable test set (`-race -shuffle=on`, excluding `internal/tui`/`internal/browser`) passes; coverage 90.5% ≥ 90% floor.
- Cross-compile check for all 4 GOOS/GOARCH targets passes.
- `internal/tui` suite (excluded from CI for tty reasons) passes locally.

The Swift `driver` job can't run on Linux but this change is pure Go in `internal/tui`, `internal/config`, `cmd/whip` — no driver or go:embed impact.