### PR TITLE
feat(agent): add wait tool — harness-owned polling replaces sleep loops

### DIFF
--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -51,6 +51,7 @@ Operating rules:
 - Bias toward acting on reasonable assumptions. But after about three failed attempts on the same blocker, stop and escalate it plainly instead of looping.
 - When the user shares a durable preference or fact about themselves, save it with remember; drop stale entries with forget.
 - Git hygiene: review the staged diff for secrets before committing, never run git add . — stage only the files you intend — and never force-push.
+- To wait for an external condition (CI finishing, a deploy going live, a server coming up), use the wait tool — never poll with sleep loops (each poll costs a full turn). You will be notified once when the condition changes.
 
 Current working directory: ` + wd
 	if extra := config.MeInstructions(); extra != "" {

--- a/docs/features.md
+++ b/docs/features.md
@@ -70,6 +70,45 @@ Tests: `internal/tools/bashrun/feedback_test.go` — `TestOnUpdateThrottle`
 `internal/tui/tool_output_test.go` — `TestToolOutputMsgUpdatesRunningRow`
 (unknown id ignored, tail replaces, end clears), `TestLastLines`.
 
+### Waiting without polling (`wait` tool)
+
+`internal/agent/wait.go` — the `wait` tool replaces `sleep N && check` loops
+(which spend a full LLM turn per poll) with a **harness-owned poller**. The
+model names a shell command, an optional `until` regex, an interval (min 2s,
+default 10s) and a timeout (default 10m, max 1h); a goroutine re-runs the
+command via `bashrun` on the interval with zero model involvement.
+
+Exactly one message re-enters the loop when the wait resolves — never a poll
+per check. Delivery routes on whether a turn is in flight (`Agent.TurnRunning`
+— an `atomic.Bool` set at `turn()` entry/exit): **busy** → `Steer`, drained at
+the next loop boundary like any steered message; **idle** → the registry's
+`OnWake` hook, which the TUI installs (`wireWaits`, called from `wireTasks` so
+every agent swap re-installs it) to submit a machine-authored turn
+(`submitTurn(text, false)`), the opencode/exo wake pattern. A turn that starts
+between the `TurnRunning` check and the wake message is caught by the
+`waitWakeMsg` handler re-checking `m.busy` and steering instead of
+double-submitting. Headless idle (`whip run`, tests) has no loop boundary and
+no wake hook, so the message is dropped by design; the busy path is the one
+that matters there.
+
+Resolution states (`WaitStatus`): `condition met` (exit 0 and `until` regex
+matches, checked immediately on registration and then per interval), `timed
+out`, and `command failing` — 3 consecutive non-zero exits strike out the wait
+early (hermes' 3-strike lesson) so a broken command doesn't poll for the full
+timeout. Delivery is once-only (`atomic.Bool` CAS in `deliver`), `Done` closes
+on settle like `BackgroundTask`, and `CancelWait` suppresses a pending
+delivery. Waits are live-only: a dead process's waits die with it, and the
+registry's `Close` cancels every poller on agent teardown.
+
+The system prompt (`cmd/whip/main.go`) tells the model to prefer `wait` over
+`sleep` loops, and the tool's return message restates the no-poll contract.
+
+Tests: `internal/agent/wait_test.go` — `TestWaitConditionMetImmediately`,
+`TestWaitUntilRegex`, `TestWaitStrikesOut`, `TestWaitTimeout`,
+`TestWaitBusySteersInsteadOfWaking` (busy → Steer, not OnWake),
+`TestWaitCancel`, `TestWaitToolRegisters` (def parsing + settle).
+`go test -race ./internal/agent` green.
+
 ### Compaction
 
 When the conversation fills the context window, old turns fold into an

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -459,10 +459,16 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 // deferred teardown routes each survivor to the wait registry's OnWake, which
 // submits a machine turn — the same wake path as an idle wait firing.
 func (a *Agent) drainOrphanedSteers() {
+	// Locked read: Waits()/wireWaits write waitReg under a.mu from the TUI
+	// goroutine; a bare field read here races an agent swap mid-turn.
+	a.mu.Lock()
+	reg := a.waitReg
+	a.mu.Unlock()
+	if reg == nil || reg.OnWake == nil {
+		return
+	}
 	for _, s := range a.drainPending() {
-		if a.waitReg != nil && a.waitReg.OnWake != nil {
-			a.waitReg.OnWake(s.text)
-		}
+		reg.OnWake(s.text)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/context-labs/whip/internal/llm"
@@ -97,6 +98,8 @@ type Agent struct {
 	mu        sync.Mutex
 	pending   []pendingSteer // steered user messages awaiting injection
 	compacted bool           // a compaction already happened this turn — don't retry-loop
+	running   atomic.Bool    // a turn is in flight (wait delivery routes on it)
+	waitReg   *waitRegistry  // lazily created by waits()
 
 	// msgsMu guards Messages for concurrent READERS: the turn goroutine
 	// mutates Messages freely, but a test/UI reader taking msgsMu sees a
@@ -135,6 +138,11 @@ type Agent struct {
 	usageMu sync.Mutex
 	usage   llm.Usage // session totals across every API call (PromptTokens = input)
 }
+
+// TurnRunning reports whether a turn is currently in flight. The wait
+// registry routes delivery on it: busy → Steer (drained at the next loop
+// boundary), idle → the OnWake hook (a parked steer would never be seen).
+func (a *Agent) TurnRunning() bool { return a.running.Load() }
 
 // Steer queues a user message for injection at the next loop boundary of the
 // running turn — after the in-flight response and its tool calls complete,
@@ -243,6 +251,7 @@ func New(client *llm.Client, model string, maxTokens int, systemPrompt string) *
 	}
 	a.Tools = append(a.Tools, taskTool(a), taskSteerTool(a))
 	a.Tools = append(a.Tools, todoTool(a))
+	a.Tools = append(a.Tools, waitTool(a))
 	a.Tools = append(a.Tools, memoryTools(a)...)
 	a.files = newFileLocks()
 	a.bg = newTaskRegistry()
@@ -334,6 +343,8 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 	if n := a.decay(); n > 0 && ev.OnDecay != nil {
 		ev.OnDecay(n)
 	}
+	a.running.Store(true)
+	defer a.running.Store(false)
 	msg := llm.Message{Role: "user", Content: input, Parts: parts, Authored: authored}
 	if authored {
 		now := time.Now()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -344,7 +344,10 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 		ev.OnDecay(n)
 	}
 	a.running.Store(true)
-	defer a.running.Store(false)
+	defer func() {
+		a.running.Store(false)
+		a.drainOrphanedSteers() // catch steers that lost the race to teardown
+	}()
 	msg := llm.Message{Role: "user", Content: input, Parts: parts, Authored: authored}
 	if authored {
 		now := time.Now()
@@ -445,6 +448,20 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 		if len(msg.ToolCalls) == 0 && len(steered) == 0 {
 			a.compacted = false // reset for the next Turn
 			return msg.Content, nil
+		}
+	}
+}
+
+// drainOrphanedSteers re-drains any steered messages that lost the race
+// against a turn's final loop boundary: a Steer landing after the last
+// drainPending but before running flips false would otherwise sit in pending
+// forever (the wait registry's busy delivery, a user's mid-turn message). The
+// deferred teardown routes each survivor to the wait registry's OnWake, which
+// submits a machine turn — the same wake path as an idle wait firing.
+func (a *Agent) drainOrphanedSteers() {
+	for _, s := range a.drainPending() {
+		if a.waitReg != nil && a.waitReg.OnWake != nil {
+			a.waitReg.OnWake(s.text)
 		}
 	}
 }

--- a/internal/agent/wait.go
+++ b/internal/agent/wait.go
@@ -167,7 +167,12 @@ func (r *waitRegistry) poll(ctx context.Context, w *waitTask, until *regexp.Rege
 	defer deadline.Stop()
 	strikes := 0
 	check := func() (done bool) {
-		res := bashrun.Run(ctx, bashrun.Options{Command: w.Command, Timeout: w.Interval})
+		// Per-run budget is decoupled from the poll cadence: a slow command
+		// (gh pr checks, a cold curl) must not eat a strike just because the
+		// interval is short. Floor 30s so short-interval waits still let real
+		// commands finish; capped at 60s so a hung command can't stall the
+		// ticker for the whole session timeout.
+		res := bashrun.Run(ctx, bashrun.Options{Command: w.Command, Timeout: min(max(w.Interval, 30*time.Second), 60*time.Second)})
 		if ctx.Err() != nil {
 			return true // cancelled / registry stopped — deliver nothing
 		}
@@ -217,18 +222,25 @@ func (r *waitRegistry) deliver(w *waitTask, status WaitStatus, msg string) {
 	}
 	w.setStatus(status)
 	w.Detail = msg
-	close(w.Done)
-	w.cancel() // stop the ticker select
+	// Route BEFORE closing Done: a waiter woken by the close must already
+	// find the terminal message delivered (steered or woken) — the old order
+	// (close → steer) let a woken test/caller drain pending before the steer
+	// landed. Same ordering rule as the task registry's settle.
 	if r.agent.TurnRunning() {
 		r.agent.Steer(msg)
-		return
-	}
-	if r.OnWake != nil {
+	} else if r.OnWake != nil {
 		r.OnWake(msg)
-		return
 	}
-	// Headless idle: no loop boundary is coming and no wake hook exists; the
-	// message is dropped by design (see waitRegistry doc).
+	// Headless idle (no turn, no hook): the message is dropped by design —
+	// an idle headless agent has no loop boundary coming (see waitRegistry doc).
+	close(w.Done)
+	w.cancel() // stop the ticker select
+	// ponytail: no listing surface exists yet (no /waits command), so a
+	// settled wait serves no one — drop it to keep the map bounded. If a
+	// listing lands later, keep settled rows and bound by count instead.
+	r.mu.Lock()
+	delete(r.waits, w.ID)
+	r.mu.Unlock()
 }
 
 // Close stops every poller goroutine. Called when the agent is being torn
@@ -257,6 +269,9 @@ func (r *waitRegistry) CancelWait(id string) bool {
 	w.setStatus(WaitKilled)
 	close(w.Done)
 	w.cancel()
+	r.mu.Lock()
+	delete(r.waits, id)
+	r.mu.Unlock()
 	return true
 }
 

--- a/internal/agent/wait.go
+++ b/internal/agent/wait.go
@@ -1,0 +1,319 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools"
+	"github.com/context-labs/whip/internal/tools/bashrun"
+)
+
+// A wait is a harness-owned poller: the model names a shell command and a
+// success condition, and a goroutine re-runs the command on an interval —
+// zero LLM turns while waiting. When the condition resolves (met, timed out,
+// or the command keeps failing), exactly one message re-enters the agent
+// loop: steered at the next loop boundary if a turn is running, or handed to
+// OnWake (the TUI's machine-turn hook) when idle. This is the cross-harness
+// pattern from .ai-docs/plans/agent-ux-batch/wait-tool-research.md: the timer
+// lives outside the model and only the terminal delta is ever delivered —
+// never a sleep+check loop burning a turn per poll.
+
+// WaitStatus is one wait's lifecycle state.
+type WaitStatus string
+
+const (
+	WaitRunning WaitStatus = "running"
+	WaitMet     WaitStatus = "condition met"
+	WaitTimeout WaitStatus = "timed out"
+	WaitFailed  WaitStatus = "command failing"
+	WaitKilled  WaitStatus = "cancelled"
+)
+
+// waitTask is one registered wait. Done closes on delivery, mirroring
+// BackgroundTask: any number of watchers wake on the same close. Detail is
+// written before Done closes, so readers must wait on Done (or Status) first.
+type waitTask struct {
+	ID        string
+	Command   string
+	Until     string // regex source, "" = exit-0-only
+	Interval  time.Duration
+	Timeout   time.Duration
+	Started   time.Time
+	status    atomic.Value // WaitStatus; string-typed, atomic for raced readers
+	Detail    string       // delivered message — read only after Done closes
+	Done      chan struct{}
+	cancel    context.CancelFunc
+	delivered atomic.Bool
+}
+
+// Status returns the wait's current lifecycle state.
+func (w *waitTask) Status() WaitStatus {
+	if v := w.status.Load(); v != nil {
+		return v.(WaitStatus)
+	}
+	return WaitRunning
+}
+
+// setStatus sets the lifecycle state (called only before Done closes, or in
+// CancelWait before close).
+func (w *waitTask) setStatus(s WaitStatus) { w.status.Store(s) }
+
+// waitRegistry owns the live waits for one agent. OnWake is installed by the
+// TUI to submit a machine turn when no turn is running; nil in headless runs,
+// where idle delivery falls back to queueing a steer for the next turn (an
+// idle headless agent has no loop boundary coming, so the text is discarded
+// there by design — `whip run` waits are best observed via the busy path).
+type waitRegistry struct {
+	mu     sync.Mutex
+	waits  map[string]*waitTask
+	seq    int
+	OnWake func(text string)
+	agent  *Agent
+	ctx    context.Context
+	stop   context.CancelFunc
+}
+
+var waitIDCounter atomic.Int64
+
+func newWaitRegistry(a *Agent) *waitRegistry {
+	ctx, stop := context.WithCancel(context.Background())
+	return &waitRegistry{waits: map[string]*waitTask{}, agent: a, ctx: ctx, stop: stop}
+}
+
+// Waits returns the agent's wait registry, creating it lazily. The TUI
+// installs OnWake on it; the wait tool registers pollers on it.
+func (a *Agent) Waits() *waitRegistry { return a.waits() }
+
+// waits lazily attaches the registry.
+func (a *Agent) waits() *waitRegistry {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.waitReg == nil {
+		a.waitReg = newWaitRegistry(a)
+	}
+	return a.waitReg
+}
+
+// WaitTaskSpec is one wait request from the model.
+type WaitTaskSpec struct {
+	Command  string
+	Until    string        // optional regex matched against stdout
+	Interval time.Duration // poll cadence; min 2s
+	Timeout  time.Duration // give-up wall clock; max 1h
+}
+
+const (
+	waitMinInterval = 2 * time.Second
+	waitMaxTimeout  = time.Hour
+	// waitMaxErrStrikes ends a wait whose command keeps erroring (hermes'
+	// 3-strike lesson): a broken command must not poll for the full timeout.
+	waitMaxErrStrikes = 3
+)
+
+// StartWait registers a wait and spawns its poller goroutine. Returns the
+// wait id (wait-<slug>-<n>) or an error for an unusable spec.
+func (a *Agent) StartWait(spec WaitTaskSpec) (*waitTask, error) {
+	if spec.Command == "" {
+		return nil, errors.New("command is required")
+	}
+	var untilRe *regexp.Regexp
+	if spec.Until != "" {
+		re, err := regexp.Compile(spec.Until)
+		if err != nil {
+			return nil, fmt.Errorf("until regex: %w", err)
+		}
+		untilRe = re
+	}
+	if spec.Interval < waitMinInterval {
+		spec.Interval = waitMinInterval
+	}
+	if spec.Timeout <= 0 {
+		spec.Timeout = 10 * time.Minute
+	}
+	if spec.Timeout > waitMaxTimeout {
+		spec.Timeout = waitMaxTimeout
+	}
+	r := a.waits()
+	r.mu.Lock()
+	r.seq++
+	id := taskSlug(spec.Command, waitIDCounter.Add(1))
+	id = "wait-" + id
+	ctx, cancel := context.WithCancel(r.ctx)
+	w := &waitTask{
+		ID: id, Command: spec.Command, Until: spec.Until,
+		Interval: spec.Interval, Timeout: spec.Timeout,
+		Started: time.Now(), Done: make(chan struct{}),
+		cancel: cancel,
+	}
+	r.waits[id] = w
+	r.mu.Unlock()
+
+	go r.poll(ctx, w, untilRe)
+	return w, nil
+}
+
+// poll is the wait's poller goroutine: runs the command each interval until
+// the condition resolves, the timeout fires, or the registry stops. Owner of
+// the goroutine; exits on every path.
+func (r *waitRegistry) poll(ctx context.Context, w *waitTask, until *regexp.Regexp) {
+	ticker := time.NewTicker(w.Interval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(w.Timeout)
+	defer deadline.Stop()
+	strikes := 0
+	check := func() (done bool) {
+		res := bashrun.Run(ctx, bashrun.Options{Command: w.Command, Timeout: w.Interval})
+		if ctx.Err() != nil {
+			return true // cancelled / registry stopped — deliver nothing
+		}
+		if res.TimedOut || res.Exit != "" {
+			strikes++
+			if strikes >= waitMaxErrStrikes {
+				r.deliver(w, WaitFailed, fmt.Sprintf("[wait %s] gave up: command failed %d consecutive times (last: %s)\n\nLast output:\n%s",
+					w.ID, strikes, res.Exit, tailLines(res.Output, 20)))
+				return true
+			}
+			return false
+		}
+		strikes = 0
+		if until == nil || until.MatchString(res.Output) {
+			r.deliver(w, WaitMet, fmt.Sprintf("[wait %s done] condition met (ran every %s):\n$ %s\n\n%s",
+				w.ID, w.Interval, w.Command, tailLines(res.Output, 40)))
+			return true
+		}
+		return false
+	}
+	// First check immediately — a condition already true resolves in one run.
+	if check() {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			r.deliver(w, WaitTimeout, fmt.Sprintf("[wait %s timeout] %s elapsed without the condition being met:\n$ %s",
+				w.ID, w.Timeout, w.Command))
+			return
+		case <-ticker.C:
+			if check() {
+				return
+			}
+		}
+	}
+}
+
+// deliver settles the wait exactly once (the atomic CAS is the once-guard —
+// timeout and a concurrent strike can race) and routes the terminal message:
+// steered at the next loop boundary while a turn runs, OnWake when idle.
+func (r *waitRegistry) deliver(w *waitTask, status WaitStatus, msg string) {
+	if !w.delivered.CompareAndSwap(false, true) {
+		return
+	}
+	w.setStatus(status)
+	w.Detail = msg
+	close(w.Done)
+	w.cancel() // stop the ticker select
+	if r.agent.TurnRunning() {
+		r.agent.Steer(msg)
+		return
+	}
+	if r.OnWake != nil {
+		r.OnWake(msg)
+		return
+	}
+	// Headless idle: no loop boundary is coming and no wake hook exists; the
+	// message is dropped by design (see waitRegistry doc).
+}
+
+// Close stops every poller goroutine. Called when the agent is being torn
+// down (session switch/exit); in-flight polls see ctx cancellation and
+// deliver nothing.
+func (r *waitRegistry) Close() {
+	if r.stop != nil {
+		r.stop()
+	}
+}
+
+// CancelWait stops a running wait. Returns false if unknown or settled.
+func (r *waitRegistry) CancelWait(id string) bool {
+	r.mu.Lock()
+	w, ok := r.waits[id]
+	running := ok && w.Status() == WaitRunning
+	r.mu.Unlock()
+	if !running {
+		return false
+	}
+	w.delivered.Store(true) // suppress delivery from the in-flight poll
+	w.setStatus(WaitKilled)
+	close(w.Done)
+	w.cancel()
+	return true
+}
+
+// ListWaits snapshots all waits, running first.
+func (r *waitRegistry) ListWaits() []*waitTask {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*waitTask, 0, len(r.waits))
+	for _, w := range r.waits {
+		out = append(out, w)
+	}
+	return out
+}
+
+// tailLines keeps the last n lines of s (delivery messages quote output; the
+// tail is where the interesting state is).
+func tailLines(s string, n int) string {
+	lines := []byte(s)
+	count, idx := 0, len(lines)
+	for idx > 0 && count < n {
+		idx--
+		if lines[idx] == '\n' {
+			count++
+		}
+	}
+	if idx > 0 {
+		return "[…]\n" + string(lines[idx+1:])
+	}
+	return s
+}
+
+// waitTool is the model-facing surface: `wait` registers a poller and
+// returns immediately.
+func waitTool(a *Agent) tools.Tool {
+	return tools.Tool{
+		Def: llm.NewTool("wait",
+			"Wait for an external condition without burning LLM turns: a background poller re-runs the shell command on the given interval (no model involvement while waiting) and you are notified EXACTLY ONCE when the condition is met, the timeout elapses, or the command keeps failing. Use this instead of `sleep N && check` loops (those spend a full turn per poll). Typical uses: CI finishing (`gh pr checks 55 | grep -q pass` or until the command exits 0), a deploy going live, a server coming up. The notification arrives as a message — do NOT poll for it.",
+			`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to run repeatedly; success means exit 0"},"until":{"type":"string","description":"Optional regex the command's output must match (in addition to exit 0) to count as met"},"interval":{"type":"number","description":"Seconds between runs (default 10, min 2)"},"timeout":{"type":"number","description":"Seconds before giving up (default 600, max 3600)"}},"required":["command"]}`),
+		Run: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var spec struct {
+				Command  string  `json:"command"`
+				Until    string  `json:"until"`
+				Interval float64 `json:"interval"`
+				Timeout  float64 `json:"timeout"`
+			}
+			if err := json.Unmarshal(args, &spec); err != nil {
+				return "", err
+			}
+			w, err := a.StartWait(WaitTaskSpec{
+				Command:  spec.Command,
+				Until:    spec.Until,
+				Interval: time.Duration(spec.Interval * float64(time.Second)),
+				Timeout:  time.Duration(spec.Timeout * float64(time.Second)),
+			})
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Waiting (%s): `%s` every %s, giving up after %s. You will be notified once — keep working or answer the user; do NOT sleep-poll.",
+				w.ID, w.Command, w.Interval, w.Timeout), nil
+		},
+	}
+}

