### PR TITLE
feat(agent,session,tui): persist subagent transcripts with attribution

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -147,6 +147,20 @@ as a **steered message**, so the model sees it on the next loop boundary.
   The dock itself shows running tasks plus ones settled within a one-minute
   grace window (`dockSettledGrace`) — long enough to notice the ✓, then the
   strip cleans itself.
+- **Full transcript persisted.** When a background subagent settles, its whole
+  conversation is saved as its own attributed session
+  (`Store.SaveSubagentTranscript`, id `task-<parentID>-<taskID>` — the
+  `task-` prefix avoids a prefix-collision with the parent id in `Load`),
+  with `forked_from` = the parent session and `task_id` = the task. A
+  follow-up turn on the settled subagent re-saves the transcript
+  (`refreshTranscript` after `FollowupTask`). On resume, opening a restored
+  task replays the persisted transcript read-only (`renderTranscript`) instead
+  of showing only the bare report — a crashed process no longer loses the
+  completed work. Tests: `session_test.go`
+  `TestSubagentTranscriptRoundTrip` (attribution + follow-up re-save + no-op
+  without a parent), `tasks_test.go`
+  `TestRestoredTaskReplaysPersistedTranscript` (kill → resume → open shows the
+  full transcript).
 
 Background tasks use a context **not** tied to the current turn — they outlive
 it by design. Cancelling a task cancels its subagent's turn. `settle()`

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/context-labs/whip/internal/llm"
 )
 
 // TaskStatus is the lifecycle of a background subagent.
@@ -47,6 +49,13 @@ type BackgroundTask struct {
 	// context. nil on restored tasks (their process died). Set before the
 	// task is published, never reassigned — snapshots copy the pointer safely.
 	sub *Agent
+
+	// SubMessages is the subagent's full conversation, snapshotted at settle
+	// for persistence (the TUI's OnRecord saves it as an attributed session).
+	// A copy, not a live alias — FollowupTask keeps appending to sub.Messages
+	// after settle, and a shared slice would let a follow-up mutate an
+	// already-saved snapshot. nil while running and on restored tasks.
+	SubMessages []llm.Message
 }
 
 // taskRegistry tracks background subagents for one parent agent. It is the
@@ -271,6 +280,9 @@ func (a *Agent) StartBackground(description, prompt string, o SubModel) *Backgro
 		case err != nil:
 			status, text = TaskError, err.Error()
 		}
+		// Snapshot the transcript BEFORE settle: settle fires OnRecord (which
+		// persists SubMessages), so it must be populated first.
+		t.SubMessages = t.sub.MessagesSnapshot()
 		a.bg.settle(id, status, text)
 		// subscribers stop here; late events after settle go nowhere (Subscribe
 		// rejects non-running tasks, and settled state is visible via List/Get)
@@ -283,6 +295,23 @@ func (a *Agent) StartBackground(description, prompt string, o SubModel) *Backgro
 		a.Steer(fmt.Sprintf("[subagent %s %s] %s\n\n%s", id, status, description, text))
 	}()
 	return t
+}
+
+// refreshTranscript re-snapshots a settled task's SubMessages after a
+// follow-up turn grew the sub's conversation, then re-fires OnRecord so the
+// persisted transcript stays current. A follow-up turn is the only thing that
+// mutates a settled task's messages, so this is the only refresh path.
+func (r *taskRegistry) refreshTranscript(id string, sub *Agent) {
+	r.mu.Lock()
+	t, ok := r.tasks[id]
+	if ok {
+		t.SubMessages = sub.MessagesSnapshot()
+	}
+	r.mu.Unlock()
+	if !ok || r.OnRecord == nil {
+		return
+	}
+	r.OnRecord(r.recordSession(), t)
 }
 
 // Subscribe registers a live event subscriber for a running task. Returns

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -56,6 +56,13 @@ type BackgroundTask struct {
 	// after settle, and a shared slice would let a follow-up mutate an
 	// already-saved snapshot. nil while running and on restored tasks.
 	SubMessages []llm.Message
+
+	// SubModel names the route the subagent actually ran on, for transcript
+	// attribution — the sub often runs a DIFFERENT model than the parent
+	// (TaskDefault or a per-task override), so persisting the parent's model
+	// would mislabel the transcript. Captured at StartBackground from the
+	// resolved sub, before any turn runs.
+	SubModel string
 }
 
 // taskRegistry tracks background subagents for one parent agent. It is the
