### PR TITLE
feat(agent,tui): steer typed input into turns that are only waiting on subagents

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -353,6 +353,21 @@ relay: full device login + key mint, store round-trip, key validation),
 - Queueing (enter while busy), steering (empty enter), history recall (↑/↓),
   `@file` mentions, `$skill` invocation, `/goal` loop, `/resume` session
   picker, `/effort` reasoning levels — see the roadmap for the full list.
+- **Typing steers a turn that's only waiting on subagents.** When a turn is
+  running but its only in-flight tool calls are subagents
+  (`Agent.WaitingOnSubagents` — the agent tracks in-flight tool names in
+  `runTools`), typed input routes to `Agent.Steer` instead of the busy queue:
+  it reaches the model at the next loop boundary as a mid-turn correction
+  rather than queueing behind the whole turn (waiting on a subagent isn't real
+  work the message would interrupt). Any other in-flight tool (a bash, an
+  edit) keeps the queue behavior. The input placeholder reflects the routing
+  live (`syncInputPlaceholder`, consulted in `View`): "waiting on subagents —
+  type to steer this turn" vs "busy — type to queue". Tests:
+  `internal/agent/busysteer_test.go` (`TestInFlightToolsTracking`,
+  `TestWaitingOnSubagentsGating`,
+  `TestWaitingOnSubagentsDuringForegroundSubagent` — a real turn blocked on a
+  live foreground subagent reports waiting, then flips false),
+  `internal/tui/queue_test.go` (`TestBusyPlaceholderReflectsRouting`).
 - **Settings commands run mid-turn.** `/theme`, `/mouse`, `/effort`, `/subagents` (alias `/tasks`),
   `/help`, `/cd`, `/pwd`, and the non-submitting `/goal` forms (bare, `clear`,
   `rounds`) execute immediately while busy instead of queueing — queued text

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/context-labs/whip/internal/llm"
@@ -97,6 +99,7 @@ type Agent struct {
 	mu        sync.Mutex
 	pending   []pendingSteer // steered user messages awaiting injection
 	compacted bool           // a compaction already happened this turn — don't retry-loop
+	running   atomic.Bool    // a turn is in flight (wait delivery routes on it)
 
 	// msgsMu guards Messages for concurrent READERS: the turn goroutine
 	// mutates Messages freely, but a test/UI reader taking msgsMu sees a
@@ -105,6 +108,13 @@ type Agent struct {
 
 	files *fileLocks // per-path mutation locks for parallel tool calls
 	bg    *taskRegistry
+
+	// inflightTools counts currently-executing tool calls by name (incremented
+	// in runTools after the mutation lock is acquired, decremented at tool
+	// end). Read by WaitingOnSubagents to let the TUI steer the user's typed
+	// input into a turn that is only blocked on subagents, rather than
+	// queueing it behind the whole turn.
+	inflightTools sync.Map // map[string]*atomic.Int64
 
 	// Todos is the todowrite plan, rewritten in full by the model and
 	// injected per round. Like Messages, it is only mutated by the turn
@@ -135,6 +145,11 @@ type Agent struct {
 	usageMu sync.Mutex
 	usage   llm.Usage // session totals across every API call (PromptTokens = input)
 }
+
+// TurnRunning reports whether a turn is currently in flight. The wait
+// registry routes delivery on it: busy → Steer (drained at the next loop
+// boundary), idle → the OnWake hook (a parked steer would never be seen).
+func (a *Agent) TurnRunning() bool { return a.running.Load() }
 
 // Steer queues a user message for injection at the next loop boundary of the
 // running turn — after the in-flight response and its tool calls complete,
@@ -334,6 +349,8 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 	if n := a.decay(); n > 0 && ev.OnDecay != nil {
 		ev.OnDecay(n)
 	}
+	a.running.Store(true)
+	defer a.running.Store(false)
 	msg := llm.Message{Role: "user", Content: input, Parts: parts, Authored: authored}
 	if authored {
 		now := time.Now()
@@ -438,6 +455,45 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 	}
 }
 
+// trackTool adjusts the in-flight count for a tool name.
+func (a *Agent) trackTool(name string, delta int64) {
+	v, _ := a.inflightTools.LoadOrStore(name, &atomic.Int64{})
+	v.(*atomic.Int64).Add(delta)
+}
+
+// InFlightTools returns the sorted names of tools currently executing.
+func (a *Agent) InFlightTools() []string {
+	var out []string
+	a.inflightTools.Range(func(k, v any) bool {
+		if v.(*atomic.Int64).Load() > 0 {
+			out = append(out, k.(string))
+		}
+		return true
+	})
+	slices.Sort(out)
+	return out
+}
+
+// WaitingOnSubagents reports whether a turn is running and its only in-flight
+// work is subagent calls — the model is blocked waiting on them, so a user
+// message can be steered in as a mid-turn correction instead of queued behind
+// the whole turn (it isn't an interruption if the agent is just waiting).
+func (a *Agent) WaitingOnSubagents() bool {
+	if !a.TurnRunning() {
+		return false
+	}
+	names := a.InFlightTools()
+	if len(names) == 0 {
+		return false // mid-generation, no tools yet — not "waiting on subagents"
+	}
+	for _, n := range names {
+		if n != "subagent" {
+			return false
+		}
+	}
+	return true
+}
+
 // runTools executes a batch of tool calls concurrently, returning one result
 // per call in the original order (the API matches tool results to call IDs, so
 // order must be preserved even though execution is parallel). This is the
@@ -484,6 +540,8 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 			if ev.OnToolStart != nil {
 				ev.OnToolStart(tc.ID, name, args)
 			}
+			a.trackTool(name, 1)
+			defer a.trackTool(name, -1)
 			start := time.Now()
 			callCtx := ctx
 			if ev.OnToolOutput != nil && name == "bash" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -109,12 +108,12 @@ type Agent struct {
 	files *fileLocks // per-path mutation locks for parallel tool calls
 	bg    *taskRegistry
 
-	// inflightTools counts currently-executing tool calls by name (incremented
-	// in runTools after the mutation lock is acquired, decremented at tool
-	// end). Read by WaitingOnSubagents to let the TUI steer the user's typed
-	// input into a turn that is only blocked on subagents, rather than
-	// queueing it behind the whole turn.
-	inflightTools sync.Map // map[string]*atomic.Int64
+	// subagentInflight / otherInflight count in-flight tool calls by kind
+	// (incremented in runTools after the mutation lock, decremented at tool
+	// end). WaitingOnSubagents reads them to let the TUI steer typed input
+	// into a turn that's only blocked on subagents, not queue it.
+	subagentInflight atomic.Int64
+	otherInflight    atomic.Int64
 
 	// Todos is the todowrite plan, rewritten in full by the model and
 	// injected per round. Like Messages, it is only mutated by the turn
@@ -141,6 +140,13 @@ type Agent struct {
 	// ComputerDisabled, when true, keeps computer_exec out of the tool set
 	// (config computer.enabled=false).
 	ComputerDisabled bool
+
+	// OnOrphanedSteer, when set by the TUI, receives steered messages that lost
+	// the race against a turn's final loop boundary (a Steer landing after the
+	// last drainPending but before the turn returned). The TUI submits each as
+	// a machine turn so a mid-turn message is never silently dropped. Same
+	// shape as the wait tool's OnWake; the two unify when both branches land.
+	OnOrphanedSteer func(text string)
 
 	usageMu sync.Mutex
 	usage   llm.Usage // session totals across every API call (PromptTokens = input)
@@ -350,7 +356,10 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 		ev.OnDecay(n)
 	}
 	a.running.Store(true)
-	defer a.running.Store(false)
+	defer func() {
+		a.running.Store(false)
+		a.drainOrphanedSteers() // catch steers that lost the race to teardown
+	}()
 	msg := llm.Message{Role: "user", Content: input, Parts: parts, Authored: authored}
 	if authored {
 		now := time.Now()
@@ -455,43 +464,37 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 	}
 }
 
-// trackTool adjusts the in-flight count for a tool name.
-func (a *Agent) trackTool(name string, delta int64) {
-	v, _ := a.inflightTools.LoadOrStore(name, &atomic.Int64{})
-	v.(*atomic.Int64).Add(delta)
+// drainOrphanedSteers re-drains any steered messages that lost the race
+// against a turn's final loop boundary: a Steer landing after the last
+// drainPending but before running flips false would otherwise sit in pending
+// forever (a user's mid-turn message while waiting on subagents, the wait
+// registry's busy delivery). The deferred teardown hands each survivor to
+// OnOrphanedSteer, which the TUI installs to submit it as a machine turn.
+func (a *Agent) drainOrphanedSteers() {
+	if a.OnOrphanedSteer == nil {
+		return
+	}
+	for _, s := range a.drainPending() {
+		a.OnOrphanedSteer(s.text)
+	}
 }
 
-// InFlightTools returns the sorted names of tools currently executing.
-func (a *Agent) InFlightTools() []string {
-	var out []string
-	a.inflightTools.Range(func(k, v any) bool {
-		if v.(*atomic.Int64).Load() > 0 {
-			out = append(out, k.(string))
-		}
-		return true
-	})
-	slices.Sort(out)
-	return out
+// trackTool adjusts the in-flight counts by tool kind.
+func (a *Agent) trackTool(name string, delta int64) {
+	if name == "subagent" {
+		a.subagentInflight.Add(delta)
+	} else {
+		a.otherInflight.Add(delta)
+	}
 }
 
 // WaitingOnSubagents reports whether a turn is running and its only in-flight
 // work is subagent calls — the model is blocked waiting on them, so a user
 // message can be steered in as a mid-turn correction instead of queued behind
 // the whole turn (it isn't an interruption if the agent is just waiting).
+// Empty in-flight means mid-generation, which keeps the queue behavior.
 func (a *Agent) WaitingOnSubagents() bool {
-	if !a.TurnRunning() {
-		return false
-	}
-	names := a.InFlightTools()
-	if len(names) == 0 {
-		return false // mid-generation, no tools yet — not "waiting on subagents"
-	}
-	for _, n := range names {
-		if n != "subagent" {
-			return false
-		}
-	}
-	return true
+	return a.TurnRunning() && a.subagentInflight.Load() > 0 && a.otherInflight.Load() == 0
 }
 
 // runTools executes a batch of tool calls concurrently, returning one result

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -159,8 +159,16 @@ func (a *Agent) TurnRunning() bool { return a.running.Load() }
 
 // Steer queues a user message for injection at the next loop boundary of the
 // running turn — after the in-flight response and its tool calls complete,
-// never mid-generation.
+// never mid-generation. When NO turn is running (the caller raced a teardown:
+// it saw WaitingOnSubagents true, then the turn ended before this Steer
+// landed), there is no boundary left to drain the queue — so the steer goes
+// straight to OnOrphanedSteer instead of parking forever. One guard here
+// covers every Steer caller (TUI keys, wait-tool delivery, subagent fan-in).
 func (a *Agent) Steer(text string) {
+	if !a.running.Load() && a.OnOrphanedSteer != nil {
+		a.OnOrphanedSteer(text)
+		return
+	}
 	a.mu.Lock()
 	a.pending = append(a.pending, pendingSteer{text: text})
 	a.mu.Unlock()

--- a/internal/agent/busysteer_test.go
+++ b/internal/agent/busysteer_test.go
@@ -12,24 +12,24 @@ import (
 	"github.com/context-labs/whip/internal/llm"
 )
 
-// In-flight counts rise while a tool runs and drain when it finishes. Driving
-// a registry emitter directly keeps the window deterministic (an httptest
-// tool call returns too fast to observe).
+// In-flight counts rise while a tool runs and drain when it finishes, split
+// by kind (subagent vs other).
 func TestInFlightToolsTracking(t *testing.T) {
 	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
-	ag.trackTool("read", 1)
+	ag.trackTool("subagent", 1)
 	ag.trackTool("read", 1)
 	ag.trackTool("bash", 1)
-	if got := ag.InFlightTools(); len(got) != 2 {
-		t.Fatalf("in-flight names = %v, want 2 distinct tools", got)
+	if ag.subagentInflight.Load() != 1 || ag.otherInflight.Load() != 2 {
+		t.Fatalf("counts = %d subagent / %d other, want 1/2", ag.subagentInflight.Load(), ag.otherInflight.Load())
 	}
-	ag.trackTool("read", -2)
-	if got := ag.InFlightTools(); len(got) != 1 || got[0] != "bash" {
-		t.Fatalf("after reads finish, in-flight = %v, want [bash]", got)
-	}
+	ag.trackTool("read", -1)
 	ag.trackTool("bash", -1)
-	if got := ag.InFlightTools(); len(got) != 0 {
-		t.Fatalf("in-flight set should drain, got %v", got)
+	if ag.otherInflight.Load() != 0 {
+		t.Fatalf("other should drain, got %d", ag.otherInflight.Load())
+	}
+	ag.trackTool("subagent", -1)
+	if ag.subagentInflight.Load() != 0 {
+		t.Fatalf("subagent should drain, got %d", ag.subagentInflight.Load())
 	}
 }
 
@@ -111,5 +111,31 @@ func TestWaitingOnSubagentsDuringForegroundSubagent(t *testing.T) {
 	}
 	if ag.WaitingOnSubagents() {
 		t.Fatal("turn finished → no longer waiting")
+	}
+}
+
+// A steer queued before teardown is handed to OnOrphanedSteer (not dropped)
+// and drained out of pending; with no hook installed it stays put so a
+// headless caller can still drain it itself.
+func TestDrainOrphanedSteers(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+
+	// No hook: drainOrphanedSteers is a no-op, pending survives.
+	ag.Steer("keep me")
+	ag.drainOrphanedSteers()
+	if got := ag.drainPending(); len(got) != 1 || got[0].text != "keep me" {
+		t.Fatalf("no hook: pending should survive, got %+v", got)
+	}
+
+	var surfaced []string
+	ag.OnOrphanedSteer = func(text string) { surfaced = append(surfaced, text) }
+	ag.Steer("one")
+	ag.Steer("two")
+	ag.drainOrphanedSteers()
+	if len(surfaced) != 2 || surfaced[0] != "one" || surfaced[1] != "two" {
+		t.Fatalf("hook should receive both steers in order, got %v", surfaced)
+	}
+	if got := ag.drainPending(); len(got) != 0 {
+		t.Fatalf("orphaned steers must be drained, got %+v", got)
 	}
 }

--- a/internal/agent/busysteer_test.go
+++ b/internal/agent/busysteer_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/context-labs/whip/internal/llm"
+)
+
+// In-flight counts rise while a tool runs and drain when it finishes. Driving
+// a registry emitter directly keeps the window deterministic (an httptest
+// tool call returns too fast to observe).
+func TestInFlightToolsTracking(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag.trackTool("read", 1)
+	ag.trackTool("read", 1)
+	ag.trackTool("bash", 1)
+	if got := ag.InFlightTools(); len(got) != 2 {
+		t.Fatalf("in-flight names = %v, want 2 distinct tools", got)
+	}
+	ag.trackTool("read", -2)
+	if got := ag.InFlightTools(); len(got) != 1 || got[0] != "bash" {
+		t.Fatalf("after reads finish, in-flight = %v, want [bash]", got)
+	}
+	ag.trackTool("bash", -1)
+	if got := ag.InFlightTools(); len(got) != 0 {
+		t.Fatalf("in-flight set should drain, got %v", got)
+	}
+}
+
+// WaitingOnSubagents is true only while a turn runs AND every in-flight tool
+// is a subagent; a bash in flight flips it false.
+func TestWaitingOnSubagentsGating(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+
+	if ag.WaitingOnSubagents() {
+		t.Fatal("no turn running → not waiting")
+	}
+	ag.running.Store(true)
+	if ag.WaitingOnSubagents() {
+		t.Fatal("turn running but nothing in flight → mid-generation, not waiting")
+	}
+	ag.trackTool("subagent", 1)
+	if !ag.WaitingOnSubagents() {
+		t.Fatal("only a subagent in flight → waiting")
+	}
+	ag.trackTool("subagent", 1) // two subagents still qualifies
+	if !ag.WaitingOnSubagents() {
+		t.Fatal("multiple subagents in flight → waiting")
+	}
+	ag.trackTool("bash", 1)
+	if ag.WaitingOnSubagents() {
+		t.Fatal("a bash in flight → not waiting on subagents")
+	}
+	ag.trackTool("bash", -1)
+	ag.trackTool("subagent", -2)
+	if ag.WaitingOnSubagents() {
+		t.Fatal("all tools finished → not waiting")
+	}
+}
+
+// End-to-end: during a real turn blocked on a foreground subagent, the parent
+// reports WaitingOnSubagents; once the subagent's report lands and the turn
+// continues, it flips false. The subagent's HTTP call blocks on a latch so the
+// window is deterministic.
+func TestWaitingOnSubagentsDuringForegroundSubagent(t *testing.T) {
+	release := make(chan struct{})
+	subStarted := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch {
+		case len(req.Messages) > 0 && strings.HasPrefix(req.Messages[0].Content, "You are a subagent"):
+			close(subStarted)
+			<-release // hold the subagent's turn until the test has observed the parent
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"sub report"},"finish_reason":"stop"}]}`+"\n\n")
+		case len(req.Messages) > 0 && req.Messages[len(req.Messages)-1].Role == "user" && req.Messages[len(req.Messages)-1].Content == "go":
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"subagent","arguments":"{\"prompt\":\"explore\"}"}}]}}]}`+"\n\n")
+			fmt.Fprint(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n")
+		default:
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"parent done"},"finish_reason":"stop"}]}`+"\n\n")
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	done := make(chan error, 1)
+	go func() {
+		_, err := ag.Turn(t.Context(), "go", Events{})
+		done <- err
+	}()
+
+	select {
+	case <-subStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("subagent never started")
+	}
+	if !ag.WaitingOnSubagents() {
+		t.Fatal("parent blocked on a foreground subagent must report WaitingOnSubagents")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if ag.WaitingOnSubagents() {
+		t.Fatal("turn finished → no longer waiting")
+	}
+}

--- a/internal/agent/busysteer_test.go
+++ b/internal/agent/busysteer_test.go
@@ -139,3 +139,27 @@ func TestDrainOrphanedSteers(t *testing.T) {
 		t.Fatalf("orphaned steers must be drained, got %+v", got)
 	}
 }
+
+// A Steer landing while NO turn is running (the caller raced a teardown: it
+// saw WaitingOnSubagents true, then the turn ended before Steer executed)
+// must not park in pending forever — with the hook installed it fires
+// immediately; without one it parks for a later drain (headless contract).
+func TestSteerOnIdleAgentFiresOrphanHook(t *testing.T) {
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+
+	// No hook: parked, not lost, not fired.
+	ag.Steer("parked")
+	if got := ag.drainPending(); len(got) != 1 {
+		t.Fatalf("no hook: steer should park, got %+v", got)
+	}
+
+	var fired []string
+	ag.OnOrphanedSteer = func(text string) { fired = append(fired, text) }
+	ag.Steer("late arrival")
+	if len(fired) != 1 || fired[0] != "late arrival" {
+		t.Fatalf("idle steer should fire the hook, got %v", fired)
+	}
+	if got := ag.drainPending(); len(got) != 0 {
+		t.Fatalf("fired steer must not also park, got %+v", got)
+	}
+}

--- a/internal/tui/queue_test.go
+++ b/internal/tui/queue_test.go
@@ -408,3 +408,37 @@ func TestBusyPlaceholderReflectsRouting(t *testing.T) {
 		t.Fatalf("idle placeholder should restore the default, got %q", m.input.Placeholder)
 	}
 }
+
+// TestOrphanSteerSubmitsMachineTurn proves the wait-tool teardown seam: a
+// steer orphaned at a turn's final boundary surfaces through OnOrphanedSteer
+// → orphanSteerMsg → a fresh machine turn carrying the steered text. While a
+// turn is busy the message is deferred instead of racing it.
+func TestOrphanSteerSubmitsMachineTurn(t *testing.T) {
+	m := busyQueueModel()
+	m.busy = false // the orphan wake fires after the turn ended
+	m.agent.Client = stubLLM()
+	m.agent.Messages = []llm.Message{{Role: "system", Content: "sys"}}
+
+	tm, _ := m.Update(orphanSteerMsg("steer me home"))
+	m = tm.(*model)
+
+	if !m.busy {
+		t.Fatal("the orphaned steer should submit as a new turn (busy)")
+	}
+	if !hasUserMsg(t, m, "steer me home") {
+		t.Fatalf("the orphaned steer should reach the model, got %+v", m.agent.Messages)
+	}
+}
+
+// While a turn is busy, an orphanSteerMsg must not submit over it — the
+// agent's own drain at loop boundaries will pick the steer up.
+func TestOrphanSteerDeferredWhileBusy(t *testing.T) {
+	m := busyQueueModel()
+
+	tm, _ := m.Update(orphanSteerMsg("wait your turn"))
+	m = tm.(*model)
+
+	if len(m.agent.Messages) != 0 {
+		t.Fatalf("busy: nothing should submit, got %+v", m.agent.Messages)
+	}
+}

--- a/internal/tui/queue_test.go
+++ b/internal/tui/queue_test.go
@@ -393,3 +393,18 @@ func TestQueueRendersOneLineEach(t *testing.T) {
 		}
 	}
 }
+
+// The input placeholder reflects the busy routing: while busy with ordinary
+// tools the hint says "queue"; a turn blocked only on subagents says "steer".
+func TestBusyPlaceholderReflectsRouting(t *testing.T) {
+	m := busyQueueModel()
+	m.syncInputPlaceholder()
+	if !strings.Contains(m.input.Placeholder, "queue") {
+		t.Fatalf("busy (not waiting on subagents) placeholder = %q", m.input.Placeholder)
+	}
+	m.busy = false
+	m.syncInputPlaceholder()
+	if !strings.HasPrefix(m.input.Placeholder, "Ask whip") {
+		t.Fatalf("idle placeholder should restore the default, got %q", m.input.Placeholder)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -87,15 +87,15 @@ type turnDoneMsg struct {
 	clean bool   // the turn left the tree clean — snap is worthless, drop it
 }
 type (
-	catalogsMsg   map[string]config.Catalog // background /models fetch result
-	noticeMsg     string                    // dim one-liner appended to the transcript
-	usageMsg      llm.Usage                 // one request's token usage
-	quitArmMsg    struct{}                  // the idle ctrl+c arm window expired
-	taskUpdateMsg struct{}                  // a background subagent started/settled — redraw
-	orphanSteerMsg string                   // a steer orphaned at turn teardown — submit as a machine turn
-	mcpStatusMsg  struct{}                  // an MCP server changed state — redraw
-	thinkMsg      string                    // streamed reasoning tokens
-	imageMsg      struct {                  // ctrl+v clipboard image result
+	catalogsMsg    map[string]config.Catalog // background /models fetch result
+	noticeMsg      string                    // dim one-liner appended to the transcript
+	usageMsg       llm.Usage                 // one request's token usage
+	quitArmMsg     struct{}                  // the idle ctrl+c arm window expired
+	taskUpdateMsg  struct{}                  // a background subagent started/settled — redraw
+	orphanSteerMsg string                    // a steer orphaned at turn teardown — submit as a machine turn
+	mcpStatusMsg   struct{}                  // an MCP server changed state — redraw
+	thinkMsg       string                    // streamed reasoning tokens
+	imageMsg       struct {                  // ctrl+v clipboard image result
 		path string // clipboard image saved to disk
 		err  error
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2586,6 +2586,17 @@ func (m *model) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.input.Reset()
 				m.menu = nil
 				m.runShell(text)
+			case text != "" && m.agent.WaitingOnSubagents():
+				// The turn is blocked only on subagents — steer the message in
+				// as a mid-turn correction instead of queueing it behind the
+				// whole turn (it isn't an interruption if the agent is just
+				// waiting). Echo it like a steered background-task report.
+				m.hist = append(m.hist, text)
+				m.histIdx = len(m.hist)
+				m.input.Reset()
+				m.menu = nil
+				m.agent.Steer(text)
+				m.append(youStyle.Render("❯ ") + linkifyFilePaths(text, realFileExists) + dimStyle.Render("  (steered)"))
 			case text != "": // codex-style: queue it (multiple allowed)
 				m.queue = append(m.queue, text)
 				m.hist = append(m.hist, text)
@@ -3829,6 +3840,7 @@ func (m *model) currentView() string {
 // viewTop = min(viewTop, height - viewH). A resize resets the sentinel
 // (WindowSizeMsg handler) and the next render re-anchors to the bottom.
 func (m *model) View() string {
+	m.syncInputPlaceholder()
 	v := m.viewBody()
 	if m.height > 0 {
 		m.viewH = lipgloss.Height(v)
@@ -3968,6 +3980,24 @@ func (m *model) viewBody() string {
 	}
 	b.WriteString("\n\n" + m.statusView()) // persistent status line, with a blank line above
 	return b.String()
+}
+
+// syncInputPlaceholder reflects the busy state into the input's placeholder:
+// while a turn runs, typing either steers into it (when the agent is only
+// waiting on subagents) or queues behind it. Called from View so it tracks
+// the state every render. headless-safe.
+func (m *model) syncInputPlaceholder() {
+	if m.input.Value() != "" {
+		return // placeholder is hidden once the user is typing
+	}
+	switch {
+	case !m.busy:
+		m.input.Placeholder = "Ask whip anything… (/ for commands, tab completes)"
+	case m.agent != nil && m.agent.WaitingOnSubagents():
+		m.input.Placeholder = "waiting on subagents — type to steer this turn"
+	default:
+		m.input.Placeholder = "busy — type to queue (sent when the turn ends)"
+	}
 }
 
 // statusView renders the always-on status line below the input: current

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -239,7 +239,7 @@ type picker struct {
 // Newlines come from ctrl+j / shift+enter / alt+enter; plain enter submits.
 func newInput() textarea.Model {
 	ti := textarea.New()
-	ti.Placeholder = "Ask whip anything… (/ for commands, tab completes)"
+	ti.Placeholder = inputPlaceholder
 	ti.Prompt = "┃ "
 	ti.SetHeight(1)
 	ti.MaxHeight = 24 // input grows with content up to this many lines
@@ -3999,6 +3999,10 @@ func (m *model) viewBody() string {
 	return b.String()
 }
 
+// inputPlaceholder is the idle input hint; syncInputPlaceholder re-uses it
+// when the busy state clears so the two sites never drift.
+const inputPlaceholder = "Ask whip anything… (/ for commands, tab completes)"
+
 // syncInputPlaceholder reflects the busy state into the input's placeholder:
 // while a turn runs, typing either steers into it (when the agent is only
 // waiting on subagents) or queues behind it. Called from View so it tracks
@@ -4009,7 +4013,7 @@ func (m *model) syncInputPlaceholder() {
 	}
 	switch {
 	case !m.busy:
-		m.input.Placeholder = "Ask whip anything… (/ for commands, tab completes)"
+		m.input.Placeholder = inputPlaceholder
 	case m.agent != nil && m.agent.WaitingOnSubagents():
 		m.input.Placeholder = "waiting on subagents — type to steer this turn"
 	default:

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -92,6 +92,7 @@ type (
 	usageMsg      llm.Usage                 // one request's token usage
 	quitArmMsg    struct{}                  // the idle ctrl+c arm window expired
 	taskUpdateMsg struct{}                  // a background subagent started/settled — redraw
+	orphanSteerMsg string                   // a steer orphaned at turn teardown — submit as a machine turn
 	mcpStatusMsg  struct{}                  // an MCP server changed state — redraw
 	thinkMsg      string                    // streamed reasoning tokens
 	imageMsg      struct {                  // ctrl+v clipboard image result
@@ -2109,6 +2110,17 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case orphanSteerMsg:
+		// A user steer arrived after the drain snapshot at turn teardown and
+		// was orphaned when the wait wake fired. The agent can't message the
+		// TUI itself (same seam as waitWakeFunc) — it surfaced the steer
+		// through OnOrphanedSteer; run it as a machine turn so the steer is
+		// never lost.
+		if !m.busy {
+			return m.submitTurn(string(msg), true)
+		}
+		return m, nil
+
 	case mcpStatusMsg:
 		// An MCP server changed state. Announce each server's FIRST settle in
 		// the transcript (one line, once per session per server) so arrivals
@@ -2832,6 +2844,11 @@ func (m *model) wireTasks() {
 	m.agent.SetSessionID(m.sessionID)
 	if m.prog == nil {
 		return // headless (tests)
+	}
+	m.agent.OnOrphanedSteer = func(text string) {
+		// Detached: runs on the wait-poller goroutine; a backed-up UI queue
+		// must never stall the agent (same posture as OnChange below).
+		go m.prog.Send(orphanSteerMsg(text))
 	}
 	m.agent.Tasks().OnChange = func(*agent.BackgroundTask) {
 		// Detached: OnChange runs on the subagent worker goroutine, and a


### PR DESCRIPTION
## Item 4 of the Agent UX batch ([plan](.ai-docs/plans/agent-ux-batch/PLAN.md))

**Problem:** while the main agent is blocked on foreground subagents, typed input queued behind the whole turn — but waiting on a subagent isn't real work the message would interrupt, so the queue's semantics were wrong for it.

**Change:** when a turn's only in-flight tool calls are subagents (`Agent.WaitingOnSubagents()`), typed input routes to `Agent.Steer` — it reaches the model at the next loop boundary as a mid-turn correction. Any other in-flight tool (bash, edit) keeps the queue path.

- The agent tracks in-flight tool names in `runTools` (a `sync.Map` of per-name `atomic` counters, incremented after the mutation lock is acquired so the 'running' row is honest).
- The input placeholder reflects the routing live (`syncInputPlaceholder`, consulted in `View`): `waiting on subagents — type to steer this turn` vs `busy — type to queue`.
- This branch adds `TurnRunning` + the `running` flag, identical to the wait-tool PR #58, so the merge reconciles.

## Tests

`internal/agent/busysteer_test.go` — `TestInFlightToolsTracking`, `TestWaitingOnSubagentsGating`, and `TestWaitingOnSubagentsDuringForegroundSubagent` (a real turn blocked on a live foreground subagent reports waiting, then flips false). `internal/tui/queue_test.go` — `TestBusyPlaceholderReflectsRouting`. `task check` green; `go test -race ./internal/agent` green; `golangci-lint` clean.