--- a/internal/agent/wait.go
+++ b/internal/agent/wait.go
@@ -73,7 +73,6 @@ func (w *waitTask) setStatus(s WaitStatus) { w.status.Store(s) }
 type waitRegistry struct {
 	mu     sync.Mutex
 	waits  map[string]*waitTask
-	seq    int
 	OnWake func(text string)
 	agent  *Agent
 	ctx    context.Context
@@ -142,7 +141,6 @@ func (a *Agent) StartWait(spec WaitTaskSpec) (*waitTask, error) {
 	}
 	r := a.waits()
 	r.mu.Lock()
-	r.seq++
 	id := taskSlug(spec.Command, waitIDCounter.Add(1))
 	id = "wait-" + id
 	ctx, cancel := context.WithCancel(r.ctx)
@@ -242,7 +240,9 @@ func (r *waitRegistry) Close() {
 	}
 }
 
-// CancelWait stops a running wait. Returns false if unknown or settled.
+// CancelWait stops a running wait. Returns false if unknown or already
+// settled. The CAS is the once-guard against a poller mid-deliver: whoever
+// wins it owns the close, so Done can never close twice.
 func (r *waitRegistry) CancelWait(id string) bool {
 	r.mu.Lock()
 	w, ok := r.waits[id]
@@ -251,22 +251,13 @@ func (r *waitRegistry) CancelWait(id string) bool {
 	if !running {
 		return false
 	}
-	w.delivered.Store(true) // suppress delivery from the in-flight poll
+	if !w.delivered.CompareAndSwap(false, true) {
+		return false // a deliver is already settling it
+	}
 	w.setStatus(WaitKilled)
 	close(w.Done)
 	w.cancel()
 	return true
-}
-
-// ListWaits snapshots all waits, running first.
-func (r *waitRegistry) ListWaits() []*waitTask {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]*waitTask, 0, len(r.waits))
-	for _, w := range r.waits {
-		out = append(out, w)
-	}
-	return out
 }
 
 // tailLines keeps the last n lines of s (delivery messages quote output; the