@@ -254,11 +261,19 @@ func (a *Agent) StartBackground(description, prompt string, o SubModel) *Backgro
 	}
 	id := taskSlug(description, taskIDCounter.Add(1))
 	taskCtx, cancel := context.WithCancel(context.Background())
+	sub := a.newSub(o)
 	t := &BackgroundTask{
 		ID: id, Description: description, Prompt: prompt,
 		Status: TaskRunning, StartedAt: time.Now(),
 		Done: make(chan struct{}), cancel: cancel,
-		sub: a.newSub(o),
+		sub: sub,
+		// Attribute the transcript to the route the sub actually runs on.
+		// sub.Model is the resolved API id (TaskDefault → per-task override →
+		// parent's, per newSub's precedence) — often NOT the parent's model,
+		// so persisting the parent's model/provider would mislabel it. The
+		// provider isn't recoverable here (SubModel carries only client+API
+		// id), so it's left for the caller to keep blank.
+		SubModel: sub.Model,
 	}
 	a.bg.mu.Lock()
 	a.bg.tasks[id] = t

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -211,5 +211,9 @@ func (a *Agent) FollowupTask(ctx context.Context, id, text string, ev Events) (s
 	if t.sub == nil {
 		return "", fmt.Errorf("subagent %s is not live (restored from a previous session)", id)
 	}
-	return t.sub.Turn(ctx, text, FanIn(ev, Events{OnUsage: a.AddUsage}))
+	out, err := t.sub.Turn(ctx, text, FanIn(ev, Events{OnUsage: a.AddUsage}))
+	// The follow-up grew the sub's conversation; refresh the persisted
+	// transcript so a resume sees it (no-op without a store).
+	r.refreshTranscript(id, t.sub)
+	return out, err
 }

--- a/internal/agent/subagent_test.go
+++ b/internal/agent/subagent_test.go
@@ -82,3 +82,38 @@ func TestStartBackgroundSlugID(t *testing.T) {
 		t.Fatalf("task id should be a description slug, got %q", task.ID)
 	}
 }
