### PR TITLE
feat(agent,tui): journal background-task events for full transcript on open

### DIFF
--- a/.ai-docs/plans/agent-ux-batch/PLAN.md
+++ b/.ai-docs/plans/agent-ux-batch/PLAN.md
@@ -1,0 +1,510 @@
+# Agent UX batch — execution plan
+
+Signed off by user 2026-08-05 ("i need all these to be done"). Research and
+root-cause work already live in this directory:
+
+- `wait-tool-research.md` — 6-harness wait/poll research, distilled
+- `opencode-speed.md` — why opencode feels fast (prompt caching + O(1) render)
+- `tui-findings.md` — TUI root causes (journal, spawn lag, busy steering, persistence)
+
+This file is the build plan. **Status: written, not started.** Work top-down;
+each item is its own branch + PR. Update checkboxes as things land. `task
+check` (gofmt -s + go vet + go test ./...) must pass per item; add `go test
+-race ./...` for anything touching goroutines (items 1, 3, 4, 5, 6).
+
+Standing rules (from the new-feature-development skill):
+- Minimal is the product. `// ponytail:`-mark deliberate shortcuts.
+- Errors are tool output (`"Error: <msg>"`), never loop-abort. Bound all output.
+- Channels over locks; every goroutine has an owner and an exit.
+- Docs are part of the diff: `docs/features.md` section + roadmap checkbox per
+  shipped item; `docs/concurrency.md` if a new channel pattern is introduced.
+- Session persistence correctness (`--resume`) is part of any feature that
+  adds message-adjacent state.
+
+---
+
+## Item 1 — `wait` tool: kill sleep-poll turns
+
+Branch: `feat/wait-tool`
+
+**What it does:** the model calls `wait` with a shell command, a success
+condition, an interval, and a timeout. A harness-owned poller goroutine loops
+the command at the interval — zero LLM turns while waiting. On state change
+(condition met / timeout / command error), exactly one message re-enters the
+agent loop: steered at the next loop boundary if the agent is busy, or a
+machine-authored wake turn if idle. Research: `wait-tool-research.md`.
+
+**Goal:** replace `sleep 60 && gh pr checks` loops (observed: 28M tokens on an
+8-minute CI watch) with one tool call + one completion message.
+
+**Non-goals:** cron/scheduling (that's `/schedule`), auto-backgrounding of
+arbitrary bash calls (later, Item 7), adaptive backoff ladder (ponytail later
+if fixed intervals prove noisy), file watching.
+
+### Design
+
+New file `internal/tools/wait.go` (tool def + Run), new file
+`internal/agent/wait.go` (poller registry + goroutine). Surfaces: tool,
+agent-loop (idle-wake hook), system prompt (one line), TUI (installs the wake
+hook). No config, no persistence (waits are live-only; a dead process's waits
+die with it — same as background subagents pre-Item-5).
+
+Tool def (appended in `tools.All()` — subagents get it too, which is fine):
+
+```
+wait(command, until?, interval?, timeout?)
+  command:  shell command to run repeatedly (same bashrun path as bash tool)
+  until:    optional regex; success = exit 0 AND (until absent OR stdout matches)
+  interval: seconds between runs, default 10, min 2
+  timeout:  seconds before giving up, default 600, max 3600
+Returns immediately: "Waiting on <desc> (wait-3): checking every 10s, giving
+up after 10m. You will be notified once — do NOT poll or sleep-check."
+```
+
+Registry (`internal/agent/wait.go`):
+
+```go
+type waitRegistry struct {
+    mu    sync.Mutex
+    waits map[string]*waitTask   // id "wait-<n>" (reuse taskSlug-style counter)
+    OnWake func(text string)     // installed by TUI; nil headless
+}
+type waitTask struct {
+    id string; command, until string; interval, timeout time.Duration
+    cancel context.CancelFunc; done atomic.Bool
+}
+```
+
+Poller goroutine per wait (owner = registry; exits on condition, timeout,
+cancel, or agent teardown — plumbed via a registry-level context canceled in
+a `Close()` the TUI/agent calls on session switch):
+
+```
+ticker at interval → run command via bashrun (bounded, same timeout per run
+as interval) → evaluate condition:
+  met      → deliver("[wait-3 done] <command> succeeded: <last ~2KB stdout>")
+  timeout  → deliver("[wait-3 timeout] gave up after 10m; last output: …")
+  run err  → count; 3 consecutive errors also delivers as failure (hermes
+             3-strike lesson) so a broken command doesn't poll for an hour
+deliver() = once (atomic.Bool CAS): if a turn is running → a.Steer(msg)
+            (drained at next loop boundary, agent.go:408-421);
+            else → OnWake(msg) → TUI submitTurn(msg, false) machine turn.
+```
+
+Busy-vs-idle: the registry needs to know. Cheapest correct source: the agent
+already knows when a Turn is in flight — add `a.TurnRunning() bool` guarded by
+the existing turn mutex (or an atomic set at Turn entry/exit). If that's
+awkward, invert it: always `Steer`, and have the TUI's wake hook only used
+when `!m.busy` — but Steer on an idle agent parks the message until the next
+turn, so idle must go through OnWake. Verify TurnRunning() against
+double-submit races (a wait firing during submitTurn's busy-set window):
+mitigate by having OnWake re-check `m.busy` and fall back to queueing.
+
+**Interruptible waits** (codex/oh-my-pi lesson): a new user message while a
+wait is pending does NOT cancel the wait (waits are cheap, no tokens) — the
+user can `/waits` + cancel explicitly. Cancel surface: extend `/subagents`
+list or add `/waits` listing + `/waits cancel <id>` calling registry cancel.
+Ponytail option: fold waits INTO the existing task dock as rows (they're
+conceptually background tasks without an LLM) — check effort; if the dock
+code generalizes cleanly, do that instead of a new /waits command.
+
+System prompt: one line in the main prompt — "To wait for an external
+condition (CI, deploys, servers), use the `wait` tool; never poll with
+`sleep` loops — you will be notified once when the condition changes."
+
+### Tests (internal/agent/wait_test.go, internal/tools test for def parsing)
+
+- Poller fires deliver exactly once on condition-met (fake command via a
+  temp script; short intervals).
+- Timeout path delivers timeout message.
+- 3-strike error path.
+- Busy → Steer (message appears in agent Messages after loop boundary in the
+  fake-provider loop test); idle → OnWake invoked.
+- Cancel stops the ticker, no delivery.
+- Race: `-race` over concurrent waits + cancel + settle.
+- TUI headless: OnWake wiring → machine turn submitted when idle; steered
+  path when busy.
+
+### Docs
+
+`docs/features.md` section (behavior → code → tests); roadmap checkbox if a
+matching entry exists (grep "wait" docs/roadmap.md); one line in
+`docs/tools.md` tool table.
+
+---
+
+## Item 2 — prompt caching in internal/llm
+
+Branch: `feat/prompt-caching`
+
+**What it does:** stamps provider cache hints so intra-turn tool round-trips
+hit the provider's prompt-prefix cache instead of reprocessing the full
+conversation. This is the measured root of opencode's speed
+(`opencode-speed.md`): their `cache-policy.ts` stamps ephemeral breakpoints at
+[last tool def, last system part, latest user message] and pins
+`promptCacheKey = sessionID` for OpenAI-shaped APIs.
+
+**Goal:** `Usage.Cached()` (already parsed! openai.go:372-379) becomes nonzero
+on typical turns; TTFT on intra-turn calls drops.
+
+**Non-goals:** response caching, provider-specificAnthropic-beta headers
+beyond the standard fields, caching for one-shot `whip run` invocations
+(harmless if it happens anyway).
+
+### Design
+
+whip speaks OpenAI chat-completions JSON (`internal/llm/openai.go`) to
+multiple providers (OpenAI, OpenRouter, Moonshot/Kimi, Anthropic-compatible
+gateways, inference.net). Two mechanisms, both additive JSON fields:
+
+1. **`prompt_cache_key`** (OpenAI + compatible: openrouter, xai, azure):
+   add `PromptCacheKey string \`json:"prompt_cache_key,omitempty"\`` to
+   `Request` (openai.go:348). Value = session ID. Agent needs to know it:
+   `Agent.SetSessionID` already exists (called from wireTasks) — thread it to
+   a new `Client.SessionID` field or onto Request at call time. Client-level
+   field is simplest: set when the TUI establishes/resumes a session;
+   subagents get their own task-scoped key (`parent-session/task-id`) so
+   their caches don't collide.
+
+2. **Anthropic-style `cache_control` breakpoints**: gateways that accept
+   Anthropic-shaped payloads want `cache_control: {type:"ephemeral"}` on
+   message content parts. whip's `Message.Content` is a plain string for the
+   OpenAI wire format; breakpoints mean emitting content as a parts array with
+   the extra field for providers that understand it. This needs a
+   provider-capability signal — read `docs/models-providers.md` and the
+   config provider block before designing; likely a per-provider config flag
+   or base-URL heuristic (ponytail: ship `prompt_cache_key` first, gate
+   cache_control behind a provider config knob `"cache_control": true`).
+
+Also required for hits (verify, fix if violated):
+- **Byte-stable prefix**: system prompt must be identical across turns of a
+  session (check: does anything append turn-varying content to the system
+  message — timestamps, cwd churn, memory file mtime? Memory DOES change
+  between turns when the model remembers things — that's mid-conversation
+  prefix mutation; acceptable, cache resumes after the mutation point, but
+  keep memory block at the END of the system prompt so the stable part stays
+  prefix-maximal. Audit where the memory block is concatenated.)
+- **Deterministic tool ordering**: `AllTools()` order must be stable
+  (grep for map iteration feeding the tool list — MCP tools especially;
+  sort if needed).
+
+### Tests
+
+- Unit: request JSON includes `prompt_cache_key` when session set; omitted
+  when empty. cache_control emitted only when the provider flag is on.
+- Loop test with fake provider: capture two consecutive requests, assert
+  byte-identical prefix up to the latest user message (guards regressions
+  that silently break caching — e.g. someone adding a timestamp to the
+  system prompt).
+- Ordering test: AllTools() stable across calls with MCP tools present.
+- Manual verification: run a session against a real provider, watch
+  `Usage.Cached()` climb; add it to the status line if it isn't visible
+  (check current usage display first).
+
+### Docs
+
+`docs/features.md` section; `docs/models-providers.md` note about which
+providers get which mechanism.
+
+---
+
+## Item 3 — subagent event journal (open a task, see full history)
+
+Branch: `feat/task-journal`
+
+**Root cause (confirmed):** `openTask` (internal/tui/tasks.go:165-201) seeds
+the pane with header+prompt, then `Subscribe` receives only FUTURE events.
+`emitter()` (internal/agent/background.go:305) broadcasts to current
+subscribers and drops everything. Settled tasks show only the final Report.
+
+**What it does:** the registry keeps a bounded per-task journal of every
+emitted event; `openTask` replays it (formatted like the live handlers) and
+subscribes atomically so nothing is missed or duplicated.
+
+### Design
+
+- New type in `internal/agent/background.go`:
+
+```go
+type journaledEvent struct {
+    kind  int    // mirrors taskEventMsg kinds: 0 text, 1 tool start,
+                  // 2 tool end, 3 steer, 4 compact
+    s, s2 string // text / tool name+args / result
+}
+```
+
+- Registry field `journal map[string][]journaledEvent` + byte budget
+  (~128KB per task; on overflow drop oldest and mark `truncated bool` once —
+  replay renders "[earlier output dropped]" at the top). Text deltas are
+  fine-grained; coalesce consecutive kind-0 appends into one entry's string
+  to keep the slice small.
+- `emitter()` appends to the journal under `mu` before broadcasting (same
+  lock hold — broadcast already snapshots subscribers under mu).
+- New method `SubscribeWithJournal(id string, ev Events) ([]journaledEvent,
+  bool)`: one lock hold — returns journal snapshot AND registers subscriber.
+  Replaces `Subscribe` in `openTask`; keep `Subscribe` for other callers if
+  any (grep; if only openTask uses it, fold and delete the old one —
+  ponytail: one method).
+- `openTask` renders the journal through the SAME formatting code as live
+  `taskEventMsg` handling — factor the render into a helper
+  (`renderTaskEvent(buf, kind, s, s2)`) so replay and live can never drift.
+- Journal freed on `ClearSettled` (delete with the task) and on settle IF
+  nobody opens views... no — settled tasks' journal IS their history until
+  cleared; keep until ClearSettled. Memory bound: tasks × 128KB, fine.
+- Steers into the task (taskSend) and follow-up turns: follow-up turn events
+  (taskSend's ev closure) should also journal if the task is settled+open...
+  ponytail: journal only the registry-emitter stream (the original run);
+  follow-up turns already render into the open view and are covered
+  properly by Item 5 persistence.
+
+### Tests
+
+- Loop test (fake provider): start background task, let it emit text + tool
+  events, settle; THEN openTask in a headless model; assert buf contains the
+  full pre-open transcript in order.
+- Overflow: force >budget events, assert marker + retained tail.
+- Atomicity: concurrent SubscribeWithJournal vs emitter — no missed/dup
+  events (count-based assertion, `-race`).
+- ClearSettled frees journals.
+
+### Docs
+
+`docs/features.md` subagent-view section update.
+
+---
+
+## Item 4 — busy-state steering while waiting on subagents
+
+Branch: `feat/busy-steer`
+
+**What it does:** when the user types while a turn is running AND the turn's
+only in-flight work is foreground subagent tool calls, the message is
+delivered as a steer into the live turn (`Agent.Steer`, drained at the next
+loop boundary) instead of queueing behind the whole turn. Queue behavior is
+unchanged when real tools (bash/edit/…) are mid-flight.
+
+Research notes: `tui-findings.md` §C + §E (opencode re-checks steer after
+every turn; codex interrupts waits on input).
+
+### Design
+
+1. Agent-side observability (`internal/agent`):
+   - runTools (agent.go:441+) tracks in-flight tool names:
+     `a.inflight sync.Map` (or mutex-guarded map[string]int) — increment at
+     tool goroutine start (after lock acquisition, where OnToolStart fires),
+     decrement at end.
+   - `func (a *Agent) InFlightTools() []string` — snapshot, sorted.
+   - `func (a *Agent) WaitingOnSubagents() bool` — true iff a turn is
+     running AND inflight non-empty AND every entry == "subagent".
+     (Empty inflight = mid-generation; treat as NOT waiting — typing during
+     generation keeps queue semantics for now; widening that is a separate
+     decision, see open questions in tui-findings.md §C.)
+2. TUI submit path (tui.go ~2591, the busy+enter branch):
+   - `if m.agent.WaitingOnSubagents() → m.agent.Steer(text)` + local echo as
+     a steer row (reuse the steeredMsg rendering style, prefixed
+     "you (steer):") — do NOT also queue it.
+   - else → current queue behavior unchanged.
+   - Input affordance: when WaitingOnSubagents, input placeholder switches to
+     "steer this turn… (enter)"; when busy otherwise, "queued — sent when the
+     turn ends". A cheap `placeholderFor()` consulted on refresh.
+3. Empty-enter cancel path stays exactly as-is (explicit user intent,
+   tui.go:2027 comment).
+4. Steered message content: the model sees the user's text as a normal
+   steered user message — same shape as background-task reports. No special
+   wrapper needed; the loop-boundary injection already renders OnSteer.
+
+Race notes: WaitingOnSubagents is a snapshot — by the time Steer lands the
+subagent may have finished and real tools started. Harmless: Steer is
+loop-boundary-delivered regardless; worst case the user message arrives
+mid-turn (which is what steering IS). The queue path remains the
+conservative default.
+
+### Tests
+
+- agent: inflight tracking counts across parallel batches (table test with
+  scripted tool durations); WaitingOnSubagents true only for pure-subagent
+  in-flight sets.
+- Loop test: steer injected while subagent tool blocked → message appears at
+  next boundary, turn continues (existing steer tests are the pattern —
+  agent_test.go).
+- TUI headless: busy + fake waiting-state → submit routes to Steer (assert
+  agent.Messages / pending), queue stays empty; busy + bash in flight →
+  routes to queue. Placeholder text switches.
+- `-race`: inflight map under parallel tool execution.
+
+### Docs
+
+`docs/features.md` (busy/queue section update); key-hint text if the
+placeholder changes are user-visible enough to document (they are).
+
+---
+
+## Item 5 — subagent session persistence with attribution
+
+Branch: `feat/subagent-session-persistence`
+
+**What it does:** a subagent's full message transcript persists to the
+session store (SQLite, ~/.whip) attributed to its parent session and task id;
+`--resume` shows restored tasks with their transcripts; the session list
+shows subagent sessions nested under their parent.
+
+Current state: only task METADATA persists (`SaveTask`, tui.go:2807-2820 —
+id, description, prompt, status, report, times). The transcript lives in the
+retained `BackgroundTask.sub *Agent` in memory and dies with the process.
+Restored tasks (`Restored: true`) have no transcript at all.
+
+### Design
+
+1. Schema (`internal/session/session.go`, follow the existing ALTER TABLE
+   additive-migration pattern at :144-148):
+   - `sessions ADD COLUMN parent_session_id TEXT NOT NULL DEFAULT ''`
+   - `sessions ADD COLUMN task_id TEXT NOT NULL DEFAULT ''`
+   - (kind derivable: parent_session_id != '' ⇒ subagent)
+   - Subagent session id: `<parentID>/task/<taskID>` — deterministic, so
+     re-persist is idempotent and resume can find it.
+2. Save path: subagent messages are `t.sub.Messages`. Persist incrementally
+   the same way the main session does — the StartBackground goroutine
+   (background.go:264-284) wraps the turn; simplest correct version:
+   **persist at settle** (after `Turn` returns, before/after `settle` — one
+   `Save(subSessionID, 0, sub.Messages, model, provider)`), PLUS a
+   **mid-run checkpoint every N appended messages** only if settle-only
+   proves lossy in practice. Ponytail decision: settle-only first, note the
+   checkpoint option. Follow-up turns (taskSend path) must re-persist after
+   each follow-up — hook the same save after the follow-up Turn completes.
+   OnRecord already gives a persistence seam; this is a second writer to a
+   DIFFERENT table row (messages), keep it in background.go next to settle,
+   guarded by the same session-id publication (SetSessionID pattern — the
+   parent session id must be known; it is, via recordSession()).
+3. Resume:
+   - Loading a session (`--resume`) already restores task rows as
+     `Restored: true` (tui.go:701 area). Extend: when restoring a task, look
+     up `<sessionID>/task/<taskID>`; if messages exist, keep them on the
+     restored BackgroundTask (new field `Transcript []llm.Message` or lazy
+     load on openTask — lazy is cleaner: `openTask` on a Restored task reads
+     the store when store != nil).
+   - Restored task detail view renders the persisted transcript read-only
+     (reuse Item 3's `renderTaskEvent` formatting by converting messages →
+     journaledEvent-ish render, or a simpler message-level renderer —
+     decide during implementation; simplest: role-labeled blocks, tool calls
+     shown as rows).
+   - ClearSettled must NOT delete persisted transcripts (live journal only).
+4. Session list UI (`/resume` picker, ctrl+j resume test files show the
+   surface): subagent sessions appear nested under the parent, dimmed,
+   "↳ <task-id>: <description>", selectable read-only. If the picker code
+   makes nesting awkward, ponytail: filter them out of the top-level list
+   and surface them ONLY via the parent's restored task views. Decide with a
+   quick look at the picker implementation.
+5. Retention: subagent sessions accumulate fast (research fan-outs of 6+).
+   Policy: subagent sessions die with their parent (delete cascade when a
+   session is deleted — check if session deletion exists; if not, note it
+   and skip). No independent cap for now; revisit if DB size matters.
+
+### Tests
+
+- session package: migration adds columns on an old DB file; Save/load of a
+  subagent session row with attribution.
+- agent loop test: background task settles → store has the transcript row
+  with parent attribution.
+- Resume test (REQUIRED per skill): run session with background task → kill
+  (new process/store reopen) → resume → openTask shows the persisted
+  transcript, read-only, no live input.
+- Follow-up turn after settle re-persists (append, not clobber — Save with
+  correct `from` index).
+- `whip run` headless path: no store → no persistence, no panic.
+
+### Docs
+
+`docs/features.md` (sessions + subagents sections); README only if a
+user-facing flag/command changes (probably none).
+
+---
+
+## Item 6 — spawn-lag polish
+
+Branch: `feat/subagent-spawn-feedback`
+
+Verified state (`tui-findings.md` §B-update): the transcript queued row
+("⋯ subagent <desc>") renders mid-stream and swaps to a running row at tool
+start — that path is fine. The DOCK row appears only when the tool's Run
+completes (StartBackground fires OnChange), which can lag behind a slow
+parallel sibling (global bash lock) or synchronous `git worktree add`
+(subagent.go:110).
+
+**What it does:**
+1. Fire the dock-visible start signal EARLIER: move registry insertion +
+   OnChange to the moment the subagent tool starts executing (before worktree
+   provisioning and before the goroutine is fully armed). Concretely: split
+   `StartBackground` into `RegisterBackground` (id + row + OnChange, status
+   "starting") and the goroutine launch; or cheaper — keep one function but
+   call it before `provisionSubagentWorktree` and pass the worktree into the
+   prompt after (prompt is already built before StartBackground — reorder:
+   provision → register+OnChange immediately → launch). Watch ordering: the
+   ⚙ badge count and dock use registry state, so registering before the
+   goroutine starts is safe as long as cancel/Done are initialized first
+   (they are, in the constructor).
+2. Provision worktrees concurrently with registration so a slow `git
+   worktree add` doesn't delay the visible row: provision in the task's
+   goroutine and steer the path into the subagent's initial prompt… that
+   changes prompt timing. Ponytail: measure first — if `git worktree add` is
+   <100ms on this repo, skip async entirely and just do (1).
+3. Status line: while a background task is "starting" (registered, goroutine
+   not yet emitting), the dock row already shows ⟳ — verify no extra state
+   needed.
+
+**Tests:** headless model — subagent tool starts, assert dockTasks()
+non-empty BEFORE the tool result returns (block the tool via a scripted
+provider/latch). `-race` over register/launch ordering.
+
+**Docs:** one line in `docs/features.md` subagent section.
+
+---
+
+## Item 7 — (deferred) opencode-style auto-background for bash
+
+Not in this batch. Research captured (`wait-tool-research.md` oh-my-pi
+section): bash calls race completion vs a 60s threshold; slow commands
+auto-background with a handle + notify-on-complete delivered at the yield
+boundary. Revisit after Items 1–6 land; `wait` may cover the practical need.
+
+---
+
+## Execution order & dependencies
+
+```
+1 (wait tool)        ─┐ independent
+2 (prompt caching)   ─┤ independent
+3 (task journal)     ─┤ independent; 5 builds on 3's renderTaskEvent helper
+4 (busy steer)       ─┤ independent
+5 (persistence)      ─┘ benefits from 3 (restored-task rendering)
+6 (spawn feedback)   ── last; smallest
+```
+
+Suggested sequence: **3 → 1 → 2 → 4 → 5 → 6** (3 is smallest and fixes the
+daily annoyance; 1 is the original ask; 2 is the biggest felt-perf win).
+Parallelizable: 1, 2, 3, 4 touch mostly disjoint files (tools+agent vs llm
+vs tui/tasks vs tui submit path) — background subagents could run 2 and 3
+concurrently while driving 1/4 directly, if desired.
+
+## Definition of done (per item)
+
+- [ ] `task check` green; `go test -race ./...` green for concurrent items
+- [ ] tests named in `docs/features.md` section, roadmap checkbox if listed
+- [ ] plan checkbox ticked here; deviation notes appended if the design
+      changed mid-build
+- [ ] least-code re-read of the diff (ponytail pass) before PR
+
+## Global checklist
+
+- [ ] 1. wait tool
+- [ ] 2. prompt caching
+- [x] 3. task event journal — DONE on branch feat/task-journal (registry
+      journal + atomic SubscribeWithJournal + shared renderTaskEvent; journal
+      tests, replay tests, task check + -race green)
+- [ ] 4. busy-state steering
+- [ ] 5. subagent session persistence
+- [ ] 6. spawn-lag polish
+- [ ] memory cap change (DONE — 300→2000 in internal/memory/memory.go,
+      uncommitted; fold into whichever PR lands first or commit standalone)
+- [ ] cleanup: delete `internal/tui/whip-transcript-.md` (stray untracked
+      export file noticed at session start — confirm with user before
+      deleting)

--- a/.ai-docs/plans/agent-ux-batch/PLAN.md
+++ b/.ai-docs/plans/agent-ux-batch/PLAN.md
@@ -495,16 +495,22 @@ concurrently while driving 1/4 directly, if desired.
 
 ## Global checklist
 
-- [ ] 1. wait tool
-- [ ] 2. prompt caching
-- [x] 3. task event journal — DONE on branch feat/task-journal (registry
+All six items shipped, each on its own branch/PR, CI green (11/11) at PR-open
+time; PLAN.md's per-item checkboxes and Definition-of-done apply. #59 merged.
+
+- [x] 1. wait tool — PR #58 (feat/wait-tool)
+- [x] 2. prompt caching — PR #59 MERGED (feat/prompt-caching)
+- [x] 3. task event journal — PR #57 (feat/task-journal; registry
       journal + atomic SubscribeWithJournal + shared renderTaskEvent; journal
       tests, replay tests, task check + -race green)
-- [ ] 4. busy-state steering
-- [ ] 5. subagent session persistence
-- [ ] 6. spawn-lag polish
-- [ ] memory cap change (DONE — 300→2000 in internal/memory/memory.go,
-      uncommitted; fold into whichever PR lands first or commit standalone)
+- [x] 4. busy-state steering — PR #60 (feat/busy-steer)
+- [x] 5. subagent session persistence — PR #61
+      (feat/subagent-session-persistence; transcripts as attributed sessions
+      `task-<parent>-<taskID>`, forked_from=parent, restored-task replay)
+- [x] 6. spawn-lag polish — PR #62 (feat/subagent-spawn-feedback; register
+      before worktree provision, worktree path queued as first steer)
+- [x] memory cap change (DONE — 300→2000 in internal/memory/memory.go,
+      folded into PR #57)
 - [ ] cleanup: delete `internal/tui/whip-transcript-.md` (stray untracked
       export file noticed at session start — confirm with user before
       deleting)

--- a/.ai-docs/plans/agent-ux-batch/README.md
+++ b/.ai-docs/plans/agent-ux-batch/README.md
@@ -1,0 +1,148 @@
+# Agent UX batch: waits, subagent visibility, busy-state messaging, speed
+
+Branch: TBD (likely split into several PRs)
+
+Working file for a cluster of issues raised in one session (2026-08-05). Each
+item has its own section with findings + proposed design. Nothing implemented
+yet — awaiting user sign-off per item.
+
+## Threads in flight
+
+- [x] Research: wait/poll mechanisms — exo, codex, pi, opencode, claude-code (done)
+- [ ] Research: hermes + oh-my-pi wait/poll (subagent sub-4 still running)
+- [ ] Research: opencode speed secrets (subagent sub-7 still running)
+- [x] TUI investigation: subagent view has no history (root cause found)
+- [~] TUI investigation: spawn visibility lag + busy-state messaging (partial)
+
+---
+
+## 1. `wait` tool — kill `sleep`+poll turns (the original request)
+
+**Problem:** model runs `sleep 60 && gh pr checks` loops; each poll costs a
+full LLM turn (~28M tok observed on an 8-min CI watch).
+
+**Cross-harness research summary** (full reports in session history; distilled
+in `.ai-docs/plans/agent-ux-batch/wait-tool-research.md` — TODO write):
+
+- **codex**: `exec_command(cmd, yield_time_ms)` returns a session handle;
+  `write_stdin(session_id, "", yield=up to 5min)` is a harness-owned long-poll.
+  Activity watch channel wakes blocked tools on new user input.
+- **opencode**: background task → `Deferred` await → `notify()` injects
+  synthetic `<task state>` message into parent via `prompt()` + coalesced
+  wake/re-drain. Tool prompt literally says "DO NOT sleep, poll… you will be
+  notified". No generic wait tool.
+- **pi**: nothing. (Has unwired `DeferredHandle` design for future.)
+- **exo**: external scheduler daemon injects a wakeup User message starting a
+  fresh turn. Grid-anchored, durable, crash-recoverable.
+- **claude-code**: background bash + "remind to continue" — completion injected
+  once as system/user message; O(1) messages, never n polls.
+
+**whip's existing pieces:** `Agent.Steer` (drained at loop boundaries),
+`taskRegistry` + `Done` channels + `OnChange`, TUI 5s tick, `submitTurn(text,
+false)` for machine turns, bash timeout escalation already exists.
+
+**Proposed design (candidate, needs sign-off):**
+- New tool `wait` (internal/tools/wait.go): args `command`, `until`
+  (optional regex; absent = exit 0), `interval` (default 10s), `timeout`
+  (default 10m, hard cap 1h).
+- Poller goroutine loops command at interval — zero LLM turns.
+- Delivery: if agent busy → `Steer("[wait …] …")` drained at next boundary;
+  if idle → TUI wake → `submitTurn(msg, false)` (opencode/exo wake pattern).
+  Needs an idle-wake hook on Agent (nil in headless/tests).
+- System-prompt nudge: "prefer `wait` over sleep loops; you will be notified".
+- Anti-patterns to refuse: no polling a task whose `Done` channel we already
+  have (claude-code lesson 6); steer once, on state transition only.
+
+## 2. Subagent spawn visibility lag
+
+**Symptom:** model-spawned background subagents take a long time to appear in
+the dock below the input box.
+
+**Findings so far:**
+- `/subagent` command path (taskmodel.go:128-129) appends a confirmation line
+  immediately — no lag there.
+- Model-driven path: `subagent(background:true)` tool → `StartBackground`
+  (agent.go) → `OnChange` → detached `prog.Send(taskUpdateMsg{})` → dock
+  redraw. Design looks immediate.
+- Suspects: (a) tool runs in the parallel batch — `OnChange` fires only after
+  the tool result, plus the turn keeps streaming; (b) `sendTaskMsg`/
+  `OnChange` use detached goroutine per send (`go p.Send`) — a backed-up UI
+  queue delays arrival; (c) user perception may actually be "no feedback until
+  the whole turn ends" because the ⚙ badge/dock only stands out when idle.
+- TODO: verify what actually shows between tool call and settle: does
+  OnToolStart render a row for the subagent tool call? (It should — but user
+  says "eventually spawned", implying not.)
+- Next step: reproduce with a headless test asserting dock content right after
+  the subagent tool call completes.
+
+## 3. Busy-state messaging while waiting on subagents
+
+**Symptom:** when the main agent is blocked on foreground subagents, user
+messages queue behind the whole turn (tui.go:2027: queue drains only when turn
+ends); user wants typing to feel live.
+
+**Proposal (needs sign-off):** new steer-vs-queue routing rule —
+if busy AND no main-thread tool running yet in this turn (i.e. model is
+"thinking" or in-flight API call; hard to observe cheaply) OR the current tool
+batch is entirely subagent waits → submit as steer (inject at loop boundary)
+instead of queue. Otherwise keep queue semantics. Alternative simpler take:
+always steer when busy and the turn's only in-flight work is foreground
+subagent tools; never cancel (keep the current empty-enter=cancel special case
+intact? that one is explicit user intent).
+
+Open question: how does Turn know "only subagents in flight"? The TUI can't see
+the tool batch directly — needs an agent-side signal (e.g. atomic counter of
+running non-subagent tools, or an `Agent.BusyKind()` snapshot).
+
+## 4. Subagent detail view shows only post-attach events
+
+**Root cause (confirmed):** `openTask` (internal/tui/tasks.go:165) seeds the
+pane with prompt only; live events are broadcast to subscribers and discarded —
+no journal. Subscribe gets only future events. Settled tasks show only the
+final Report, no transcript.
+
+**Fix (needs sign-off):** bounded per-task event journal in taskRegistry
+(e.g. `journal []taskEvent` capped ~100KB, appended in `emitter()` before
+broadcast). `openTask` replays journal into `tv.buf` before subscribing.
+Journal is live-only (cleared with ClearSettled); persistence covered by #5.
+
+## 5. Subagent session persistence (~/.whip, with attribution)
+
+**Ask:** subagent sessions persist like regular sessions, with attribution
+(parent session id, task id, spawned-by).
+
+**Current state:** registry persists only task metadata row (ID, description,
+prompt, status, report) via `OnRecord` → `SaveTask`; the subagent's message
+list lives in the retained `*Agent` in memory only, dies with the process.
+
+**Proposal (needs sign-off):**
+- session.Store: subagent sessions as rows in the sessions table with
+  `parent_session_id`, `task_id`, `kind=subagent` columns (or a
+  `subagent_sessions` table — prefer extending sessions, one table).
+- Where messages get saved: subagent Turn appends to `sub.Messages`; hook
+  persistence the way main agent does (TUI persists main session in turnDone;
+  subagent worker has no TUI — persist on settle in the StartBackground
+  goroutine, and incrementally? incremental = Save(id, from, msgs) per turn
+  boundary like main).
+- `whip resume` / session list: show subagent sessions nested/attributed
+  ("↳ subagent of <session> · <task id>").
+- Interaction with #4: persisted subagent transcript could replace/supplement
+  the live journal for restored tasks — `--resume` re-renders history.
+  Restored task detail view = read-only replay of persisted messages.
+- Resume correctness test required (skill rule): kill mid-subagent, resume,
+  open task, see full transcript.
+
+## 6. opencode "feels faster" — research pending
+
+Subagent sub-7 investigating: parallel tool dispatch, streaming pipeline,
+prompt caching (`cache_control`), request pipelining. Await report before
+designing.
+
+---
+
+## Docs/plan bookkeeping
+
+- Skill: new-feature-development — each item above gets its own plan dir (or a
+  checkbox here) before implementation; `docs/features.md` section + roadmap
+  checkbox per shipped item.
+- Session memory entries mirror this file's index.

--- a/.ai-docs/plans/agent-ux-batch/opencode-speed.md
+++ b/.ai-docs/plans/agent-ux-batch/opencode-speed.md
@@ -1,0 +1,87 @@
+# Why opencode feels fast — research distillation (sub-7, 2026-08-05)
+
+User observation: whip and opencode on the same models — opencode feels
+"blazing fast". Suspicion was parallel command dispatch. Research says the
+dominant factors are elsewhere.
+
+## Ranked causes (file:line in opencode repo, ~/code/coding-harnesses/opencode)
+
+### 1. Provider prefix caching (dominant — cuts TTFT on every intra-turn call)
+
+- **Native runtime auto cache policy, always on:**
+  `packages/llm/src/cache-policy.ts` — stamps `cache_control: ephemeral`
+  breakpoints at (a) last tool definition, (b) last system part, (c) **latest
+  user message**. Comment: "the latest user message stays put while a single
+  turn explodes into many assistant/tool round-trips, so caching at that
+  boundary lets every intra-turn API call hit the prefix". Applied at
+  `route/client.ts:344-345`, policy "auto" default, restricted to
+  anthropic-messages/bedrock-converse.
+- **AI-SDK path also stamps caching:** `provider/transform.ts:366-407`
+  `applyCaching` — cache_control on first 2 system + last 2 non-system
+  messages (anthropic/openrouter/bedrock/openai-compatible/copilot).
+- **OpenAI: stable `promptCacheKey = sessionID`**
+  (`provider/transform.ts:1260-1273`; gpt-5 also :1317-1321 +
+  `reasoningSummary:"auto"`). Same key all session → cached prefix reused
+  across turns.
+- Micro-opt: cache-policy avoids `.map()`, mutates a `messages.slice()` copy
+  because it runs per request on long conversations.
+
+Effect: intra-turn tool round-trips (5–20 per task) get cached-prefix TTFT
+(tens of ms) instead of full-prompt TTFT (seconds). Most agent-loop wall-clock
+is sequential first-token waits — this is plausibly THE "feels fast" factor.
+
+### 2. O(1)-per-delta rendering (Solid fine-grained store)
+
+- Deltas publish immediately: `session.updatePartDelta` →
+  `events.publish(PartDelta)` fire-and-forget (`session/session.ts:877-884`).
+- SSE transport unbuffered: `Cache-Control: no-cache, no-transform`,
+  `X-Accel-Buffering: no` (`server/routes/.../handlers/event.ts:79-84`).
+- TUI mutates one part field via Solid `produce`/`reconcile` inside `batch()`
+  (`packages/tui/src/context/sync.tsx:343,376-415,505`) — only subscribed
+  components re-render. NO full-transcript re-render per delta.
+- No throttle/debounce/rAF anywhere in the streaming path.
+
+### 3. Tool execution overlapped with the stream
+
+- AI-SDK path: SDK dispatches tools, results stream back into `fullStream`
+  (`session/llm.ts:280`, `processor.ts:642-646`). Native path: tool calls
+  dispatched to `FiberSet.run(..., {startImmediately:true})`, results queued
+  back into the LLM event stream (`session/llm/native-runtime.ts:103-137`).
+- Per-file `Semaphore(1)` only for `edit` (`tool/edit.ts:35-45,88`);
+  write/apply_patch unlocked; no global tool mutex.
+- Tool parts materialize in the UI on `tool-input-start` — user sees the tool
+  BEFORE it runs (`processor.ts:315-335`).
+
+### 4. Non-critical work forked off the hot path
+
+Title gen, session summary, pruning, compaction all `Effect.forkIn(scope)` /
+`Effect.ignore` (`prompt.ts:1133-1139,1253,1338`, `processor.ts:476`) — never
+delay the next step.
+
+### 5. What it does NOT do
+
+- Loop is strictly serial per turn (`prompt.ts:1141-1336`) — NO speculative
+  execution, NO next-request pipelining. The user's "parallel dispatch"
+  intuition is only partially right.
+- No bespoke HTTP pooling (undici default keep-alive).
+- No server-side delta batching; no second throttle.
+
+## Implications for whip (Go + bubbletea)
+
+whip already has: 25fps coalesced streaming, goroutine-per-tool parallel
+dispatch with per-path semaphores + global bash lock, detached prog.Send.
+
+Gap analysis (to verify):
+1. **`internal/llm` likely sends no cache_control / prompt_cache_key** —
+   highest-value change. Add: byte-stable system prompt + deterministic tool
+   ordering, ephemeral breakpoints at [last tool def, last system part, latest
+   user message] for anthropic-shaped endpoints, `prompt_cache_key =
+   sessionID` for OpenAI-shaped ones.
+2. **Render cost per delta** — bubbletea re-runs `View()` per message; if
+   View re-renders the whole transcript string per delta that's O(transcript)
+   per tick. whip coalesces to 25fps which bounds it, but check transcript
+   block caching (blocks re-render on resize — is there a width-keyed cache?).
+3. Tool spawn feedback — ensure OnToolStart renders before execution (probably
+   already; verify for subagent calls — see spawn-lag thread).
+
+No action on speculative execution — opencode does none.

--- a/.ai-docs/plans/agent-ux-batch/tui-findings.md
+++ b/.ai-docs/plans/agent-ux-batch/tui-findings.md
@@ -1,0 +1,149 @@
+# TUI issues — root causes and candidate fixes (2026-08-05)
+
+All three found by reading internal/tui + internal/agent/background.go.
+
+## A. Subagent detail view shows only post-attach events (CONFIRMED root cause)
+
+`openTask` (internal/tui/tasks.go:165-201):
+- Seeds `tv.buf` with header + prompt only.
+- Running task → `Tasks().Subscribe(id, Events{...})` — receives only events
+  from that point on. Registry `emitter()` (background.go:305) broadcasts to
+  current subscribers and DROPS everything else. No journal anywhere.
+- Settled task → prints only the final `Report` string. The full transcript
+  (text, tool calls, steers) is gone unless a view was open the whole run.
+
+User impact: "I can't see the completed result of the subagent when I open it"
+— worse than annoying: the dock opens feel broken.
+
+Candidate fix: bounded per-task event journal.
+- `taskRegistry`: `journal map[string][]journaledEvent` (or field on
+  BackgroundTask — but tasks are snapshot-copied by List/Get, so a registry
+  map is safer; or store `*[]event` pointer on the task).
+- `emitter()` appends each event (kind, text/args) before broadcast; cap
+  total bytes (~64-100KB per task, drop-oldest with a "[earlier output
+  dropped]" marker line).
+- `openTask` replays journal into `tv.buf` (formatted exactly like the live
+  handlers do), then subscribes — atomically with the replay under the
+  registry lock so no event is missed or duplicated between replay and
+  subscribe. Cleanest: a `SubscribeWithJournal(id, ev) ([]event, bool)` that
+  returns the journal snapshot and registers the subscriber in one lock hold.
+- Journal lives only while the task is registered; ClearSettled drops it.
+  Persistence across process restarts is thread E below, not the journal.
+- Test: spawn task in headless loop test, let it emit, THEN openTask, assert
+  buf contains pre-open events. Race-clean.
+
+## B. Spawn visibility lag (PARTIAL — needs reproduction)
+
+Facts:
+- `/subagent` hand-spawn (taskmodel.go:128-129) prints a confirmation line
+  synchronously — no lag on that path.
+- Model-spawned: subagent tool with `background:true` → `StartBackground`
+  → registry `OnChange` → wireTasks (tui.go:2826-2830) does `go
+  m.prog.Send(taskUpdateMsg{})` → taskUpdateMsg case → dock redraw.
+- The design looks immediate. Suspects, in order:
+  1. The dock only renders below the INPUT box — during a busy turn the user's
+     eyes are on the streaming transcript; if the subagent tool-call row in
+     the transcript doesn't render until tool END, there's genuinely no
+     visible signal mid-turn. Need to check: does OnToolStart fire/render for
+     the subagent tool call itself? (grep toolrow.go / toolcall_stream_test.go
+     handling of OnToolStart vs OnToolEnd.)
+  2. `go p.Send(msg)` detached goroutine per event — under a backed-up UI
+     queue, ordering and latency are whatever the scheduler gives. Fine for
+     coalescing, but combined with (1) it can look like "eventually spawned".
+  3. `dockTasks()` filters `Restored` and ages out settled tasks after
+     `dockSettledGrace` (1 min) — not the spawn path, but worth knowing.
+
+Next step: headless test driving a turn with a fake provider that calls
+subagent(background:true); assert dock shows the task row before settle.
+
+## C. Busy-state messaging while waiting on subagents (design needed)
+
+Current behavior (tui.go):
+- Busy + enter with text → `m.queue = append(m.queue, text)` (tui.go:2591),
+  dim "queued" rows render (chrome at :1548).
+- Queue drains ONLY at turnDone (tui.go:2027-2033), one message per new turn.
+- Empty enter while busy = intentional cancel-then-drain.
+- `Agent.Steer` exists and drains at loop boundaries inside the running turn
+  (agent.go:408-421) — but the TUI never uses it for typed user input.
+
+User want: when the main agent is just WAITING on (foreground) subagents,
+typing should steer into the live turn, not queue behind it. "It's not
+technically an interruption."
+
+Design constraint: the TUI can't see what the in-flight tool batch is. Needs
+an agent-side observable, e.g.:
+- `Agent.InFlightTools() []string` snapshot (names of currently-running tool
+  calls, maintained in runTools), or
+- `Agent.WaitingOnSubagents() bool` (in-flight set ⊆ {subagent}).
+
+Then submit() while busy: if `WaitingOnSubagents()` → `agent.Steer(text)` +
+echo locally as a steer row; else → queue (current behavior). Keep
+empty-enter cancel as-is (explicit user intent).
+
+Open questions for sign-off:
+- Should steered-while-waiting also apply when the model is mid-generation
+  with no tools in flight? (Codex does this: activity channel interrupts
+  sleeps. More aggressive; changes turn semantics more.)
+- UI affordance: how does the user know typing will steer vs queue? Maybe
+  input placeholder changes ("steer this turn…" vs "queued").
+
+## D. Subagent session persistence to ~/.whip (feature request)
+
+Ask: subagent sessions persist like regular sessions, with attribution.
+
+Current state:
+- Only task metadata persists: OnRecord → `st.SaveTask(sessionID,
+  session.Task{ID, Description, Prompt, Status, Report, StartedAt,
+  EndedAt})` (wireTasks, tui.go:2807-2820). The subagent's MESSAGE LIST lives
+  only in the retained `*Agent` (BackgroundTask.sub) — dies with the process.
+- `--resume` restores task rows as settled-with-history (`Restored: true`),
+  no transcript.
+
+Design sketch (needs sign-off):
+- Extend session store: subagent sessions as first-class session rows with
+  attribution columns: `parent_session_id`, `task_id`, `kind='subagent'`
+  (prefer extending the sessions table over a parallel table — one store,
+  attribution is just columns).
+- Save path: subagent Turn appends to `sub.Messages`; persist incrementally
+  at loop boundaries like the main session does (`Save(id, from, msgs)`), or
+  minimally once at settle. Incremental is better for crash-mid-run but
+  settle-only is the ponytail version. Decide.
+- `--resume`/session list UI: subagent sessions listed nested under parent
+  ("↳ subagent <task-id> of <session>"), openable read-only.
+- Synergy with (A): restored tasks' detail view replays the persisted
+  transcript instead of showing only the report — makes Restored tasks
+  useful. The live journal stays live-only.
+- Retention: subagent sessions accumulate fast (research fan-outs!) — need a
+  policy (delete with parent? cap? age out?) — ask user.
+- Resume test required per skill: kill mid-subagent, resume, open task, see
+  full transcript.
+
+## E. Cross-cutting: opencode's busy-drain lesson for C
+
+opencode re-checks `hasPending("steer")` after EVERY LLM turn inside a drain
+(runner/llm.ts:408) and coalesces wakes (pendingWake). whip's Steer already
+drains per loop boundary — equivalent. The missing piece is purely TUI-side
+routing of typed input + the agent-side in-flight observability.
+
+## B-update: spawn-lag verification result (done)
+
+Traced the full chain:
+- llm.Stream fires OnToolCall per tool-call delta (openai.go:744) → TUI
+  renders "⋯ subagent <desc>" queued row MID-STREAM (tui.go:1752) →
+  toolStartMsg swaps it to a live running row (tui.go:1779) →
+  StartBackground fires OnChange → dock row + ⚙ badge (tui.go:2826).
+- Conclusion: transcript feedback is immediate by design. The dock row,
+  however, appears only at TOOL COMPLETION (OnChange is inside
+  StartBackground), not when the call streams in — under a parallel batch that
+  includes a slow tool (bash holding the global lock, or another subagent's
+  worktree `git worktree add`), the subagent tool's Run can sit blocked
+  post-stream, and the dock stays empty the whole time.
+- Secondary suspect inside the tool: worktree provisioning runs
+  `git worktree add` synchronously before StartBackground (subagent.go:110) —
+  slow on big repos.
+- Candidate fixes: (1) fire a cheap "spawning" signal at tool START for
+  subagent calls (or render queued toolCall rows into the dock too — probably
+  wrong surface); (2) provision worktrees asynchronously so OnChange isn't
+  delayed; (3) cheapest: accept transcript-row-only feedback and make the ⚙
+  badge count "queued" subagent calls too. Decide with user; the felt lag may
+  also just have been the previous session's load.

--- a/.ai-docs/plans/agent-ux-batch/wait-tool-research.md
+++ b/.ai-docs/plans/agent-ux-batch/wait-tool-research.md
@@ -1,0 +1,211 @@
+# Wait/poll mechanisms — cross-harness research distillation
+
+Six harnesses researched (2026-08-05), full reports in session history. This
+file is the durable distillation for the `wait`-tool design.
+
+## The question
+
+When the agent must wait for an external condition (CI checks, deploy, server
+up), what does the harness offer instead of the model running
+`sleep 30 && check` loops (each poll = a full LLM turn)?
+
+## Per-harness findings
+
+### codex (OpenAI, Rust) — session-handle long-poll
+
+- No generic wait/watch/notify tool; no auto-wakeup ticker.
+- **`exec_command(cmd, yield_time_ms)`** (`core/src/tools/handlers/unified_exec/exec_command.rs`,
+  schema `shell_spec.rs:21-111`): blocks up to `yield_time_ms` (250–30_000,
+  default 10s), returns a `session_id` handle if the process is still alive.
+- **`write_stdin(session_id, chars, yield_time_ms)`**: empty-write polls wait
+  5s–300s. The harness owns the PTY registry (`ProcessStore`, max 64 live,
+  `unified_exec/mod.rs:77`) and an exit-watcher (`async_watcher.rs:165`) that
+  emits a session/UI event on exit — but NOT into the model conversation.
+  Completion re-enters the model only via the next `write_stdin` poll.
+- **`clock.sleep(duration_ms)`** (`tools/handlers/sleep.rs:107-137`): blocks
+  but `select!`s on `session.input_queue.subscribe_activity().changed()` —
+  new user input interrupts the sleep ("Sleep interrupted by new input").
+  Same pattern in `wait_agent` (mailbox watch) and `wait_for_environment`.
+- **Async hooks** (`hooks/src/engine/dispatcher.rs:131-140`): background hook
+  results are drained and injected as `ResponseItem`s **only at turn
+  boundaries** (`turn.rs:161,410`) via `inject_if_running` → pending-input
+  queue → activity `watch` channel. `SubagentNotification` renders subagent
+  status changes as a user-role `<subagent_notification>` fragment injected
+  the same way.
+- `file-watcher` crate exists but is unused by core.
+- **Port-worthy:** (1) yield_time_ms session handle — replaces sleep loops
+  with a harness-owned long poll; (2) one session-level `watch.Sender`
+  activity channel every blocking tool selects on; (3) turn-boundary-only
+  injection with `has_pending_input` re-sample check; (4) model-visible bounds
+  in the schema text so the model learns cadence by reading the def.
+
+### opencode (TS) — Deferred await + synthetic injection + coalesced wake
+
+- No wait/watch tool. Shell tool: only `timeout`; kills on expiry, tells model
+  to retry bigger. No background mode on shell.
+- Background jobs only for the `task` (subagent) tool:
+  `core/src/background-job.ts` — registry with `Deferred<Info>` per job;
+  `wait()` is a pure promise await (optional timeout → `{timedOut:true}`).
+- Foreground task (`tool/task.ts:317-347`): races `wait(jobId)` vs
+  `waitForPromotion(jobId)` in-call — synchronous delegation, no polling.
+- Background task: tool returns immediately; a forked `notify(jobId)` fiber
+  awaits the Deferred; on settle, `injectBackgroundResult` calls
+  `ops.prompt()` on the PARENT session with a `synthetic:true` text part
+  rendered `<task state=...>...</task>` (task.ts:216-254).
+- Tool prompt explicitly: "You will be notified automatically when it
+  finishes. DO NOT sleep, poll for progress…".
+- **Wake machinery**: `V2Session.prompt()` (`core/src/session.ts:360-384`)
+  admits input with `delivery:"steer"` → `execution.wake(sessionID)` →
+  run-coordinator (`run-coordinator.ts:51-92`) sets `pendingWake` on the
+  active drain and coalesces N wakes into exactly one follow-up drain. The
+  drain (`runner/llm.ts:390-413`) re-checks `hasPending("steer")` after EVERY
+  LLM turn, not just between drains.
+- No setInterval/heartbeat in the agent loop anywhere. Event-driven push. The
+  one 250ms poll (`cli/cmd/run/stream.transport.ts:867-872`) is a UI liveness
+  fallback only — never generates model input.
+- LLM retry policy: 2s initial, ×2, 0.25 jitter, honor Retry-After, cap 30s,
+  max 5 (`session/retry.ts`).
+- **Port-worthy:** notify-on-settle injection (message-shaped, once);
+  coalesced wake (atomic pendingWake bool + single re-drain); steer re-check
+  after every turn; event-first with poll only as UI safety net.
+
+### pi (TS) — nothing (baseline)
+
+- Tools: bash/edit/find/grep/ls/read/write only. bash has `timeout` +
+  SIGTERM→SIGKILL escalation (`core/tools/bash.ts:123-144`). No async mode.
+- Loop (`agent/src/agent-loop.ts:155-275`): strict
+  stream→execute-tools→drain-queues→continue. Steer/follow-up queues drained
+  synchronously at turn boundaries (`getSteeringMessages`/`getFollowUpMessages`,
+  types.ts:222-257); NO event wakes a parked loop — a long bash can't be
+  interrupted by steering.
+- Subagent tool (example extension): spawns child processes, blocks until all
+  exit; `onUpdate` partials go to UI only, never the model.
+- `DeferredHandle` type (`ai/src/types.ts:409-419`, `pollAfterMs`,
+  `expiresAt`) designed for provider deferred responses; harness that would
+  drive it is a stub (`HarnessNotImplemented` everywhere). Designed, not wired.
+- **Port-worthy:** drain-at-boundaries queue semantic (whip has this via
+  Steer); bash timeout kill escalation (whip has); throttled partial-output UI
+  channel (`BASH_UPDATE_THROTTLE_MS=100`); the lesson that designing a
+  deferred surface without wiring it = it never ships.
+
+### exo (Rust) — external scheduler daemon, wakeup User message
+
+- No wait tool; shell tool blocks the turn synchronously and has NO timeout
+  (`harness_tool.rs:894-916`).
+- **Scheduler** is the wait primitive: model calls `schedule_sandbox_task`
+  (argv command, `@every/@at/cron`, `missed` policy, sandbox scope,
+  `reportPrompt`, `maxOutputBytes`).
+- Timing owned by a separate host binary `exo-scheduler-runner`
+  (`exo/scheduler-runner/src/main.rs:109-117`): `loop { run_due_tasks; sleep
+  60s }` fixed poll.
+- Fire → run command in sandbox → write result artifact →
+  `send_conversation_wakeup` (`scheduler_runtime.rs:353`) →
+  `HarnessConversation::send()` acquires per-conversation async lock → starts
+  a FRESH model turn whose user input is the wakeup prompt
+  (`harness_executor.rs:151-184`). Not an injection into a running turn.
+- Durability: tasks + pending-fire records persisted (`scheduler_store.rs`);
+  lease 10min, `(task_id, slot_ms)` dedupe → bounded at-least-once;
+  `redeliver_pending_wakes` on startup. Grid-anchored fires
+  (anchor + n×interval, no drift). `MissedPolicy::{Skip,Once,All}`, catch-up
+  cap 100. Command timeout 10min. Wakeup file lock stale 30min.
+- **Port-worthy:** wakeup-as-fresh-turn via conversation lock; durable
+  pending-fire record written BEFORE delivery; grid anchor + missed policy;
+  distinct command timeouts (scheduler has one, shell doesn't — port a shell
+  default timeout too).
+
+### claude-code (closed; documented/observed/inferred)
+
+- Background bash + `TaskOutput` polling tool — but each TaskOutput call IS a
+  turn; docs steer away from poll loops toward shell-level blocking (`wait
+  $PID`) or sparse checks.
+- 2.x: background task completion → status-bar notice → "remind to continue"
+  injects ONE short `[Background command <id> finished]` system/user message.
+  O(1) injections, never n polls. Process watcher lives in the harness/OS.
+- Hooks (`SessionStart`, `Pre/PostToolUse`, `Notification`, `StatusLine`) let
+  external scripts surface status with zero model turns at emission; folded
+  into the next real invocation.
+- `/bashes` list = TUI-side process table, human-operated kill/jump, zero
+  model involvement.
+- Invariant: **the timer lives outside the model; only terminal deltas
+  (started/finished/failed) serialize into the transcript, once.**
+
+### hermes-agent (Python, OpenHands-family) — closest structural match to Claude
+
+- `terminal(background=true, notify_on_complete=true)` → returns session_id,
+  process tracked in `process_registry.py`. `watch_patterns` = regex
+  notification for never-exiting servers.
+- Gateway asyncio watcher `_run_process_watcher` (`gateway/run.py:26066`):
+  sleeps on check_interval, silent unless state changed; on exit (and not
+  consumed) builds synthetic completion event →
+  `_enqueue_process_completion_notification` → **new turn when idle, never
+  spliced into a running turn** (run.py ~10323).
+- Exactly-once: `is_completion_consumed` shared by foreground wait, poll/log,
+  notify, auto-delivery.
+- Anti-spam: watch patterns capped 1/15s (`WATCH_MIN_INTERVAL_SECONDS`,
+  process_registry.py:73-84), 3 strikes → disabled → auto-promoted to
+  notify_on_complete. Notifications truncated to ~2000 chars, line-snapped.
+- `process(wait, session_id, timeout)`: blocking in-turn wait, max 180s,
+  polls interrupt event so new user input aborts with `status:"interrupted"`;
+  timeout framed as not-an-error with a nudge to use notify_on_complete.
+- `delegate_task(background=true)` uses the same injection architecture for
+  async subagents.
+- **Port-worthy:** idle-only injection; consume-dedup across all read paths;
+  watch-pattern rate limit + self-disable; "timeout is not an error" protocol.
+
+### oh-my-pi (TS) — richest: auto-background + adaptive ladder + yield queue
+
+- `hub wait` tool: blocks until FIRST of peer message / watched job settling /
+  window elapsing / steering interrupt. Never "wait until all done" — model
+  re-issues to keep waiting.
+- **Adaptive poll ladder** `POLL_WAIT_LADDER_MS = [5s,10s,30s,60s,300s]`
+  (`async/job-manager.ts:35`): consecutive quick re-polls climb the ladder;
+  reset to floor after 60s of real work (`POLL_ESCALATION_RESET_MS`).
+- **Auto-background**: bash/eval/task race
+  `raceJobSettlement(job.completion, 60s, abortSignal, steeringSignal)`
+  (`async/auto-background.ts`) — finish within 60s → inline result; else tool
+  returns "Backgrounded as job bg_N; result delivered automatically."
+- **Delivery**: job settles → `AsyncJobManager` delivery loop (retry 500ms
+  ×2 cap 30s + jitter) → session sink → `async-result` custom message →
+  per-session `YieldQueue` idle-flush → loop's `getFollowUpMessages()` at
+  stop/yield boundary → `continue` with new turn (agent-loop.ts:1480).
+  Multiple completions coalesce into ONE async-result turn.
+- Steering signal aborts in-flight waits cooperatively
+  (`STEERING_INTERRUPT_POLL_MS=250`).
+- Bounds: max 15 running jobs, 5min result retention with eviction,
+  `consumeJobResults` dedup.
+- **Port-worthy:** auto-background race (threshold window then hand back a
+  handle); adaptive ladder; coalesce multiple completions into one turn;
+  yield-boundary-only delivery.
+
+## The convergence (what "excellent" looks like)
+
+Every good implementation agrees on:
+
+1. **Harness owns the timer** (goroutine/fiber/asyncio task/daemon), never the
+   model. Zero LLM turns during the wait.
+2. **Completion enters the loop ONCE**, as a message, at a boundary:
+   busy → steered into the running turn's next boundary (whip `Steer`);
+   idle → wake → fresh turn (exo/opencode/oh-my-pi).
+3. **Exactly-once delivery** with dedup when multiple read paths exist.
+4. **Interruptible waits**: blocking tools select on user-input/steer signals
+   (codex activity watch; oh-my-pi steering abort; hermes interrupt event).
+5. **Anti-loop protocol in the tool docs**: "you will be notified — DO NOT
+   poll"; timeouts framed as not-errors.
+6. **Coalescing**: N concurrent completions → 1 follow-up turn (opencode
+   pendingWake; oh-my-pi batched async-result).
+7. **Bounds everywhere**: max live handles, retention, timeouts, rate limits.
+
+## Proposed whip shape (candidate for sign-off)
+
+`wait` tool: `{command, until? (regex), interval? (default 10s), timeout?
+(default 10m, cap 1h)}` → returns immediately with a wait id; poller goroutine
+loops `command` at interval; on condition/timeout/error → ONE message:
+busy → `Agent.Steer("[wait <id> done] …")` (drains at next loop boundary);
+idle → TUI wake hook → `submitTurn(msg, false)`.
+
+Needs: idle-wake hook on Agent (TUI installs, nil headless); bounded
+concurrent waits registry; reuse bashrun for command execution; system-prompt
+line steering model from sleep loops to `wait`.
+
+Later (from research, optional): auto-background for bash (60s race → handle),
+adaptive interval ladder, wait-pattern watches with rate limits.

--- a/docs/features.md
+++ b/docs/features.md
@@ -147,6 +147,17 @@ as a **steered message**, so the model sees it on the next loop boundary.
   The dock itself shows running tasks plus ones settled within a one-minute
   grace window (`dockSettledGrace`) — long enough to notice the ✓, then the
   strip cleans itself.
+- **Full transcript on open.** The registry journals every emitted event per
+  task (`taskJournal`, byte-capped at 128KB, drop-oldest with a "[earlier
+  output dropped]" marker). `openTask` replays the journal and subscribes to
+  the live stream as ONE atomic call (`SubscribeWithJournal`), so a detail
+  view opened mid-run or after settle shows the complete transcript — tool
+  calls, steers, and all — instead of only what streams in after attach.
+  Replay and live rendering share `renderTaskEvent` (internal/tui/tasks.go)
+  so the two paths can't drift in format. Tests: `journal_test.go`
+  (recording, delta coalescing, overflow truncation, atomicity under
+  concurrent emit, survive-settle/clear lifecycle),
+  `TestTaskViewReplaysJournal`, `TestRunningTaskViewReplaysThenStreams`.
 
 Background tasks use a context **not** tied to the current turn — they outlive
 it by design. Cancelling a task cancels its subagent's turn. `settle()`

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -88,6 +88,16 @@ func (j *taskJournal) append(kind int, s, s2 string) {
 		j.events = j.events[1:]
 		j.Truncated = true
 	}
+	// A pure-text stream (no interleaving tool calls) coalesces into ONE
+	// entry, which the front-drop loop above can't touch (it keeps len>=1) —
+	// without this tail cap the "bounded at 128KB" guarantee is false for the
+	// one case a long uninterrupted answer hits.
+	if len(j.events) == 1 && len(j.events[0].S) > journalBudget {
+		drop := len(j.events[0].S) - journalBudget
+		j.events[0].S = j.events[0].S[drop:]
+		j.bytes -= drop
+		j.Truncated = true
+	}
 }
 
 // taskRegistry tracks background subagents for one parent agent. It is the
@@ -363,6 +373,8 @@ func (r *taskRegistry) SubscribeWithJournal(id string, ev Events) (events []Jour
 // callbacks run on the worker goroutine, so they must be cheap and
 // non-blocking. Tool calls stream in as args deltas (OnToolCall); only the
 // start (kind 1) and end (kind 2) are journaled — the deltas would fill the
+// journal with partial JSON.
+//
 // emitLocked folds the journal append and the subscriber snapshot into a
 // single registry lock hold so an event can never be both replayed from the
 // journal AND delivered live to the same view: a SubscribeWithJournal that

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -358,18 +358,39 @@ func (r *taskRegistry) SubscribeWithJournal(id string, ev Events) (events []Jour
 	return events, truncated, true
 }
 
-// record appends one event to the task's journal. Called from emitter
-// callbacks (the subagent worker goroutine) under the registry lock; the
-// journal map entry is created on first event.
-func (r *taskRegistry) record(id string, kind int, s, s2 string) {
+// emitter returns an Events that journals every callback and forwards it to
+// the task's current subscribers (the TUI's per-task view). Subscriber
+// callbacks run on the worker goroutine, so they must be cheap and
+// non-blocking. Tool calls stream in as args deltas (OnToolCall); only the
+// start (kind 1) and end (kind 2) are journaled — the deltas would fill the
+// emitLocked folds the journal append and the subscriber snapshot into a
+// single registry lock hold so an event can never be both replayed from the
+// journal AND delivered live to the same view: a SubscribeWithJournal that
+// runs before emitLocked sees the event in the journal (and the subscriber
+// isn't registered yet, so it's not in the snapshot); one that runs after
+// finds the event already journaled and the subscriber registered for the
+// NEXT event. The two-orderings-are-exhaustive property is what makes the
+// replay→live seam neither drop nor double an event.
+//
+// Callbacks run AFTER the lock is released (the snapshot is taken under it):
+// subscribers are allowed to block (the TUI's task view funnels events
+// through prog.Send, which parks when the UI event queue backs up), and a
+// blocked callback must never hold mu hostage — the UI goroutine itself takes
+// mu via List/Get when rendering the dock, so running a blocking callback
+// under the lock is an ABBA deadlock (worker holds mu → waits on the UI
+// queue; UI waits on mu).
+func (r *taskRegistry) emitLocked(id string, kind int, s, s2 string, journaled bool) []Events {
 	r.mu.Lock()
-	j := r.journals[id]
-	if j == nil {
-		j = &taskJournal{}
-		r.journals[id] = j
+	defer r.mu.Unlock()
+	if journaled {
+		j := r.journals[id]
+		if j == nil {
+			j = &taskJournal{}
+			r.journals[id] = j
+		}
+		j.append(kind, s, s2)
 	}
-	j.append(kind, s, s2)
-	r.mu.Unlock()
+	return append([]Events(nil), r.subs[id]...)
 }
 
 // emitter returns an Events that journals every callback and forwards it to
@@ -377,81 +398,66 @@ func (r *taskRegistry) record(id string, kind int, s, s2 string) {
 // callbacks run on the worker goroutine, so they must be cheap and
 // non-blocking. Tool calls stream in as args deltas (OnToolCall); only the
 // start (kind 1) and end (kind 2) are journaled — the deltas would fill the
-// budget with partial JSON.
+// budget with partial JSON. Compaction is NOT journaled: kind 4 is reserved
+// for the TUI's follow-up-settled message, and replaying a compact as if it
+// were a settle would render it as an error.
 func (r *taskRegistry) emitter(id string) Events {
 	return Events{
 		OnText: func(s string) {
-			r.record(id, 0, s, "")
-			r.broadcast(id, func(e Events) {
+			subs := r.emitLocked(id, 0, s, "", true)
+			for _, e := range subs {
 				if e.OnText != nil {
 					e.OnText(s)
 				}
-			})
+			}
 		},
 		OnThink: func(s string) {
-			r.broadcast(id, func(e Events) {
+			for _, e := range r.emitLocked(id, 0, "", "", false) {
 				if e.OnThink != nil {
 					e.OnThink(s)
 				}
-			})
+			}
 		},
 		OnToolStart: func(tcID, n, a string) {
-			r.record(id, 1, n, a)
-			r.broadcast(id, func(e Events) {
+			subs := r.emitLocked(id, 1, n, a, true)
+			for _, e := range subs {
 				if e.OnToolStart != nil {
 					e.OnToolStart(tcID, n, a)
 				}
-			})
+			}
 		},
 		OnToolCall: func(tcID, n, a string) {
-			r.broadcast(id, func(e Events) {
+			for _, e := range r.emitLocked(id, 0, "", "", false) {
 				if e.OnToolCall != nil {
 					e.OnToolCall(tcID, n, a)
 				}
-			})
+			}
 		},
 		OnToolEnd: func(tcID, n, res string) {
-			r.record(id, 2, n, res)
-			r.broadcast(id, func(e Events) {
+			subs := r.emitLocked(id, 2, n, res, true)
+			for _, e := range subs {
 				if e.OnToolEnd != nil {
 					e.OnToolEnd(tcID, n, res)
 				}
-			})
+			}
 		},
 		OnSteer: func(s string) {
-			r.record(id, 3, s, "")
-			r.broadcast(id, func(e Events) {
+			subs := r.emitLocked(id, 3, s, "", true)
+			for _, e := range subs {
 				if e.OnSteer != nil {
 					e.OnSteer(s)
 				}
-			})
+			}
 		},
 		OnCompact: func(took, kept int) {
-			r.record(id, 4, fmt.Sprintf("%d→%d", took, kept), "")
-			r.broadcast(id, func(e Events) {
+			// journaled=false: kind 4 is follow-up-settled in the TUI, so a
+			// journaled compact would replay as an error line.
+			for _, e := range r.emitLocked(id, 0, "", "", false) {
 				if e.OnCompact != nil {
 					e.OnCompact(took, kept)
 				}
-			})
+			}
 		},
-	}
-}
-
-// broadcast runs a subscriber callback for each of the task's subscribers.
-// The slice is snapshotted under the registry lock, then callbacks run AFTER
-// the lock is released: subscribers are allowed to block (the TUI's task view
-// funnels events through prog.Send, which parks when the UI event queue is
-// backed up), and a blocked callback must never hold mu hostage — the UI
-// goroutine itself takes mu via List/Get when rendering the dock, so running
-// a blocking callback under the lock is an ABBA deadlock (worker holds mu →
-// waits on the UI queue; UI waits on mu). settle deletes the entry, so
-// post-settle events (there should be none) go nowhere.
-func (r *taskRegistry) broadcast(id string, call func(Events)) {
-	r.mu.Lock()
-	subs := append([]Events(nil), r.subs[id]...)
-	r.mu.Unlock()
-	for _, e := range subs {
-		call(e)
 	}
 }
 

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -49,6 +49,47 @@ type BackgroundTask struct {
 	sub *Agent
 }
 
+// JournaledEvent is one recorded task event. Kind mirrors the TUI's
+// taskEventMsg kinds: 0 text, 1 tool start, 2 tool end, 3 steer, 4 compact.
+// S/S2 carry the payload (text / tool name+args / tool result). Consecutive
+// text deltas coalesce into one entry so long streams don't fill the slice.
+type JournaledEvent struct {
+	Kind  int
+	S, S2 string
+}
+
+// taskJournal is a per-task ring of recent events, byte-bounded so a chatty
+// subagent can't grow memory without limit. Over budget → drop from the front
+// and mark Truncated (the detail view renders a "[earlier output dropped]"
+// header line instead of pretending the transcript is complete).
+type taskJournal struct {
+	events    []JournaledEvent
+	bytes     int
+	Truncated bool
+}
+
+// journalBudget caps one task's journal at 128KB of payload text. Sized to
+// hold a typical exploration's full transcript (tool outputs dominate) while
+// bounding a registry full of tasks at single-digit MB.
+const journalBudget = 128 * 1024
+
+// append records one event, coalescing consecutive text deltas (kind 0) into
+// the previous entry — the stream emits one event per SSE delta.
+func (j *taskJournal) append(kind int, s, s2 string) {
+	if kind == 0 && len(j.events) > 0 && j.events[len(j.events)-1].Kind == 0 {
+		j.events[len(j.events)-1].S += s
+		j.bytes += len(s)
+	} else {
+		j.events = append(j.events, JournaledEvent{Kind: kind, S: s, S2: s2})
+		j.bytes += len(s) + len(s2)
+	}
+	for j.bytes > journalBudget && len(j.events) > 1 {
+		j.bytes -= len(j.events[0].S) + len(j.events[0].S2)
+		j.events = j.events[1:]
+		j.Truncated = true
+	}
+}
+
 // taskRegistry tracks background subagents for one parent agent. It is the
 // Go-channels counterpart of opencode's BackgroundJob registry: a map of id →
 // task whose Done channel fans completion out to the tool caller, the TUI, and
@@ -56,6 +97,12 @@ type BackgroundTask struct {
 type taskRegistry struct {
 	mu    sync.Mutex
 	tasks map[string]*BackgroundTask
+	// journals record each task's emitted events so a detail view opened
+	// mid-run (or after settle) replays the full transcript instead of only
+	// what streams in after Subscribe. Written under mu in emitter(); read
+	// under mu by SubscribeWithJournal. Entries die with their task in
+	// ClearSettled.
+	journals map[string]*taskJournal
 	// subs are live event subscribers per task id (the TUI's per-task view).
 	// Events is all callbacks, so fan-out is a slice the worker walks per
 	// event — no channel to close, no per-subscriber goroutine. Kept here
@@ -96,7 +143,7 @@ func (r *taskRegistry) recordSession() string {
 }
 
 func newTaskRegistry() *taskRegistry {
-	return &taskRegistry{tasks: map[string]*BackgroundTask{}, subs: map[string][]Events{}}
+	return &taskRegistry{tasks: map[string]*BackgroundTask{}, subs: map[string][]Events{}, journals: map[string]*taskJournal{}}
 }
 
 // List returns a snapshot of all tasks, oldest first.
@@ -181,6 +228,7 @@ func (r *taskRegistry) ClearSettled(keep ...string) int {
 		if !slices.Contains(keep, id) && t.Status != TaskRunning {
 			delete(r.tasks, id)
 			delete(r.subs, id)
+			delete(r.journals, id)
 			n++
 		}
 	}
@@ -285,26 +333,55 @@ func (a *Agent) StartBackground(description, prompt string, o SubModel) *Backgro
 	return t
 }
 
-// Subscribe registers a live event subscriber for a running task. Returns
-// false when the task is unknown or already settled — the caller should then
-// render the stored Report instead of a live stream.
-func (r *taskRegistry) Subscribe(id string, ev Events) bool {
+// SubscribeWithJournal returns the task's journaled events so far and, when
+// the task is still running, registers ev as a live subscriber — atomically
+// under one lock hold, so no event between the replay point and the
+// subscription is missed or delivered twice. Running reports ok=true; a
+// settled (or restored) task reports ok=false and the caller renders the
+// journal as history. Returns false with a nil journal for unknown ids.
+func (r *taskRegistry) SubscribeWithJournal(id string, ev Events) (events []JournaledEvent, truncated, ok bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	t, ok := r.tasks[id]
-	if !ok || t.Status != TaskRunning {
-		return false
+	t, exists := r.tasks[id]
+	if !exists {
+		return nil, false, false
+	}
+	j := r.journals[id]
+	if j != nil {
+		events = append([]JournaledEvent(nil), j.events...)
+		truncated = j.Truncated
+	}
+	if t.Status != TaskRunning {
+		return events, truncated, false
 	}
 	r.subs[id] = append(r.subs[id], ev)
-	return true
+	return events, truncated, true
 }
 
-// emitter returns an Events that forwards every callback to the task's
-// current subscribers (the TUI's per-task view). Subscriber callbacks run on
-// the worker goroutine, so they must be cheap and non-blocking.
+// record appends one event to the task's journal. Called from emitter
+// callbacks (the subagent worker goroutine) under the registry lock; the
+// journal map entry is created on first event.
+func (r *taskRegistry) record(id string, kind int, s, s2 string) {
+	r.mu.Lock()
+	j := r.journals[id]
+	if j == nil {
+		j = &taskJournal{}
+		r.journals[id] = j
+	}
+	j.append(kind, s, s2)
+	r.mu.Unlock()
+}
+
+// emitter returns an Events that journals every callback and forwards it to
+// the task's current subscribers (the TUI's per-task view). Subscriber
+// callbacks run on the worker goroutine, so they must be cheap and
+// non-blocking. Tool calls stream in as args deltas (OnToolCall); only the
+// start (kind 1) and end (kind 2) are journaled — the deltas would fill the
+// budget with partial JSON.
 func (r *taskRegistry) emitter(id string) Events {
 	return Events{
 		OnText: func(s string) {
+			r.record(id, 0, s, "")
 			r.broadcast(id, func(e Events) {
 				if e.OnText != nil {
 					e.OnText(s)
@@ -319,6 +396,7 @@ func (r *taskRegistry) emitter(id string) Events {
 			})
 		},
 		OnToolStart: func(tcID, n, a string) {
+			r.record(id, 1, n, a)
 			r.broadcast(id, func(e Events) {
 				if e.OnToolStart != nil {
 					e.OnToolStart(tcID, n, a)
@@ -333,6 +411,7 @@ func (r *taskRegistry) emitter(id string) Events {
 			})
 		},
 		OnToolEnd: func(tcID, n, res string) {
+			r.record(id, 2, n, res)
 			r.broadcast(id, func(e Events) {
 				if e.OnToolEnd != nil {
 					e.OnToolEnd(tcID, n, res)
@@ -340,6 +419,7 @@ func (r *taskRegistry) emitter(id string) Events {
 			})
 		},
 		OnSteer: func(s string) {
+			r.record(id, 3, s, "")
 			r.broadcast(id, func(e Events) {
 				if e.OnSteer != nil {
 					e.OnSteer(s)
@@ -347,6 +427,7 @@ func (r *taskRegistry) emitter(id string) Events {
 			})
 		},
 		OnCompact: func(took, kept int) {
+			r.record(id, 4, fmt.Sprintf("%d→%d", took, kept), "")
 			r.broadcast(id, func(e Events) {
 				if e.OnCompact != nil {
 					e.OnCompact(took, kept)

--- a/internal/agent/events_test.go
+++ b/internal/agent/events_test.go
@@ -68,11 +68,13 @@ func TestEmitterBroadcastsToSubscribers(t *testing.T) {
 
 	var mu sync.Mutex
 	var a, b []string
-	if !r.Subscribe(task.ID, recorder(&mu, &a)) || !r.Subscribe(task.ID, recorder(&mu, &b)) {
-		t.Fatal("Subscribe on a running task must succeed")
+	_, _, okA := r.SubscribeWithJournal(task.ID, recorder(&mu, &a))
+	_, _, okB := r.SubscribeWithJournal(task.ID, recorder(&mu, &b))
+	if !okA || !okB {
+		t.Fatal("SubscribeWithJournal on a running task must report live")
 	}
-	if r.Subscribe("task-nope", Events{}) {
-		t.Error("Subscribe on an unknown task must fail")
+	if _, _, ok := r.SubscribeWithJournal("task-nope", Events{}); ok {
+		t.Error("SubscribeWithJournal on an unknown task must fail")
 	}
 
 	fire(r.emitter(task.ID)) // emitter has no OnUsage — fire skips it
@@ -86,8 +88,8 @@ func TestEmitterBroadcastsToSubscribers(t *testing.T) {
 	fire(r.emitter("task-nope"))
 
 	r.settle(task.ID, TaskDone, "report")
-	if r.Subscribe(task.ID, Events{}) {
-		t.Error("Subscribe on a settled task must fail")
+	if _, _, ok := r.SubscribeWithJournal(task.ID, Events{}); ok {
+		t.Error("SubscribeWithJournal on a settled task must not report live")
 	}
 }
 

--- a/internal/agent/journal_test.go
+++ b/internal/agent/journal_test.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The journal records every emitted event in order so a detail view opened
+// after the fact replays the full transcript; consecutive text deltas
+// coalesce into one entry.
+func TestJournalRecordsEmittedEvents(t *testing.T) {
+	r := newTaskRegistry()
+	task := &BackgroundTask{ID: "task-1", Status: TaskRunning, Done: make(chan struct{}), cancel: func() {}}
+	r.tasks[task.ID] = task
+
+	fire(r.emitter(task.ID)) // text, think, tool start/call/end, steer, compact
+
+	events, truncated, ok := r.SubscribeWithJournal(task.ID, Events{})
+	if !ok || truncated {
+		t.Fatalf("running task with journal: ok=%v truncated=%v", ok, truncated)
+	}
+	var kinds []int
+	for _, e := range events {
+		kinds = append(kinds, e.Kind)
+	}
+	// fire emits: text "t", think (not journaled), start, call (not
+	// journaled — args deltas), end, steer, compact.
+	want := []int{0, 1, 2, 3, 4}
+	if fmt.Sprint(kinds) != fmt.Sprint(want) {
+		t.Fatalf("journal kinds = %v, want %v", kinds, want)
+	}
+	if events[0].S != "t" {
+		t.Fatalf("text event = %q, want %q", events[0].S, "t")
+	}
+}
+
+// Text deltas streaming one per SSE chunk coalesce into a single journal
+// entry — a long answer must not stack one entry per fragment.
+func TestJournalCoalescesTextDeltas(t *testing.T) {
+	r := newTaskRegistry()
+	task := &BackgroundTask{ID: "task-1", Status: TaskRunning, Done: make(chan struct{}), cancel: func() {}}
+	r.tasks[task.ID] = task
+
+	em := r.emitter(task.ID)
+	em.OnText("hel")
+	em.OnText("lo ")
+	em.OnText("world")
+	em.OnToolStart("tc1", "read", "{}")
+	em.OnText("after")
+
+	events, _, _ := r.SubscribeWithJournal(task.ID, Events{})
+	if len(events) != 3 {
+		t.Fatalf("journal = %d events, want 3 (coalesced text, tool start, text): %+v", len(events), events)
+	}
+	if events[0].S != "hello world" || events[2].S != "after" {
+		t.Fatalf("coalesced text = %q / %q", events[0].S, events[2].S)
+	}
+}
+
+// Over-budget journals drop from the front and mark truncation; the retained
+// tail stays within the budget.
+func TestJournalOverflowDropsOldest(t *testing.T) {
+	j := &taskJournal{}
+	chunk := strings.Repeat("x", journalBudget/4)
+	for range 6 { // 1.5× budget
+		j.append(1, "tool", chunk)
+	}
+	if !j.Truncated {
+		t.Fatal("overflow should mark the journal truncated")
+	}
+	if j.bytes > journalBudget {
+		t.Fatalf("journal bytes %d exceed budget %d after truncation", j.bytes, journalBudget)
+	}
+	if len(j.events) == 0 || len(j.events) >= 6 {
+		t.Fatalf("truncation should keep a bounded tail, kept %d of 6", len(j.events))
+	}
+	// Text coalescing must not defeat truncation: one giant delta still fits
+	// the budget accounting.
+	k := &taskJournal{}
+	k.append(0, strings.Repeat("y", journalBudget*2), "")
+	if k.bytes != journalBudget*2 {
+		t.Fatalf("single oversized event: bytes = %d", k.bytes)
+	}
+}
+
+// Replay-then-subscribe is atomic: events emitted concurrently with
+// SubscribeWithJournal appear either in the journal snapshot or via the live
+// subscriber — never in both, never in neither.
+func TestSubscribeWithJournalIsAtomic(t *testing.T) {
+	r := newTaskRegistry()
+	task := &BackgroundTask{ID: "task-1", Status: TaskRunning, Done: make(chan struct{}), cancel: func() {}}
+	r.tasks[task.ID] = task
+
+	const pre = 50
+	em := r.emitter(task.ID)
+	for i := range pre {
+		em.OnToolStart("", fmt.Sprint(i), "")
+	}
+
+	var mu sync.Mutex
+	var live []string
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := pre; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				em.OnToolStart("", fmt.Sprint(i), "")
+			}
+		}
+	}()
+
+	events, _, ok := r.SubscribeWithJournal(task.ID, Events{
+		OnToolStart: func(_, n, _ string) { mu.Lock(); live = append(live, n); mu.Unlock() },
+	})
+	close(stop)
+	wg.Wait()
+	if !ok {
+		t.Fatal("running task should report live")
+	}
+
+	seen := map[string]int{}
+	for _, e := range events {
+		seen[e.S]++
+	}
+	mu.Lock()
+	for _, id := range live {
+		seen[id]++
+	}
+	mu.Unlock()
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("event %s seen %d times (journal %d + live %d total = %d)", id, n, len(events), len(live), n)
+		}
+	}
+	if len(seen) < pre {
+		t.Fatalf("the %d pre-subscribe events must all be in the journal: saw %d unique", pre, len(seen))
+	}
+}
+
+// Settled tasks hand back their journal for replay without registering a
+// subscriber; ClearSettled drops the journal with the task.
+func TestJournalSurvivesSettleUntilCleared(t *testing.T) {
+	r := newTaskRegistry()
+	task := &BackgroundTask{ID: "task-1", Status: TaskRunning, Done: make(chan struct{}), cancel: func() {}}
+	r.tasks[task.ID] = task
+	fire(r.emitter(task.ID))
+	r.settle(task.ID, TaskDone, "report")
+
+	events, _, ok := r.SubscribeWithJournal(task.ID, Events{})
+	if ok {
+		t.Fatal("a settled task must not report live")
+	}
+	if len(events) != 5 {
+		t.Fatalf("settled task journal = %d events, want 5", len(events))
+	}
+
+	r.ClearSettled()
+	if events, _, _ := r.SubscribeWithJournal(task.ID, Events{}); events != nil {
+		t.Fatal("ClearSettled should drop the journal with the task")
+	}
+}

--- a/internal/agent/journal_test.go
+++ b/internal/agent/journal_test.go
@@ -27,8 +27,10 @@ func TestJournalRecordsEmittedEvents(t *testing.T) {
 		kinds = append(kinds, e.Kind)
 	}
 	// fire emits: text "t", think (not journaled), start, call (not
-	// journaled — args deltas), end, steer, compact.
-	want := []int{0, 1, 2, 3, 4}
+	// journaled — args deltas), end, steer, compact (not journaled — kind 4
+	// is follow-up-settled in the TUI, and replaying a compact would render
+	// it as an error).
+	want := []int{0, 1, 2, 3}
 	if fmt.Sprint(kinds) != fmt.Sprint(want) {
 		t.Fatalf("journal kinds = %v, want %v", kinds, want)
 	}
@@ -156,8 +158,8 @@ func TestJournalSurvivesSettleUntilCleared(t *testing.T) {
 	if ok {
 		t.Fatal("a settled task must not report live")
 	}
-	if len(events) != 5 {
-		t.Fatalf("settled task journal = %d events, want 5", len(events))
+	if len(events) != 4 {
+		t.Fatalf("settled task journal = %d events, want 4 (text, tool start, tool end, steer)", len(events))
 	}
 
 	r.ClearSettled()

--- a/internal/agent/journal_test.go
+++ b/internal/agent/journal_test.go
@@ -79,12 +79,15 @@ func TestJournalOverflowDropsOldest(t *testing.T) {
 	if len(j.events) == 0 || len(j.events) >= 6 {
 		t.Fatalf("truncation should keep a bounded tail, kept %d of 6", len(j.events))
 	}
-	// Text coalescing must not defeat truncation: one giant delta still fits
-	// the budget accounting.
+	// Text coalescing must not defeat truncation: one giant delta is tail-capped
+	// to the budget, marked truncated.
 	k := &taskJournal{}
 	k.append(0, strings.Repeat("y", journalBudget*2), "")
-	if k.bytes != journalBudget*2 {
-		t.Fatalf("single oversized event: bytes = %d", k.bytes)
+	if k.bytes > journalBudget {
+		t.Fatalf("single oversized event: bytes = %d, want <= %d", k.bytes, journalBudget)
+	}
+	if !k.Truncated {
+		t.Fatal("oversized single entry should mark the journal truncated")
 	}
 }
 

--- a/internal/agent/journal_test.go
+++ b/internal/agent/journal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -96,25 +97,23 @@ func TestSubscribeWithJournalIsAtomic(t *testing.T) {
 	const pre = 50
 	em := r.emitter(task.ID)
 	for i := range pre {
-		em.OnToolStart("", fmt.Sprint(i), "")
+		em.OnToolStart("", strconv.Itoa(i), "")
 	}
 
 	var mu sync.Mutex
 	var live []string
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := pre; ; i++ {
 			select {
 			case <-stop:
 				return
 			default:
-				em.OnToolStart("", fmt.Sprint(i), "")
+				em.OnToolStart("", strconv.Itoa(i), "")
 			}
 		}
-	}()
+	})
 
 	events, _, ok := r.SubscribeWithJournal(task.ID, Events{
 		OnToolStart: func(_, n, _ string) { mu.Lock(); live = append(live, n); mu.Unlock() },

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -358,9 +358,9 @@ func TestBackgroundTaskSubscribersSeeLiveStream(t *testing.T) {
 	task := ag.StartBackground("d", "p", SubModel{})
 
 	var got atomic.Int32
-	ok := ag.Tasks().Subscribe(task.ID, Events{OnText: func(s string) { got.Add(int32(len(s))) }})
+	_, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{OnText: func(s string) { got.Add(int32(len(s))) }})
 	if !ok {
-		t.Fatal("Subscribe on a running task should succeed")
+		t.Fatal("SubscribeWithJournal on a running task should report live")
 	}
 	select {
 	case <-task.Done:
@@ -370,8 +370,8 @@ func TestBackgroundTaskSubscribersSeeLiveStream(t *testing.T) {
 	if got.Load() == 0 {
 		t.Fatal("subscriber saw no text events")
 	}
-	if ag.Tasks().Subscribe(task.ID, Events{}) {
-		t.Fatal("Subscribe on a settled task should report false")
+	if _, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{}); ok {
+		t.Fatal("SubscribeWithJournal on a settled task should not report live")
 	}
 }
 
@@ -424,13 +424,13 @@ func TestBackgroundTaskSubscriberSeesToolEvents(t *testing.T) {
 
 	var mu sync.Mutex
 	var seq []string
-	ok := ag.Tasks().Subscribe(task.ID, Events{
+	_, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{
 		OnText:      func(s string) { mu.Lock(); seq = append(seq, "text:"+s); mu.Unlock() },
 		OnToolStart: func(_, n, _ string) { mu.Lock(); seq = append(seq, "start:"+n); mu.Unlock() },
 		OnToolEnd:   func(_, n, r string) { mu.Lock(); seq = append(seq, "end:"+n+":"+r); mu.Unlock() },
 	})
 	if !ok {
-		t.Fatal("Subscribe on a running task should succeed")
+		t.Fatal("SubscribeWithJournal on a running task should report live")
 	}
 	select {
 	case <-task.Done:
@@ -462,7 +462,7 @@ func TestBackgroundTaskManySubscribers(t *testing.T) {
 	const subs = 4
 	var counts [subs]atomic.Int32
 	for i := range subs {
-		if !ag.Tasks().Subscribe(task.ID, Events{OnText: func(s string) { counts[i].Add(int32(len(s))) }}) {
+		if _, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{OnText: func(s string) { counts[i].Add(int32(len(s))) }}); !ok {
 			t.Fatalf("subscriber %d rejected", i)
 		}
 	}
@@ -478,11 +478,11 @@ func TestBackgroundTaskManySubscribers(t *testing.T) {
 	}
 }
 
-// Subscribing an unknown task id reports false rather than panicking.
+// Subscribing an unknown task id reports not-ok rather than panicking.
 func TestSubscribeUnknownTask(t *testing.T) {
 	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
-	if ag.Tasks().Subscribe("task-999", Events{}) {
-		t.Fatal("Subscribe on an unknown id should report false")
+	if _, _, ok := ag.Tasks().SubscribeWithJournal("task-999", Events{}); ok {
+		t.Fatal("SubscribeWithJournal on an unknown id should report not-ok")
 	}
 }
 
@@ -563,12 +563,12 @@ func TestBroadcastBlockingSubscriberCannotDeadlock(t *testing.T) {
 
 	inCallback := make(chan struct{})
 	notify := sync.OnceFunc(func() { close(inCallback) })
-	if !ag.Tasks().Subscribe(task.ID, Events{
+	if _, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{
 		OnText: func(string) {
 			notify()  // parked mid-broadcast, like Send on a full queue
 			<-release // simulates prog.Send parked behind a stuck UI event loop
 		},
-	}) {
+	}); !ok {
 		t.Fatal("task should accept a subscriber while running")
 	}
 

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -29,8 +29,11 @@ import (
 )
 
 const (
-	maxEntries     = 50
-	maxEntryLength = 300
+	maxEntries = 50
+	// Entries must stay one physical line (the file format is line-based), but
+	// 300 chars forced research takeaways to be split across several entries.
+	// The injection budget stays bounded by maxEntries, not by line length.
+	maxEntryLength = 2000
 )
 
 // Entry is one numbered memory line. Entries are numbered across the whole

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -50,6 +50,33 @@ func sendTaskMsg(p *tea.Program, msg taskEventMsg) {
 	go p.Send(msg)
 }
 
+// renderTaskEvent writes one task event to the transcript buffer. Shared by
+// the live stream (taskEventMsg in tui.go) and the journal replay in
+// openTask, so replayed history and live events can never drift in format.
+// Kind 4 (follow-up settled) only ever arrives live, never from the journal.
+func renderTaskEvent(buf *strings.Builder, kind int, s, s2 string) {
+	switch kind {
+	case 0: // text delta
+		buf.WriteString(s)
+	case 1: // tool start
+		fmt.Fprintf(buf, "\n%s %s %s\n", toolStyle.Render("⚒"), s, dimStyle.Render(s2))
+	case 2: // tool end
+		preview := strings.Split(strings.TrimRight(s2, "\n"), "\n")
+		if len(preview) > 4 {
+			preview = append(preview[:4], fmt.Sprintf("… +%d lines", len(s2)-4))
+		}
+		fmt.Fprintf(buf, "%s\n", dimStyle.Render("  "+strings.Join(preview, "\n  ")))
+	case 3: // a steered message reached the running subagent (task_steer / chat)
+		fmt.Fprintf(buf, "\n%s %s\n", youStyle.Render("↪ steered:"), s)
+	case 4: // follow-up turn settled
+		if s != "" {
+			fmt.Fprintf(buf, "\n%s\n", errStyle.Render(s))
+		} else {
+			buf.WriteString("\n")
+		}
+	}
+}
+
 // taskView is the open per-task pane: the live transcript of one background
 // subagent (or its stored report once settled), plus a chat input — a task IS
 // a session: while it runs, typing steers it; once it settles, typing runs
@@ -163,14 +190,16 @@ func (m *model) tasksDock() string {
 }
 
 // openTask opens the detail view for one task: a scrollback pane seeded with
-// the prompt, then the live event stream while the task runs, or the stored
-// report once it has settled.
+// the prompt, then the journaled transcript replayed up to now, then the
+// live event stream while the task runs (or the stored report once it has
+// settled). The replay+subscribe is one atomic registry call, so no event
+// landing mid-open is missed or shown twice.
 func (m *model) openTask(id string) {
 	t, ok := m.agent.Tasks().Get(id)
 	if !ok {
 		return
 	}
-	tv := &taskView{id: id, live: t.Status == agent.TaskRunning}
+	tv := &taskView{id: id}
 	tv.input = textinput.New()
 	tv.input.Prompt = youStyle.Render("› ")
 	tv.input.Placeholder = "message this subagent (enter to send)"
@@ -178,24 +207,35 @@ func (m *model) openTask(id string) {
 	fmt.Fprintf(&tv.buf, "%s %s  %s\n\n%s %s\n",
 		toolStyle.Render("⚙"), t.ID, t.Description,
 		youStyle.Render("prompt:"), t.Prompt)
-	if t.Status == agent.TaskRunning {
+	p := m.prog
+	events, truncated, live := m.agent.Tasks().SubscribeWithJournal(id, agent.Events{
+		OnText: func(s string) {
+			sendTaskMsg(p, taskEventMsg{id: id, kind: 0, s: s})
+		},
+		OnToolStart: func(_, n, a string) {
+			sendTaskMsg(p, taskEventMsg{id: id, kind: 1, s: n, s2: a})
+		},
+		OnToolEnd: func(_, n, r string) {
+			sendTaskMsg(p, taskEventMsg{id: id, kind: 2, s: n, s2: r})
+		},
+		OnSteer: func(s string) {
+			sendTaskMsg(p, taskEventMsg{id: id, kind: 3, s: s})
+		},
+	})
+	tv.live = live
+	if truncated {
+		fmt.Fprintf(&tv.buf, "\n%s\n", dimStyle.Render("  [earlier output dropped]"))
+	}
+	for _, e := range events {
+		renderTaskEvent(&tv.buf, e.Kind, e.S, e.S2)
+	}
+	switch {
+	case live:
+		if len(events) > 0 {
+			tv.buf.WriteString("\n")
+		}
 		fmt.Fprintf(&tv.buf, "\n%s\n", dimStyle.Render("  running…"))
-		p := m.prog
-		m.agent.Tasks().Subscribe(id, agent.Events{
-			OnText: func(s string) {
-				sendTaskMsg(p, taskEventMsg{id: id, kind: 0, s: s})
-			},
-			OnToolStart: func(_, n, a string) {
-				sendTaskMsg(p, taskEventMsg{id: id, kind: 1, s: n, s2: a})
-			},
-			OnToolEnd: func(_, n, r string) {
-				sendTaskMsg(p, taskEventMsg{id: id, kind: 2, s: n, s2: r})
-			},
-			OnSteer: func(s string) {
-				sendTaskMsg(p, taskEventMsg{id: id, kind: 3, s: s})
-			},
-		})
-	} else {
+	default:
 		fmt.Fprintf(&tv.buf, "\n%s %s\n", toolStyle.Render(string(t.Status)+":"), t.Report)
 	}
 	m.taskVP = tv

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -469,8 +469,85 @@ func TestSettledTaskViewShowsReport(t *testing.T) {
 	if !strings.Contains(stripAll(m.taskViewView()), "the final report") {
 		t.Fatalf("settled task view should render the report, got %q", stripAll(m.taskViewView()))
 	}
-	if m.agent.Tasks().Subscribe(task.ID, agent.Events{}) {
-		t.Fatal("subscribing a settled task should fail")
+	if _, _, ok := m.agent.Tasks().SubscribeWithJournal(task.ID, agent.Events{}); ok {
+		t.Fatal("subscribing a settled task should not report live")
+	}
+}
+
+// The detail view replays the journaled transcript, so opening a task AFTER
+// it emitted (or even settled) shows the full history — tool calls included —
+// not just the final report.
+func TestTaskViewReplaysJournal(t *testing.T) {
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		call++
+		switch call {
+		case 1:
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"read","arguments":"{\"path\":\"/tmp/x\"}"}}]}}]}`+"\n\n")
+			fmt.Fprint(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n")
+		default:
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"the final report"},"finish_reason":"stop"}]}`+"\n\n")
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+	m := tasksModel(srv.URL)
+	task := m.agent.StartBackground("probe", "p", agent.SubModel{})
+	waitSettled(t, task)
+
+	m.openTask(task.ID)
+	if m.taskVP.live {
+		t.Fatal("a settled task's view should not subscribe to events")
+	}
+	view := stripAll(m.taskViewView())
+	for _, want := range []string{"⚒ read", "the final report", "done:"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("replayed view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// Opening a RUNNING task replays what streamed before the open, then keeps
+// streaming live events after it.
+func TestRunningTaskViewReplaysThenStreams(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"early-text"}}]}`+"\n\n")
+		w.(http.Flusher).Flush() // delivered before the view opens
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"late-text"},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(func() { close(release) })
+	defer srv.Close()
+	m := tasksModel(srv.URL)
+	task := m.agent.StartBackground("probe", "p", agent.SubModel{})
+	defer m.agent.Tasks().Cancel(task.ID)
+
+	// Wait for the journal to hold the early delta, then open mid-run.
+	for range 100 {
+		if events, _, _ := m.agent.Tasks().SubscribeWithJournal(task.ID, agent.Events{}); len(events) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	m.openTask(task.ID)
+	if !m.taskVP.live {
+		t.Fatal("a running task's view should subscribe to live events")
+	}
+	if view := stripAll(m.taskViewView()); !strings.Contains(view, "early-text") {
+		t.Fatalf("view opened mid-run should replay pre-open output:\n%s", view)
+	}
+	// Live events keep arriving after the open (headless model: Update direct).
+	m.Update(taskEventMsg{id: task.ID, kind: 0, s: "late-text"})
+	if view := stripAll(m.taskViewView()); !strings.Contains(view, "late-text") {
+		t.Fatalf("live event after open missing:\n%s", view)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2147,27 +2147,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if tv == nil || msg.id != tv.id {
 			return m, nil
 		}
-		switch msg.kind {
-		case 0: // text delta
-			tv.buf.WriteString(msg.s)
-		case 1: // tool start
-			fmt.Fprintf(&tv.buf, "\n%s %s %s\n", toolStyle.Render("⚒"), msg.s, dimStyle.Render(msg.s2))
-		case 2: // tool end
-			preview := strings.Split(strings.TrimRight(msg.s2, "\n"), "\n")
-			if len(preview) > 4 {
-				preview = append(preview[:4], fmt.Sprintf("… +%d lines", len(msg.s2)-4))
-			}
-			fmt.Fprintf(&tv.buf, "%s\n", dimStyle.Render("  "+strings.Join(preview, "\n  ")))
-		case 3: // a steered message reached the running subagent (task_steer / chat)
-			fmt.Fprintf(&tv.buf, "\n%s %s\n", youStyle.Render("↪ steered:"), msg.s)
-		case 4: // follow-up turn settled; unlock the chat input
+		if msg.kind == 4 { // follow-up turn settled; unlock the chat input
 			tv.busy, tv.followCancel = false, nil
-			if msg.s != "" {
-				fmt.Fprintf(&tv.buf, "\n%s\n", errStyle.Render(msg.s))
-			} else {
-				tv.buf.WriteString("\n")
-			}
 		}
+		renderTaskEvent(&tv.buf, msg.kind, msg.s, msg.s2)
 		m.refreshTaskVP()
 		return m, nil
 


### PR DESCRIPTION
## Item 3 of the Agent UX batch ([plan](.ai-docs/plans/agent-ux-batch/PLAN.md))

**Problem:** opening a subagent's detail view showed only events that arrived *after* attach — a task opened mid-run or after settle showed the prompt and nothing else; settled tasks showed only the final report.

**Fix:** the task registry now journals every emitted event per task (byte-capped at 128KB, drop-oldest with a `[earlier output dropped]` marker, consecutive text deltas coalesced). `openTask` replays the journal and subscribes to the live stream as **one atomic registry call** (`SubscribeWithJournal`), so no event is missed or duplicated at the replay→live seam. Replay and live rendering share `renderTaskEvent`, so the two paths can't drift in format.

Also folds in the pre-approved memory entry cap relaxation (300 → 2000 chars; file format unchanged, injection budget still bounded by `maxEntries`).

## Tests

- `internal/agent/journal_test.go` — recording, text-delta coalescing, overflow truncation, replay/subscribe atomicity under concurrent emit (`-race`), survive-settle/clear lifecycle
- `internal/tui/tasks_test.go` — `TestTaskViewReplaysJournal` (settled task shows full transcript incl. tool calls), `TestRunningTaskViewReplaysThenStreams` (replay then live)
- `task check` green; `go test -race ./internal/agent ./internal/tui` green