--- a/internal/agent/wait_test.go
+++ b/internal/agent/wait_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -168,22 +169,89 @@ func TestWaitToolRegisters(t *testing.T) {
 	if !strings.Contains(out, "do NOT sleep-poll") {
 		t.Fatalf("tool output should state the no-poll contract: %q", out)
 	}
-	// The registered wait should settle quickly (exit 0).
-	deadline := time.After(2 * time.Second)
-	for {
-		done := true
-		for _, w := range ag.Waits().ListWaits() {
-			if w.Status() == WaitRunning {
-				done = false
-			}
-		}
-		if done {
-			return
-		}
+	// The registered wait (exit 0) settles on the immediate first check.
+	for _, w := range ag.Waits().waits {
 		select {
-		case <-deadline:
+		case <-w.Done:
+		case <-time.After(2 * time.Second):
 			t.Fatal("registered wait never settled")
-		case <-time.After(20 * time.Millisecond):
 		}
+	}
+}
+
+// The ticker path (a condition false on the immediate first check but true on
+// a later poll) is distinct from the immediate-check path — the 2s minimum
+// interval clamps make sub-2s tests never exercise it, so this one sits at
+// the real minimum and confirms a later poll settles the wait.
+func TestWaitTickerPath(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+	ag.Waits().OnWake = func(string) {}
+
+	// A file that appears after the first check: the until regex matches only
+	// once the file exists, so the first (immediate) poll fails and a ticker
+	// poll must settle it.
+	flag := t.TempDir() + "/ready"
+	w, err := ag.StartWait(WaitTaskSpec{
+		Command:  "cat " + flag + " 2>/dev/null || true",
+		Until:    "READY",
+		Interval: waitMinInterval, // the real floor — the ticker fires at 2s
+		Timeout:  30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write the flag shortly after the first check would have run.
+	time.AfterFunc(500*time.Millisecond, func() {
+		os.WriteFile(flag, []byte("READY"), 0o600)
+	})
+	select {
+	case <-w.Done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ticker-path wait never settled")
+	}
+	if w.Status() != WaitMet {
+		t.Fatalf("status = %q, want %q", w.Status(), WaitMet)
+	}
+}
+
+// The lost-wakeup race: a Steer landing after a turn's final drainPending but
+// before running flips false must not be dropped — the turn's teardown
+// re-drain routes it to OnWake. Tested via the drain mechanism directly: the
+// exact interleaving window isn't deterministically forceable in a live turn.
+func TestTurnTeardownDrainsOrphanedSteers(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	var woke []string
+	ag.Waits().OnWake = func(s string) { woke = append(woke, s) }
+
+	ag.running.Store(true)
+	ag.Steer("orphaned message")
+	// Simulate teardown: running flips false, then the re-drain runs.
+	ag.running.Store(false)
+	ag.drainOrphanedSteers()
+
+	if len(woke) != 1 || woke[0] != "orphaned message" {
+		t.Fatalf("orphaned steer should wake, got %v", woke)
+	}
+	if len(ag.drainPending()) != 0 {
+		t.Fatal("pending should be empty after teardown drain")
+	}
+}
+
+// CancelWait racing a deliver must not panic (double close). The CAS makes
+// exactly one of them own the close. Run under -race.
+func TestWaitCancelRacesDeliver(t *testing.T) {
+	for range 200 {
+		ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+		ag.Waits().OnWake = func(string) {}
+		w, err := ag.StartWait(WaitTaskSpec{Command: "exit 0", Interval: waitMinInterval, Timeout: time.Minute})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The immediate first check delivers on this goroutine's schedule;
+		// cancel concurrently. Whichever wins, no double-close panic.
+		go ag.Waits().CancelWait(w.ID)
+		<-w.Done
+		ag.Waits().Close()
 	}
 }

--- a/internal/agent/wait_test.go
+++ b/internal/agent/wait_test.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools"
+)
+
+// A condition already true resolves in the first check (no interval wait)
+// and delivers exactly one "met" message.
+func TestWaitConditionMetImmediately(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+
+	var woke atomic.Int32
+	ag.Waits().OnWake = func(string) { woke.Add(1) }
+
+	w, err := ag.StartWait(WaitTaskSpec{Command: "exit 0", Interval: 50 * time.Millisecond, Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-w.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait never delivered")
+	}
+	if w.Status() != WaitMet {
+		t.Fatalf("status = %q, want %q", w.Status(), WaitMet)
+	}
+	if !strings.Contains(w.Detail, "condition met") {
+		t.Fatalf("detail = %q", w.Detail)
+	}
+	if got := woke.Load(); got != 1 {
+		t.Fatalf("idle wake fired %d times, want exactly 1", got)
+	}
+}
+
+// The until regex gates success: exit-0 alone doesn't settle the wait when
+// `until` is set, and a matching output settles it once the pattern appears.
+func TestWaitUntilRegex(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+	ag.Waits().OnWake = func(string) {}
+
+	// The command exits 0 but prints "running" — until "ready" must not fire.
+	w, err := ag.StartWait(WaitTaskSpec{Command: "echo running", Until: "ready", Interval: 50 * time.Millisecond, Timeout: 200 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-w.Done
+	if w.Status() != WaitTimeout {
+		t.Fatalf("status = %q, want %q (until never matched)", w.Status(), WaitTimeout)
+	}
+
+	// A bad until regex is rejected at registration, not at first poll.
+	if _, err := ag.StartWait(WaitTaskSpec{Command: "true", Until: "[unclosed"}); err == nil {
+		t.Fatal("bad until regex should fail StartWait")
+	}
+}
+
+// A command that keeps failing strikes out after 3 consecutive errors instead
+// of polling until the timeout.
+func TestWaitStrikesOut(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+	ag.Waits().OnWake = func(string) {}
+
+	start := time.Now()
+	w, err := ag.StartWait(WaitTaskSpec{Command: "exit 1", Interval: 30 * time.Millisecond, Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-w.Done
+	if w.Status() != WaitFailed {
+		t.Fatalf("status = %q, want %q", w.Status(), WaitFailed)
+	}
+	if d := time.Since(start); d > 10*time.Second {
+		t.Fatalf("strike-out should beat the timeout: took %s", d)
+	}
+}
+
+// Timeout delivers a timeout message exactly once.
+func TestWaitTimeout(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+	ag.Waits().OnWake = func(string) {}
+
+	w, err := ag.StartWait(WaitTaskSpec{Command: "echo still-waiting", Until: "never-matches", Interval: 30 * time.Millisecond, Timeout: 150 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-w.Done
+	if w.Status() != WaitTimeout {
+		t.Fatalf("status = %q, want %q", w.Status(), WaitTimeout)
+	}
+	if !strings.Contains(w.Detail, "timeout") {
+		t.Fatalf("detail = %q", w.Detail)
+	}
+}
+
+// A running turn routes delivery through Steer (loop boundary), not OnWake.
+func TestWaitBusySteersInsteadOfWaking(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+	ag.running.Store(true) // simulate an in-flight turn
+
+	var woke atomic.Int32
+	ag.Waits().OnWake = func(string) { woke.Add(1) }
+
+	w, err := ag.StartWait(WaitTaskSpec{Command: "exit 0", Interval: 30 * time.Millisecond, Timeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-w.Done
+	if woke.Load() != 0 {
+		t.Fatal("busy delivery must not fire OnWake")
+	}
+	if got := len(ag.drainPending()); got != 1 {
+		t.Fatalf("busy delivery should queue exactly one steer, got %d", got)
+	}
+}
+
+// Cancel stops the wait and suppresses delivery.
+func TestWaitCancel(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+	ag.Waits().OnWake = func(string) {}
+
+	w, err := ag.StartWait(WaitTaskSpec{Command: "echo x", Until: "never", Interval: time.Second, Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ag.Waits().CancelWait(w.ID) {
+		t.Fatal("cancel of a running wait should succeed")
+	}
+	if w.Status() != WaitKilled {
+		t.Fatalf("status = %q, want %q", w.Status(), WaitKilled)
+	}
+	if ag.Waits().CancelWait(w.ID) {
+		t.Fatal("second cancel should report not-running")
+	}
+}
+
+// The wait tool parses args, registers the poller, and returns the "don't
+// poll" contract message.
+func TestWaitToolRegisters(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	defer ag.Waits().Close()
+
+	var wt tools.Tool
+	for _, tl := range ag.AllTools() {
+		if tl.Def.Function.Name == "wait" {
+			wt = tl
+		}
+	}
+	if wt.Def.Function.Name == "" {
+		t.Fatal("agent should expose the wait tool")
+	}
+	out, err := wt.Run(t.Context(), json.RawMessage(`{"command":"exit 0","interval":0.05,"timeout":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "do NOT sleep-poll") {
+		t.Fatalf("tool output should state the no-poll contract: %q", out)
+	}
+	// The registered wait should settle quickly (exit 0).
+	deadline := time.After(2 * time.Second)
+	for {
+		done := true
+		for _, w := range ag.Waits().ListWaits() {
+			if w.Status() == WaitRunning {
+				done = false
+			}
+		}
+		if done {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("registered wait never settled")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}

--- a/internal/agent/wait_test.go
+++ b/internal/agent/wait_test.go
@@ -169,12 +169,30 @@ func TestWaitToolRegisters(t *testing.T) {
 	if !strings.Contains(out, "do NOT sleep-poll") {
 		t.Fatalf("tool output should state the no-poll contract: %q", out)
 	}
-	// The registered wait (exit 0) settles on the immediate first check.
+	// The registered wait (exit 0) settles on the immediate first check —
+	// which also removes it from the registry map, so the handle may already
+	// be gone by the time we look. Either outcome proves the wiring.
+	ag.Waits().mu.Lock()
+	var ws []*waitTask
 	for _, w := range ag.Waits().waits {
+		ws = append(ws, w)
+	}
+	ag.Waits().mu.Unlock()
+	if len(ws) > 1 {
+		t.Fatalf("at most one wait should be registered, got %d", len(ws))
+	}
+	if len(ws) == 1 {
 		select {
-		case <-w.Done:
+		case <-ws[0].Done:
 		case <-time.After(2 * time.Second):
 			t.Fatal("registered wait never settled")
+		}
+		// Settled waits are dropped from the map (no listing surface exists).
+		ag.Waits().mu.Lock()
+		left := len(ag.Waits().waits)
+		ag.Waits().mu.Unlock()
+		if left != 0 {
+			t.Fatalf("settled wait should be deleted from the registry, %d left", left)
 		}
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -92,6 +92,7 @@ type (
 	usageMsg      llm.Usage                 // one request's token usage
 	quitArmMsg    struct{}                  // the idle ctrl+c arm window expired
 	taskUpdateMsg struct{}                  // a background subagent started/settled — redraw
+	waitWakeMsg   string                    // an idle wait fired — wake as a machine turn
 	mcpStatusMsg  struct{}                  // an MCP server changed state — redraw
 	thinkMsg      string                    // streamed reasoning tokens
 	imageMsg      struct {                  // ctrl+v clipboard image result
@@ -2109,6 +2110,18 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case waitWakeMsg:
+		// An idle wait fired: wake as a machine-authored turn (the opencode/
+		// exo wake pattern). If a turn started between the wait's TurnRunning
+		// check and this message, steer into the live turn instead of
+		// double-submitting — a steer parks until the next loop boundary.
+		m.append(dimStyle.Render("⏲ " + firstLine(string(msg))))
+		if m.busy {
+			m.agent.Steer(string(msg))
+			return m, nil
+		}
+		return m.submitTurn(string(msg), false)
+
 	case mcpStatusMsg:
 		// An MCP server changed state. Announce each server's FIRST settle in
 		// the transcript (one line, once per session per server) so arrivals
@@ -2819,6 +2832,7 @@ func (m *model) wireTasks() {
 	}
 	m.agent.Tasks().SetSessionID(m.sessionID)
 	m.agent.SetSessionID(m.sessionID)
+	m.wireWaits()
 	if m.prog == nil {
 		return // headless (tests)
 	}
@@ -2832,6 +2846,20 @@ func (m *model) wireTasks() {
 	// specific agent, precisely so this handoff works.
 	if m.mcpMgr != nil {
 		m.agent.SetMCPTools(m.mcpMgr.Tools())
+	}
+}
+
+// wireWaits points the active agent's wait registry at this UI's wake hook:
+// an idle wait firing submits a machine-authored turn (the opencode/exo
+// pattern — whip's Steer only reaches a RUNNING turn, so idle delivery needs
+// the wake). Called from wireTasks so every agent swap re-installs it. The
+// hook runs on the wait's poller goroutine, so it only sends a message.
+func (m *model) wireWaits() {
+	if m.prog == nil {
+		return // headless (tests)
+	}
+	m.agent.Waits().OnWake = func(text string) {
+		go m.prog.Send(waitWakeMsg(text)) // detached, same rule as OnChange
 	}
 }
 


### PR DESCRIPTION
## Item 1 of the Agent UX batch ([plan](.ai-docs/plans/agent-ux-batch/PLAN.md))

**Problem:** a model waiting on an external condition (CI finishing, a deploy going live, a server coming up) ran `sleep N && check` loops — each poll costing a full LLM turn (~28M tokens observed on an 8-minute CI watch).

**Fix:** the new `wait` tool registers a **harness-owned poller**. A goroutine re-runs the command via `bashrun` on an interval with zero model involvement, then delivers **exactly one** message when the wait resolves:
- **busy** → `Steer`, drained at the next loop boundary (`Agent.TurnRunning`, a new `atomic.Bool` set at `turn()` entry/exit, gates it)
- **idle** → the new `OnWake` hook, which the TUI installs (`wireWaits`, called from `wireTasks`) to submit a machine-authored turn — the opencode/exo wake pattern

A turn starting between the `TurnRunning` check and the wake is caught by the `waitWakeMsg` handler re-checking `m.busy` and steering instead of double-submitting. Headless idle has no loop boundary and no wake hook, so the message drops by design (documented).

**Resolution states:** `condition met` (exit 0 + optional `until` regex, checked immediately then per interval), `timed out`, `command failing` — 3 consecutive non-zero exits strike out early (hermes' lesson) so a broken command doesn't poll for the full timeout. Delivery is once-only (atomic CAS), `Done` closes on settle like `BackgroundTask`, `CancelWait` suppresses a pending delivery. Waits are live-only; the registry's `Close` cancels all pollers on teardown.

The system prompt now steers the model to prefer `wait` over `sleep` loops, and the tool's return message restates the no-poll contract.

## Tests

`internal/agent/wait_test.go` — condition-met-immediately, until-regex gating, strike-out, timeout, **busy-steer-vs-wake routing**, cancel, tool registration. `task check` green; `go test -race ./internal/agent` green.