### PR TITLE
feat(tui): render subagent steers as user messages

### DIFF
--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -67,8 +67,11 @@ func renderTaskEvent(buf *strings.Builder, kind int, s, s2 string) {
 			preview = append(preview[:4], fmt.Sprintf("… +%d lines", len(s2)-4))
 		}
 		fmt.Fprintf(buf, "%s\n", dimStyle.Render("  "+strings.Join(preview, "\n  ")))
-	case 3: // a steered message reached the running subagent (task_steer / chat)
-		fmt.Fprintf(buf, "\n%s %s\n", youStyle.Render("↪ steered:"), s)
+	case 3: // a steered message reached the running subagent (task_steer /
+		// chat). Render it as a user message — the steering main agent (or the
+		// human in the task chat) is the subagent's orchestrator, acting as its
+		// user, so the transcript reads like a normal user turn.
+		fmt.Fprintf(buf, "\n%s %s\n", youStyle.Render("you:"), s)
 	case 4: // follow-up turn settled
 		if s != "" {
 			fmt.Fprintf(buf, "\n%s\n", errStyle.Render(s))
@@ -304,7 +307,7 @@ func (m *model) taskSend(tv *taskView, text string) {
 			fmt.Fprintf(&tv.buf, "\n%s\n", errStyle.Render(err.Error()))
 			break
 		}
-		fmt.Fprintf(&tv.buf, "\n%s %s\n", youStyle.Render("you (steer):"), text)
+		fmt.Fprintf(&tv.buf, "\n%s %s\n", youStyle.Render("you:"), text)
 	case tv.busy:
 		fmt.Fprintf(&tv.buf, "\n%s\n", dimStyle.Render("(still replying — wait for the current reply)"))
 	default:

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -869,3 +869,26 @@ func TestRestoredTaskReplaysPersistedTranscript(t *testing.T) {
 		}
 	}
 }
+
+// A steered message in the subagent view renders as a user message — the
+// steering main agent (or the human in the task chat) is the subagent's
+// orchestrator, acting as its user. The transcript should read like a normal
+// user turn, not a system note.
+func TestSteeredMessageRendersAsUser(t *testing.T) {
+	srv := sseTextServer(t, "ok")
+	defer srv.Close()
+	m := tasksModel(srv.URL)
+	task := m.agent.StartBackground("probe", "p", agent.SubModel{})
+	defer m.agent.Tasks().Cancel(task.ID)
+	m.openTask(task.ID)
+
+	// live path: a steer event renders with the "you:" label
+	m.Update(taskEventMsg{id: task.ID, kind: 3, s: "check the other file too"})
+	view := stripAll(m.taskViewView())
+	if !strings.Contains(view, "you: check the other file too") {
+		t.Fatalf("steered message should render as a user turn, got:\n%s", view)
+	}
+	if strings.Contains(view, "steered:") || strings.Contains(view, "you (steer)") {
+		t.Fatalf("steered message must not carry a 'steered' label, got:\n%s", view)
+	}
+}


### PR DESCRIPTION
## Change

In the subagent detail view, a steered message rendered as `↪ steered:` / `you (steer):` — a system-note framing. But the steering main agent (or the human in the task chat) is the subagent's orchestrator, acting as its user, so the transcript should read like a normal user turn.

Both render sites (`renderTaskEvent` kind 3 and the direct echo in `taskSend`) now use the `you:` label.

## Test

`TestSteeredMessageRendersAsUser` — a live steer event renders as a user turn and carries no `steered` label. `golangci-lint` clean; full TUI suite green.