+
+// StartBackground attributes the transcript to the SUBAGENT's model, not the
+// parent's: a TaskDefault or per-task override routes the sub to a different
+// model, and t.SubModel must record that resolved id so the persisted
+// transcript isn't mislabeled with the parent's model.
+func TestStartBackgroundCapturesSubModel(t *testing.T) {
+	srv, _ := modelRecorder(t, "ok")
+	defer srv.Close()
+
+	// Parent on "parent-m"; TaskDefault routes subs to "sub-default-m".
+	parent := New(llm.New(srv.URL, "k"), "parent-m", 100, "sys")
+	parent.TaskDefault = SubModel{Client: llm.New(srv.URL, "k"), Model: "sub-default-m"}
+
+	// Default route → the sub runs the TaskDefault model.
+	def := parent.StartBackground("uses default", "p", SubModel{})
+	<-def.Done
+	if def.SubModel != "sub-default-m" {
+		t.Fatalf("default route: SubModel = %q, want sub-default-m", def.SubModel)
+	}
+
+	// Per-task override → the sub runs the override model.
+	ov := parent.StartBackground("uses override", "p", SubModel{Client: llm.New(srv.URL, "k"), Model: "sub-override-m"})
+	<-ov.Done
+	if ov.SubModel != "sub-override-m" {
+		t.Fatalf("override route: SubModel = %q, want sub-override-m", ov.SubModel)
+	}
+
+	// No TaskDefault and no override → falls through to the parent's model.
+	bare := New(llm.New(srv.URL, "k"), "parent-m", 100, "sys")
+	own := bare.StartBackground("uses parent", "p", SubModel{})
+	<-own.Done
+	if own.SubModel != "parent-m" {
+		t.Fatalf("parent route: SubModel = %q, want parent-m", own.SubModel)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -272,17 +272,25 @@ func (s *Store) SaveSubagentTranscript(parentID, taskID string, msgs []llm.Messa
 	if err := s.Save(id, 0, msgs, model, provider); err != nil {
 		return "", err
 	}
+	// Re-save rewrites rows [0, len(msgs)); a follow-up turn that compacted
+	// the transcript writes FEWER rows than last time, and Save's per-seq
+	// INSERT OR REPLACE never touches the tail — without this sweep the stale
+	// rows at seq >= len(msgs) linger and reload as phantom trailing messages.
+	if _, err := s.db.ExecContext(context.Background(), `DELETE FROM messages WHERE session_id=? AND seq>=?`, id, len(msgs)); err != nil {
+		return "", err
+	}
 	return id, nil
 }
 
 // SubagentTranscript loads a subagent's persisted conversation by parent +
-// task id ("" when never persisted).
+// task id ("" when never persisted). Loads by exact id (loadMessages), not
+// Load's prefix scan: sibling task ids can share a stem, which would make the
+// prefix form ambiguous.
 func (s *Store) SubagentTranscript(parentID, taskID string) ([]llm.Message, error) {
-	_, msgs, err := s.Load(subagentSessionID(parentID, taskID))
-	if err != nil {
-		return nil, err
+	if parentID == "" || taskID == "" {
+		return nil, nil
 	}
-	return msgs, nil
+	return s.loadMessages(subagentSessionID(parentID, taskID))
 }
 
 // subagentSessionID builds the attributed session id for a subagent's
@@ -359,30 +367,43 @@ func (s *Store) Load(idOrPrefix string) (Meta, []llm.Message, error) {
 		return Meta{}, nil, fmt.Errorf("session id %q is ambiguous", idOrPrefix)
 	}
 	meta := metas[0]
+	msgs, err := s.loadMessages(meta.ID)
+	if err != nil {
+		return Meta{}, nil, err
+	}
+	return meta, msgs, nil
+}
 
+// loadMessages reads one session's full message log by EXACT id — the read
+// half of Load once the meta row is known. Split out so subagent transcripts
+// (whose ids are built deterministic by subagentSessionID, never typed by the
+// user) load by exact match instead of Load's prefix scan: a prefix query
+// over transcript ids goes "ambiguous" the moment two sibling task ids share
+// a stem (task-<parent>-foo-1 vs task-<parent>-foo-12).
+func (s *Store) loadMessages(id string) ([]llm.Message, error) {
 	// pre-size the slice: a long session is hundreds of rows; the COUNT is
 	// one index scan and avoids O(log n) reallocs while scanning
 	var count int
-	_ = s.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM messages WHERE session_id=?`, meta.ID).Scan(&count)
+	_ = s.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM messages WHERE session_id=?`, id).Scan(&count)
 
-	mrows, err := s.db.QueryContext(context.Background(), `SELECT content FROM messages WHERE session_id=? ORDER BY seq`, meta.ID)
+	mrows, err := s.db.QueryContext(context.Background(), `SELECT content FROM messages WHERE session_id=? ORDER BY seq`, id)
 	if err != nil {
-		return Meta{}, nil, err
+		return nil, err
 	}
 	defer func() { _ = mrows.Close() }()
 	msgs := make([]llm.Message, 0, count)
 	for mrows.Next() {
 		var data string
 		if err := mrows.Scan(&data); err != nil {
-			return Meta{}, nil, err
+			return nil, err
 		}
 		var m llm.Message
 		if err := json.Unmarshal([]byte(data), &m); err != nil {
-			return Meta{}, nil, err
+			return nil, err
 		}
 		msgs = append(msgs, m)
 	}
-	return meta, answerDanglingToolCalls(applyCompaction(s.db, meta.ID, msgs)), mrows.Err()
+	return answerDanglingToolCalls(applyCompaction(s.db, id, msgs)), mrows.Err()
 }
 
 // applyCompaction derives the compacted view from the raw log: the latest

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -98,6 +98,7 @@ var extraColumns = []struct{ name, def string }{
 	{"usage_cached", "usage_cached INTEGER NOT NULL DEFAULT 0"}, // of usage_in, tokens served from the prompt cache
 	{"usage_out", "usage_out INTEGER NOT NULL DEFAULT 0"},       // cumulative output tokens
 	{"todos", "todos TEXT NOT NULL DEFAULT ''"},                 // todowrite plan JSON ([]agent.Todo)
+	{"task_id", "task_id TEXT NOT NULL DEFAULT ''"},             // non-empty = this session is a subagent's transcript; the value is the task id
 }
 
 // Meta is a session's bookkeeping row.
@@ -117,6 +118,10 @@ type Meta struct {
 	UsageCached int      // of UsageIn, tokens served from the provider's prompt cache
 	UsageOut    int      // cumulative output tokens
 	UpdatedAt   time.Time
+	// TaskID is non-empty when this session is a subagent's persisted
+	// transcript (the value is the task id, e.g. "survey-context-3"); the
+	// parent session id is ForkedFrom. Empty for ordinary sessions.
+	TaskID string
 }
 
 type Store struct{ db *sql.DB }
@@ -245,6 +250,49 @@ func (s *Store) Close() error { return s.db.Close() }
 
 func now() string { return time.Now().UTC().Format(time.RFC3339) }
 
+// SaveSubagentTranscript persists a background subagent's conversation as its
+// own attributed session row: id "task-<parentID>-<taskID>" (prefixed so it
+// never prefix-collides with the parent session's id in Load), forked_from
+// set to the parent session, task_id set to the task. Idempotent — re-saving
+// after a follow-up turn replaces the same row and rewrites the messages from
+// seq 0. Returns the session id, or "" when there's no parent to attribute to
+// (a headless run with no store never calls this).
+func (s *Store) SaveSubagentTranscript(parentID, taskID string, msgs []llm.Message, model, provider string) (string, error) {
+	if parentID == "" || taskID == "" {
+		return "", nil
+	}
+	id := subagentSessionID(parentID, taskID)
+	if _, err := s.db.ExecContext(context.Background(), `INSERT INTO sessions
+		(id, created_at, updated_at, cwd, model, provider, title, forked_from, task_id)
+		VALUES (?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET updated_at=excluded.updated_at, model=excluded.model, provider=excluded.provider`,
+		id, now(), now(), "", model, provider, "subagent "+taskID, parentID, taskID); err != nil {
+		return "", err
+	}
+	if err := s.Save(id, 0, msgs, model, provider); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// SubagentTranscript loads a subagent's persisted conversation by parent +
+// task id ("" when never persisted).
+func (s *Store) SubagentTranscript(parentID, taskID string) ([]llm.Message, error) {
+	_, msgs, err := s.Load(subagentSessionID(parentID, taskID))
+	if err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+// subagentSessionID builds the attributed session id for a subagent's
+// transcript. The "task-" prefix guarantees it can't prefix-collide with the
+// parent session's hex id in Load's prefix match (a plain "<parent>/…" suffix
+// form would make resume(parentID) ambiguous).
+func subagentSessionID(parentID, taskID string) string {
+	return "task-" + parentID + "-" + taskID
+}
+
 // Create inserts a new session and returns its id.
 func (s *Store) Create(cwd, model, provider string) (string, error) {
 	b := make([]byte, 4)
@@ -295,7 +343,7 @@ func (s *Store) Save(id string, from int, msgs []llm.Message, model, provider st
 
 // Load resolves idOrPrefix to a session and returns its metadata and messages.
 func (s *Store) Load(idOrPrefix string) (Meta, []llm.Message, error) {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, updated_at FROM sessions WHERE id LIKE ?||'%' LIMIT 3`, idOrPrefix)
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, updated_at FROM sessions WHERE id LIKE ?||'%' LIMIT 3`, idOrPrefix)
 	if err != nil {
 		return Meta{}, nil, err
 	}
@@ -424,7 +472,7 @@ func answerDanglingToolCalls(msgs []llm.Message) []llm.Message {
 
 // Recent returns up to n sessions, newest first.
 func (s *Store) Recent(n int) ([]Meta, error) {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, updated_at FROM sessions
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, updated_at FROM sessions
 		WHERE EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)
 		ORDER BY updated_at DESC LIMIT ?`, n)
 	if err != nil {
@@ -738,7 +786,7 @@ func (s *Store) SetPinned(id string, pinned bool) error {
 // ForksOf lists sessions forked from id, newest first — the session tree's
 // children of one node.
 func (s *Store) ForksOf(id string) ([]Meta, error) {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, updated_at
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, updated_at
 		FROM sessions WHERE forked_from=? ORDER BY updated_at DESC`, id)
 	if err != nil {
 		return nil, err
@@ -802,7 +850,7 @@ func scanMetas(rows *sql.Rows) ([]Meta, error) {
 		var pinned int
 		if err := rows.Scan(&m.ID, &m.Title, &m.Model, &m.Provider, &m.CWD, &m.Goal,
 			&m.ForkedFrom, &m.ForkSeq, &tags, &pinned, &m.Effort,
-			&m.UsageIn, &m.UsageCached, &m.UsageOut, &updated); err != nil {
+			&m.UsageIn, &m.UsageCached, &m.UsageOut, &m.TaskID, &updated); err != nil {
 			return nil, err
 		}
 		if tags != "" {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -647,3 +647,56 @@ func TestScheduleRoundTrip(t *testing.T) {
 		t.Fatalf("after delete: %+v", scs)
 	}
 }
+
+// A subagent transcript round-trips as an attributed session row: id
+// <parent>/task/<task>, forked_from the parent, task_id set, messages intact.
+// Re-saving after a follow-up turn replaces the same row (no duplicate).
+func TestSubagentTranscriptRoundTrip(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	parent, err := st.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := []llm.Message{
+		{Role: "system", Content: "sub sys"},
+		{Role: "user", Content: "explore the codebase"},
+		{Role: "assistant", Content: "found 3 things"},
+	}
+	id, err := st.SaveSubagentTranscript(parent, "probe-1", msgs, "sub-m", "sub-p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "task-"+parent+"-probe-1" {
+		t.Fatalf("id = %q", id)
+	}
+	meta, got, err := st.Load(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.TaskID != "probe-1" || meta.ForkedFrom != parent {
+		t.Fatalf("attribution: taskID=%q forkedFrom=%q", meta.TaskID, meta.ForkedFrom)
+	}
+	if len(got) != 3 || got[1].Content != "explore the codebase" || got[2].Content != "found 3 things" {
+		t.Fatalf("transcript round-trip: %+v", got)
+	}
+
+	// Follow-up turn appends; re-save replaces the row, no duplicate session.
+	msgs = append(msgs, llm.Message{Role: "user", Content: "follow up"}, llm.Message{Role: "assistant", Content: "answered"})
+	if _, err := st.SaveSubagentTranscript(parent, "probe-1", msgs, "sub-m", "sub-p"); err != nil {
+		t.Fatal(err)
+	}
+	_, got, err = st.Load(id)
+	if err != nil || len(got) != 5 {
+		t.Fatalf("after follow-up: %d msgs, err %v", len(got), err)
+	}
+
+	// No parent / no task id → no-op ("" id, no error).
+	if id, err := st.SaveSubagentTranscript("", "t", msgs, "m", "p"); id != "" || err != nil {
+		t.Fatalf("empty parent should no-op: id=%q err=%v", id, err)
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -700,3 +700,112 @@ func TestSubagentTranscriptRoundTrip(t *testing.T) {
 		t.Fatalf("empty parent should no-op: id=%q err=%v", id, err)
 	}
 }
+
+// SubagentTranscript loads by EXACT id, not Load's prefix scan: two sibling
+// task ids that share a stem (foo-1 vs foo-12) would make the prefix form
+// return "ambiguous", so the transcript lookup must bypass it.
+func TestSubagentTranscriptExactIDNoPrefixCollision(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	parent, err := st.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Two sibling tasks whose ids share a stem: task-<parent>-foo-1 and
+	// task-<parent>-foo-12. Loading "-foo-1" by prefix would also match
+	// "-foo-12" and fail "ambiguous".
+	mk := []llm.Message{{Role: "user", Content: "one"}}
+	if _, err := st.SaveSubagentTranscript(parent, "foo-1", mk, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.SaveSubagentTranscript(parent, "foo-12", mk, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The exact-id lookup must succeed where the prefix form would be ambiguous.
+	got, err := st.SubagentTranscript(parent, "foo-1")
+	if err != nil {
+		t.Fatalf("exact-id transcript load: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != "one" {
+		t.Fatalf("wrong transcript: %+v", got)
+	}
+	// And a nonexistent task yields empty, not an error.
+	if got, err := st.SubagentTranscript(parent, "nope-9"); err != nil || len(got) != 0 {
+		t.Fatalf("missing transcript should be empty, got %d msgs err %v", len(got), err)
+	}
+}
+
+// A follow-up turn that compacts the transcript writes FEWER messages than
+// the first save; the re-save must delete the stale rows past the new tail,
+// not leave them to reload as phantom trailing messages.
+func TestSubagentTranscriptResaveDeletesOrphanRows(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	parent, err := st.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	long := []llm.Message{
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "u2"},
+		{Role: "assistant", Content: "a2"},
+		{Role: "user", Content: "u3"},
+		{Role: "assistant", Content: "a3"},
+	}
+	if _, err := st.SaveSubagentTranscript(parent, "t-1", long, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	// Re-save a shorter transcript (post-compaction): 2 messages.
+	short := []llm.Message{
+		{Role: "system", Content: "Summary of the conversation so far: ..."},
+		{Role: "assistant", Content: "a3"},
+	}
+	if _, err := st.SaveSubagentTranscript(parent, "t-1", short, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.SubagentTranscript(parent, "t-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(short) {
+		t.Fatalf("orphan rows survived: %d msgs, want %d (%+v)", len(got), len(short), got)
+	}
+}
+
+// The transcript records the SUBAGENT's model, not the parent's — the settle
+// path passes t.SubModel, so the saved session row attributes the work to the
+// model that actually produced it.
+func TestSubagentTranscriptAttributesSubModel(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	parent, err := st.Create("/tmp", "parent-model", "parent-prov")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := st.SaveSubagentTranscript(parent, "t-1",
+		[]llm.Message{{Role: "user", Content: "x"}}, "sub-model-id", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, _, err := st.Load(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Model != "sub-model-id" {
+		t.Fatalf("transcript should attribute the sub's model, got %q", meta.Model)
+	}
+}

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -24,6 +24,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/context-labs/whip/internal/agent"
+	"github.com/context-labs/whip/internal/llm"
 )
 
 // taskEventMsg is one live event from an opened background task (OnText /
@@ -195,11 +196,48 @@ func (m *model) openTask(id string) {
 				sendTaskMsg(p, taskEventMsg{id: id, kind: 3, s: s})
 			},
 		})
+	} else if t.Restored && m.store != nil {
+		// A restored task's subagent died with the last process, so there's no
+		// live stream and no retained context — but its transcript persisted.
+		// Replay it read-only so the view shows the completed work, not just
+		// the bare report.
+		if msgs, err := m.store.SubagentTranscript(m.sessionID, t.ID); err == nil && len(msgs) > 0 {
+			renderTranscript(&tv.buf, msgs)
+		} else {
+			fmt.Fprintf(&tv.buf, "\n%s %s\n", toolStyle.Render(string(t.Status)+":"), t.Report)
+		}
 	} else {
 		fmt.Fprintf(&tv.buf, "\n%s %s\n", toolStyle.Render(string(t.Status)+":"), t.Report)
 	}
 	m.taskVP = tv
 	m.refreshTaskVP()
+}
+
+// renderTranscript writes a persisted conversation as role-labeled blocks for
+// the restored-task detail view (read-only history). Tool calls show as their
+// name; the system prompt is skipped.
+func renderTranscript(buf *strings.Builder, msgs []llm.Message) {
+	for _, msg := range msgs {
+		switch msg.Role {
+		case "system":
+			continue
+		case "user":
+			fmt.Fprintf(buf, "\n%s %s\n", youStyle.Render("you:"), msg.Content)
+		case "assistant":
+			if msg.Content != "" {
+				fmt.Fprintf(buf, "\n%s\n", msg.Content)
+			}
+			for _, tc := range msg.ToolCalls {
+				fmt.Fprintf(buf, "\n%s %s %s\n", toolStyle.Render("⚒"), tc.Function.Name, dimStyle.Render(tc.Function.Arguments))
+			}
+		case "tool":
+			preview := strings.Split(strings.TrimRight(msg.Content, "\n"), "\n")
+			if len(preview) > 4 {
+				preview = append(preview[:4], fmt.Sprintf("… +%d lines", len(msg.Content)-4))
+			}
+			fmt.Fprintf(buf, "%s\n", dimStyle.Render("  "+strings.Join(preview, "\n  ")))
+		}
+	}
 }
 
 // taskChatable reports whether the open task can receive messages: restored

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -751,3 +751,44 @@ func TestSendTaskMsgNeverBlocksWorker(t *testing.T) {
 		t.Fatal("sendTaskMsg blocked on an undrained program — it must detach the Send")
 	}
 }
+
+// A settled subagent's transcript persists as an attributed session; after a
+// fresh process resumes the parent, opening the restored task replays the full
+// transcript (read-only) instead of just the bare report.
+func TestRestoredTaskReplaysPersistedTranscript(t *testing.T) {
+	srv := sseTextServer(t, "exploration findings here")
+	defer srv.Close()
+	m := tasksModelStore(t, srv.URL)
+	m.wireTasks()
+
+	id, err := m.store.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.sessionID = id
+	m.agent.Tasks().SetSessionID(id)
+
+	task := m.agent.StartBackground("probe the tree", "find the files", agent.SubModel{})
+	waitSettled(t, task)
+
+	// The settle persisted the transcript as an attributed session row.
+	if _, err := m.store.SubagentTranscript(id, task.ID); err != nil {
+		t.Fatalf("transcript should persist on settle: %v", err)
+	}
+
+	// Fresh process: new agent, resume the parent session.
+	m.agent = agent.New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	if err := m.resume(id); err != nil {
+		t.Fatal(err)
+	}
+	m.openTask(task.ID)
+	if m.taskVP.live {
+		t.Fatal("a restored task has no live stream")
+	}
+	view := stripAll(m.taskViewView())
+	for _, want := range []string{"find the files", "exploration findings here"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("restored task view should replay the persisted transcript, missing %q:\n%s", want, view)
+		}
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2819,8 +2819,10 @@ func (m *model) wireTasks() {
 		// Persist the subagent's full transcript as its own attributed session
 		// (id <parent>/task/<id>) once it settles — start rows carry no
 		// transcript yet, so only settled tasks with a live sub have one.
+		// Attribute it to the sub's own route (t.SubModel): a model-overridden
+		// subagent must not be recorded under the parent's model/provider.
 		if t.Status != agent.TaskRunning && t.SubMessages != nil {
-			if _, err := st.SaveSubagentTranscript(sessionID, t.ID, t.SubMessages, m.modelName, m.provName); err != nil {
+			if _, err := st.SaveSubagentTranscript(sessionID, t.ID, t.SubMessages, t.SubModel, ""); err != nil {
 				config.LogEvent("session.task", "transcript save failed: "+err.Error())
 			}
 		}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2816,6 +2816,14 @@ func (m *model) wireTasks() {
 		}); err != nil {
 			config.LogEvent("session.task", "save failed: "+err.Error())
 		}
+		// Persist the subagent's full transcript as its own attributed session
+		// (id <parent>/task/<id>) once it settles — start rows carry no
+		// transcript yet, so only settled tasks with a live sub have one.
+		if t.Status != agent.TaskRunning && t.SubMessages != nil {
+			if _, err := st.SaveSubagentTranscript(sessionID, t.ID, t.SubMessages, m.modelName, m.provName); err != nil {
+				config.LogEvent("session.task", "transcript save failed: "+err.Error())
+			}
+		}
 	}
 	m.agent.Tasks().SetSessionID(m.sessionID)
 	m.agent.SetSessionID(m.sessionID)


### PR DESCRIPTION
## Item 5 of the Agent UX batch ([plan](.ai-docs/plans/agent-ux-batch/PLAN.md))

**Problem:** a settled background subagent's conversation lived only in the retained in-memory sub-agent — it died with the process, so a resumed session's restored tasks showed only the bare final report, not the work that produced it.

**Change:**
- On settle, the TUI's `OnRecord` hook saves the subagent's full conversation as its own attributed session: `Store.SaveSubagentTranscript` writes a session row with id `task-<parentID>-<taskID>`, `forked_from` = parent session, `task_id` = the task. (The `task-` prefix avoids a prefix-collision with the parent id in `Load`'s prefix match — caught by the round-trip test.)
- `BackgroundTask` carries `SubMessages`, a snapshot copied at settle **before** `settle` fires `OnRecord`; a follow-up turn on the settled subagent re-saves the transcript via `refreshTranscript` after `FollowupTask`.
- On resume, opening a restored task replays the persisted transcript read-only (`renderTranscript`) — role-labeled blocks, tool calls by name, system prompt skipped. A crashed process no longer loses the completed work.
- Schema: additive `task_id` column via the existing idempotent `extraColumns` migration; `Meta.TaskID`; `forked_from` reused for parent attribution so subagent sessions nest under their parent in the existing `ForksOf` tree.

## Tests

- `internal/session/session_test.go` — `TestSubagentTranscriptRoundTrip` (attribution, follow-up re-save replaces the row, no-op without a parent)
- `internal/tui/tasks_test.go` — `TestRestoredTaskReplaysPersistedTranscript` (kill-mid-run → resume → open shows the full transcript)

`task check` green; `go test -race ./internal/agent ./internal/session` green; `golangci-lint` clean.