### PR TITLE
feat(llm): stamp prompt_cache_key for provider prefix caching

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -97,6 +97,32 @@ Token bookkeeping: `llm.Usage` (prompt/completion/cached) is read off the
 terminal stream chunk (`stream_options: include_usage`) and folded into session
 totals via `AddUsage`. Compaction and subagent calls count too.
 
+### Provider prompt-prefix caching
+
+To cut time-to-first-token on the many sequential turns of an agent loop,
+whip stamps `prompt_cache_key` on every request (OpenAI `prompt_cache_key`;
+openrouter/xai/azure/mistral honor the same field; providers that don't
+recognize it ignore the unknown top-level field). The key is the **session
+id**: `Agent.SetSessionID` sets `Client.CacheKey`, so a stable session lets
+the provider reuse the cached conversation prefix across turns. Subagents get
+a scoped key (`<sessionID>/<taskID>` in `StartBackground`) so their shorter,
+churning contexts never disturb the parent's cached prefix and two concurrent
+subagents don't collide on the session key. An explicit
+`Request.PromptCacheKey` overrides the client's (that's how the subagent
+scoping is applied); empty omits the field entirely so providers that would
+reject it never see it. The prefix-stability preconditions are already
+maintained elsewhere: the system prompt's per-turn memory block sits at the
+END of the system message (`prepareTurn`), MCP tools are name-sorted
+(`mcp.Manager.Tools`), and the context-decay pass keeps the recent hot window
+byte-stable. Anthropic-style `cache_control: ephemeral` breakpoints are out of
+scope — whip speaks OpenAI chat-completions uniformly and has no
+Anthropic-native consumer for them.
+
+Tests: `internal/llm/cache_test.go` — `TestPromptCacheKeyStampedFromClient`,
+`TestPromptCacheKeyRequestOverridesClient`, `TestConsecutiveRequestsSharePrefix`
+(the prefix-cache contract: turn N's messages are a byte-identical prefix of
+turn N+1's, same key on both).
+
 Commands: `/compact` (compact now), `/compact <model> [provider]` (pick the
 summarizer), `/compact off` (restore the built-in default). The palette's
 "Compaction model" panel lists every configured model behind a

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/context-labs/whip/internal/llm"
@@ -116,7 +117,7 @@ type Agent struct {
 	todosMu sync.Mutex
 	onTodos func(items []Todo)
 
-	sessionID string // scopes the per-session memory file (SetSessionID)
+	sessionID atomic.Pointer[string] // scopes the per-session memory file + keys the prompt cache (SetSessionID)
 
 	// toolsMu guards mcpTools: the MCP manager's OnChange can fire (server
 	// settled) while a Turn is streaming, and Turn reads the tool set per

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -245,11 +245,18 @@ func (a *Agent) StartBackground(description, prompt string, o SubModel) *Backgro
 	}
 	id := taskSlug(description, taskIDCounter.Add(1))
 	taskCtx, cancel := context.WithCancel(context.Background())
+	sub := a.newSub(o)
+	// Scope the subagent's prompt-cache key to the task so its shorter,
+	// churning context never disturbs the parent's cached prefix (and two
+	// concurrent subagents don't collide on the session key).
+	if sid := a.SessionIDValue(); sid != "" {
+		sub.Client.CacheKey = sid + "/" + id
+	}
 	t := &BackgroundTask{
 		ID: id, Description: description, Prompt: prompt,
 		Status: TaskRunning, StartedAt: time.Now(),
 		Done: make(chan struct{}), cancel: cancel,
-		sub: a.newSub(o),
+		sub: sub,
 	}
 	a.bg.mu.Lock()
 	a.bg.tasks[id] = t

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -12,15 +12,32 @@ import (
 )
 
 // SessionID scopes the memory tools' per-session file. Set by the TUI once a
-// session exists; "" leaves only the installation scope.
-func (a *Agent) SetSessionID(id string) { a.sessionID = id }
+// session exists; "" leaves only the installation scope. It also keys the
+// provider prompt cache (Client.CacheKey): a stable session id lets the
+// provider reuse the cached conversation prefix across turns. The id is
+// stored atomically — the TUI sets it on the UI goroutine while the subagent
+// tool reads it on a worker goroutine.
+func (a *Agent) SetSessionID(id string) {
+	a.sessionID.Store(&id)
+	if a.Client != nil {
+		a.Client.CacheKey = id
+	}
+}
+
+// SessionIDValue returns the current session id ("" when none).
+func (a *Agent) SessionIDValue() string {
+	if p := a.sessionID.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
 
 // memoryTools registers remember/forget. Both scopes are plain markdown files
 // the user can edit by hand; forget strikes an entry ("- [x]") instead of
 // deleting so the file keeps an audit trail.
 func memoryTools(a *Agent) []tools.Tool {
 	scopes := func() (installation, session memory.Scope) {
-		return memory.Installation(), memory.Session(a.sessionID)
+		return memory.Installation(), memory.Session(a.SessionIDValue())
 	}
 	resolve := func(name string) (memory.Scope, error) {
 		inst, sess := scopes()

--- a/internal/llm/cache_test.go
+++ b/internal/llm/cache_test.go
@@ -1,0 +1,110 @@
+package llm
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A Client with CacheKey stamps prompt_cache_key on every request; without
+// one the field is omitted entirely (providers that don't know it must not
+// see it).
+func TestPromptCacheKeyStampedFromClient(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "k")
+	c.CacheKey = "session-abc"
+	if _, _, err := c.Stream(context.Background(), Request{Model: "m", Messages: []Message{{Role: "user", Content: "hi"}}}, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"prompt_cache_key":"session-abc"`) {
+		t.Fatalf("prompt_cache_key missing from request: %s", body)
+	}
+
+	// No CacheKey → no field on the wire.
+	c2 := New(srv.URL, "k")
+	if _, _, err := c2.Stream(context.Background(), Request{Model: "m", Messages: []Message{{Role: "user", Content: "hi"}}}, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "prompt_cache_key") {
+		t.Fatalf("prompt_cache_key should be omitted when unset: %s", body)
+	}
+}
+
+// An explicit Request.PromptCacheKey overrides the client's (a subagent
+// scopes its own key over the parent's).
+func TestPromptCacheKeyRequestOverridesClient(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "k")
+	c.CacheKey = "session-abc"
+	req := Request{Model: "m", Messages: []Message{{Role: "user", Content: "hi"}}, PromptCacheKey: "session-abc/task-3"}
+	if _, _, err := c.Stream(context.Background(), req, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"prompt_cache_key":"session-abc/task-3"`) {
+		t.Fatalf("request-level key should win: %s", body)
+	}
+}
+
+// The prefix-cache contract: two consecutive requests in a session must share
+// a byte-identical prefix up through the last message of the earlier request.
+// This guards regressions that silently break provider prefix caching (e.g.
+// someone adding a per-turn timestamp to the system prompt).
+func TestConsecutiveRequestsSharePrefix(t *testing.T) {
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, b)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "k")
+	c.CacheKey = "sess"
+	msgs := []Message{
+		{Role: "system", Content: "You are whip."},
+		{Role: "user", Content: "first"},
+	}
+	// Turn 1.
+	resp, _, err := c.Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Turn 2 appends assistant + user; the system+first-user prefix is frozen.
+	msgs = append(msgs, Message{Role: "assistant", Content: resp.Content})
+	msgs = append(msgs, Message{Role: "user", Content: "second"})
+	if _, _, err := c.Stream(context.Background(), Request{Model: "m", Messages: msgs}, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("captured %d requests, want 2", len(bodies))
+	}
+	b1, b2 := string(bodies[0]), string(bodies[1])
+	// Turn 1's full message array is a prefix of turn 2's (turn 2 only
+	// appends). Both serialize the system + first user message identically.
+	if !strings.Contains(b2, b1[strings.Index(b1, `"messages"`):strings.LastIndex(b1, `}]`)+1]) {
+		t.Fatalf("turn-2 request does not contain turn-1's message prefix byte-identically.\nturn1: %s\nturn2: %s", b1, b2)
+	}
+	// Both carry the same cache key.
+	if !strings.Contains(b1, `"prompt_cache_key":"sess"`) || !strings.Contains(b2, `"prompt_cache_key":"sess"`) {
+		t.Fatalf("cache key must be stable across turns:\n%s\n%s", b1, b2)
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -326,6 +326,11 @@ type Client struct {
 	// OnRetry, when set, is invoked before each retry of a transient request
 	// failure. Optional — nil means silent retries.
 	OnRetry func(RetryEvent)
+	// CacheKey is stamped as prompt_cache_key on every request (see
+	// Request.PromptCacheKey). Set once per session by the caller; subagents
+	// get their own key so their shorter contexts don't churn the parent's
+	// cached prefix. Empty disables the field.
+	CacheKey string
 }
 
 // attempts returns the total try count (initial + retries) for this client.
@@ -354,10 +359,17 @@ type Request struct {
 	// Temperature and TopP are optional per-model sampling knobs. Pointers so
 	// 0.0 (a legitimate value) is distinguishable from unset; nil omits the
 	// field from the request, preserving provider defaults.
-	Temperature   *float64 `json:"temperature,omitempty"`
-	TopP          *float64 `json:"top_p,omitempty"`
-	Stream        bool     `json:"stream"`
-	StreamOptions *struct {
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"top_p,omitempty"`
+	Stream      bool     `json:"stream"`
+	// PromptCacheKey keys the provider's automatic prompt-prefix cache
+	// (OpenAI prompt_cache_key; openrouter/xai/azure/mistral honor the same
+	// field). A stable per-session key lets the provider reuse the cached
+	// conversation prefix across turns, so intra-turn tool round-trips hit
+	// cache instead of reprocessing the whole prompt. Empty omits the field.
+	// Providers that don't recognize it ignore unknown top-level fields.
+	PromptCacheKey string `json:"prompt_cache_key,omitempty"`
+	StreamOptions  *struct {
 		IncludeUsage bool `json:"include_usage"`
 	} `json:"stream_options,omitempty"`
 }
@@ -626,6 +638,9 @@ func (c *Client) Stream(ctx context.Context, req Request, onText, onThink func(s
 		IncludeUsage bool `json:"include_usage"`
 	}{IncludeUsage: true}
 	req.Messages = repairToolHistory(stripAuthored(req.Messages))
+	if req.PromptCacheKey == "" {
+		req.PromptCacheKey = c.CacheKey
+	}
 	body, err := json.Marshal(req)
 	if err != nil {
 		return Message{}, Usage{}, err


### PR DESCRIPTION
## Item 2 of the Agent UX batch ([plan](.ai-docs/plans/agent-ux-batch/PLAN.md))

**Problem:** whip sends no provider cache hints, so every turn reprocesses the full conversation prompt. opencode's research ([opencode-speed.md](.ai-docs/plans/agent-ux-batch/opencode-speed.md)) shows this is the dominant 'feels fast' factor — its loop is serial like ours, so the win is **time-to-first-token per turn**, not dispatch.

**Change:**
- `Request.PromptCacheKey` (`omitempty`) + `Client.CacheKey`, applied at the marshal site — OpenAI `prompt_cache_key`; openrouter/xai/azure/mistral honor the same field; unknown top-level fields are ignored by others.
- `Agent.SetSessionID` sets `Client.CacheKey = sessionID`, so a stable session reuses its cached prefix across turns.
- `StartBackground` scopes a subagent's key to `<sessionID>/<taskID>` so its shorter, churning context never disturbs the parent's cached prefix, and concurrent subagents don't collide on the session key.
- `SetSessionID`'s id moves to an `atomic.Pointer` (TUI sets it on the UI goroutine; the subagent tool reads it on a worker goroutine — fixes a latent race).

**Prefix-stability preconditions verified in-tree:** per-turn memory block sits at the END of the system message (`prepareTurn`), MCP tools are name-sorted (`mcp.Manager.Tools`), and context-decay keeps the recent hot window byte-stable. Anthropic-style `cache_control` breakpoints are out of scope — whip speaks OpenAI chat-completions uniformly, no Anthropic-native consumer.

## Tests

`internal/llm/cache_test.go` — key stamped from client, request-level override wins, and the **prefix-cache contract** (turn N's messages are a byte-identical prefix of turn N+1's, same key on both). `task check` + `golangci-lint` green.