### PR TITLE
feat(prompt): env block with date/time, timezone, platform, and username

### DIFF
--- a/cmd/whip/acp.go
+++ b/cmd/whip/acp.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -117,7 +118,7 @@ func acpCLI(args []string) error {
 	factory := func(ctx context.Context, wd string, servers map[string]mcp.ServerConfig) (*agent.Agent, *mcp.Manager, error) {
 		client := llm.New(prov.BaseURL, key)
 		client.MaxRetries = cfg.MaxRetries
-		ag := agent.New(client, apiID, maxOut, systemPrompt(wd))
+		ag := agent.New(client, apiID, maxOut, systemPrompt(wd, time.Now()))
 		ag.ModelName, ag.Provider = modelName, provName
 		ag.ComputerDisabled = true
 		ag.ContextLimit = ctxLimit

--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -5,6 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/user"
+	"runtime"
+	"time"
 
 	"github.com/context-labs/whip/internal/agent"
 	"github.com/context-labs/whip/internal/config"
@@ -24,10 +27,20 @@ func cwd() string {
 	return wd
 }
 
+// username is the OS login name, or "unknown" when it can't be resolved
+// (e.g. inside a container without a passwd entry).
+func username() string {
+	u, err := user.Current()
+	if err != nil || u.Username == "" {
+		return "unknown"
+	}
+	return u.Username
+}
+
 // systemPrompt builds the base system prompt rooted at wd. The TUI and
 // `whip run` pass the process cwd; `whip acp` passes the client-provided
 // session cwd (the editor spawns whip wherever it likes).
-func systemPrompt(wd string) string {
+func systemPrompt(wd string, now time.Time) string {
 	prompt := `You are an expert coding assistant operating inside whip, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
 
 Available tools:
@@ -54,7 +67,13 @@ Operating rules:
 
 whip's own docs (features, tools, configuration, MCP servers, skills) live at https://github.com/context-labs/whip/tree/main/docs — consult them when the user asks how to configure or extend whip itself.
 
-Current working directory: ` + wd
+Here is some useful information about the environment you are running in:
+<env>
+  Working directory: ` + wd + `
+  Platform: ` + runtime.GOOS + `
+  Current date/time: ` + now.Format("Mon Jan 2, 2006 15:04:05 MST (UTC-07:00)") + `
+  User: ` + username() + `
+</env>`
 	if extra := config.MeInstructions(); extra != "" {
 		prompt += "\n\nStanding instructions from the user (~/.whip/me.md — treat as user rules):\n" + extra
 	}
@@ -154,7 +173,7 @@ func main() {
 			os.Exit(1)
 		}
 		_ = prov.Key()
-		_ = agent.New(llm.New(prov.BaseURL, "bench"), id, mdl.MaxTokens, systemPrompt(cwd()))
+		_ = agent.New(llm.New(prov.BaseURL, "bench"), id, mdl.MaxTokens, systemPrompt(cwd(), time.Now()))
 		return
 	}
 
@@ -163,7 +182,7 @@ func main() {
 	// notice still shows on the next launch.
 	go update.Check(version)
 	tui.Version = version // /report names the build in the bug-report bundle
-	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(cwd()), *resumeFlag, *cautiousFlag)
+	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(cwd(), time.Now()), *resumeFlag, *cautiousFlag)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "whip:", err)
 		os.Exit(1)

--- a/cmd/whip/main_test.go
+++ b/cmd/whip/main_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The system prompt always carries the built-in operating rules (the safety
@@ -13,7 +14,7 @@ func TestSystemPromptAppendsUserMe(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("WHIP_HOME", home)
 
-	p := systemPrompt(t.TempDir())
+	p := systemPrompt(t.TempDir(), time.Now())
 	if !strings.Contains(p, "never force-push") {
 		t.Fatal("built-in operating rules must always be present")
 	}
@@ -22,11 +23,37 @@ func TestSystemPromptAppendsUserMe(t *testing.T) {
 	}
 
 	os.WriteFile(filepath.Join(home, "me.md"), []byte("- Always pnpm, never npm.\n"), 0o644)
-	p = systemPrompt(t.TempDir())
+	p = systemPrompt(t.TempDir(), time.Now())
 	if !strings.Contains(p, "never force-push") {
 		t.Fatal("built-in rules survive a user me.md")
 	}
 	if !strings.Contains(p, "Standing instructions from the user") || !strings.Contains(p, "Always pnpm") {
 		t.Fatalf("user instructions should append:\n%s", p)
+	}
+}
+
+// The env block tells the model where and when it is: the working directory,
+// the platform, the current date/time with the local timezone, and the OS
+// username — so relative dates ("tomorrow", "last Tuesday") resolve against
+// the user's clock, and the model knows who it's working with.
+func TestSystemPromptEnvBlock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WHIP_HOME", home)
+
+	now := time.Date(2026, 8, 28, 19, 21, 11, 0, time.Local)
+	p := systemPrompt("/tmp/work", now)
+
+	for _, want := range []string{
+		"<env>",
+		"Working directory: /tmp/work",
+		"Current date/time: Fri Aug 28, 2026 19:21:11",
+		"User: ",
+	} {
+		if !strings.Contains(p, want) {
+			t.Fatalf("env block should contain %q:\n%s", want, p)
+		}
+	}
+	if !strings.Contains(p, " (UTC") {
+		t.Fatalf("date/time should carry a UTC offset:\n%s", p)
 	}
 }

--- a/cmd/whip/run.go
+++ b/cmd/whip/run.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/context-labs/whip/internal/agent"
 	"github.com/context-labs/whip/internal/config"
@@ -96,7 +97,7 @@ func runCLI(args []string) error {
 
 	// System prompt: -system-file wins over -system (a file is the deliberate
 	// choice; a stray -system alongside it is almost certainly stale).
-	sys := systemPrompt(cwd())
+	sys := systemPrompt(cwd(), time.Now())
 	if *systemFlag != "" {
 		sys = *systemFlag
 	}


### PR DESCRIPTION
## What

Adds an `<env>` block to the base system prompt (inspired by OpenCode's environment segment in `packages/opencode/src/session/system.ts`):

```
<env>
  Working directory: /home/abe/code/loopy
  Platform: linux
  Current date/time: Fri Aug 28, 2026 19:21:11 PDT (UTC-07:00)
  User: abe
</env>
```

## Why

The model previously had no idea what the current date/time was — relative dates ("tomorrow", "last Friday") resolved against the training cutoff, not the user's clock. It also didn't know the user's name. Now both are explicit, with the timezone abbreviation **and** numeric UTC offset.

## Changes

- `systemPrompt(wd, now)` takes a `time.Time` so the format is testable; all three call sites (TUI, `whip run`, `whip acp`) pass `time.Now()`
- New `username()` helper (`os/user.Current`, falls back to "unknown")
- `TestSystemPromptEnvBlock` covers the block; existing `me.md` test updated

`task check` passes locally.