### PR TITLE
feat(tui): keep settled subagents in the dock until the user sends a new message

### DIFF
--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"os/exec"
@@ -597,11 +598,18 @@ func flattenResult(res *sdkmcp.CallToolResult) string {
 // normalizeSchema passes the server's input schema through as a JSON string,
 // coercing it into the object shape providers require (opencode forces
 // type:object + properties:{} + additionalProperties:false).
+// normalizeSchema renders an MCP tool's input schema as a JSON object with
+// type:"object" and a properties key (some servers omit one or both). The
+// input map is COPIED, never mutated: d.InputSchema is shared across every
+// Manager.Tools() call, and the race detector caught concurrent writes to it
+// (fatal error: concurrent map writes) when two settles interleaved.
 func normalizeSchema(schema any) string {
-	m, ok := schema.(map[string]any)
-	if !ok || m == nil {
+	src, ok := schema.(map[string]any)
+	if !ok || src == nil {
 		return `{"type":"object","properties":{}}`
 	}
+	m := make(map[string]any, len(src)+2)
+	maps.Copy(m, src)
 	m["type"] = "object"
 	if _, ok := m["properties"]; !ok {
 		m["properties"] = map[string]any{}

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -426,6 +427,28 @@ func TestNormalizeSchema(t *testing.T) {
 	}
 	if m["type"] != "object" || m["properties"] == nil || m["title"] != "x" {
 		t.Errorf("coerced schema = %v", m)
+	}
+}
+
+// normalizeSchema must not mutate its input: d.InputSchema is shared across
+// every Manager.Tools() call, and concurrent writes to it crashed the race
+// detector (fatal error: concurrent map writes). Hammering a shared map from
+// many goroutines proves it stays read-only.
+func TestNormalizeSchemaDoesNotMutateSharedInput(t *testing.T) {
+	shared := map[string]any{"title": "tool", "properties": map[string]any{"a": 1}}
+	// A sentinel key the normalizer must never add to the input: its own
+	// mutation (type:"object") would be detectable here.
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			for range 200 {
+				_ = normalizeSchema(shared)
+			}
+		})
+	}
+	wg.Wait()
+	if _, mutated := shared["type"]; mutated {
+		t.Fatalf("normalizeSchema mutated the shared input map: %v", shared)
 	}
 }
 

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -101,14 +101,10 @@ type taskView struct {
 // occupies (hint row + task rows); the strip scrolls if there are more tasks.
 const tasksDockHeight = 6
 
-// dockSettledGrace is how long a settled task stays in the dock after
-// finishing — long enough to notice the ✓ and open the report, then the
-// strip cleans itself. Restored tasks (--resume history) never show: their
-// subagents died with the previous process. /tasks lists everything.
-const dockSettledGrace = time.Minute
-
-// dockTasks returns the dock's tasks — running ones plus those settled
-// within dockSettledGrace, never restored ones — newest first. Bare test
+// dockTasks returns the dock's tasks — running ones plus settled ones,
+// never restored ones — newest first. Settled tasks stay in the dock until
+// the user sends a new message (submitTurn sweeps them then), so the user
+// can review a finished subagent's transcript before moving on. Bare test
 // models have no agent; the dock is simply empty.
 func (m *model) dockTasks() []agent.BackgroundTask {
 	if m.agent == nil {
@@ -119,10 +115,7 @@ func (m *model) dockTasks() []agent.BackgroundTask {
 		if t.Restored {
 			continue // resume history belongs in /tasks, not the dock
 		}
-		// running always shows; zero EndedAt (never settled) sorts with them
-		if t.Status == agent.TaskRunning || time.Since(t.EndedAt) < dockSettledGrace {
-			out = append(out, t)
-		}
+		out = append(out, t)
 	}
 	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
 		out[i], out[j] = out[j], out[i]

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -355,9 +355,11 @@ func TestEnterOpensTaskViewAndEscBacksOut(t *testing.T) {
 	}
 }
 
-// dockTasks is time-dependent (settled tasks age out after dockSettledGrace),
-// so the focused dock can go empty — or shrink below the selection — between
-// the last paint and the keypress. Enter must not index the empty list.
+// settled tasks linger in the dock until the user sends a new message, so the
+// focused dock's list is stable between the last paint and the keypress
+// (submitTurn sweeps it on the next authored turn). Enter must not index the
+// empty list, and a stale selection beyond the list clamps instead of
+// panicking.
 func TestEnterOnEmptyFocusedDockDoesNotPanic(t *testing.T) {
 	srv := sseTextServer(t, "ok")
 	defer srv.Close()
@@ -890,5 +892,36 @@ func TestSteeredMessageRendersAsUser(t *testing.T) {
 	}
 	if strings.Contains(view, "steered:") || strings.Contains(view, "you (steer)") {
 		t.Fatalf("steered message must not carry a 'steered' label, got:\n%s", view)
+	}
+}
+
+// Settled tasks stay in the dock until the user sends a new message: a
+// machine turn (steer/wake, authored=false) must NOT sweep them, a user-typed
+// turn (authored=true) does.
+func TestSettledTasksLingerUntilUserMessage(t *testing.T) {
+	srv := sseTextServer(t, "ok")
+	defer srv.Close()
+	m := tasksModel(srv.URL)
+	task := m.agent.StartBackground("finished probe", "p", agent.SubModel{})
+	waitSettled(t, task)
+
+	// still in the dock after settling (no age-out)
+	if len(m.dockTasks()) != 1 {
+		t.Fatalf("settled task should stay in the dock, got %d", len(m.dockTasks()))
+	}
+
+	// a machine turn (authored=false, e.g. a steered report or wake) must not sweep it
+	m.submitTurn("[subagent done] report", false)
+	if len(m.dockTasks()) != 1 {
+		t.Fatal("a machine turn must not clear the settled task from the dock")
+	}
+
+	// the user sending a new message sweeps it
+	m2 := tasksModel(srv.URL)
+	task2 := m2.agent.StartBackground("another probe", "p", agent.SubModel{})
+	waitSettled(t, task2)
+	m2.submitTurn("what's next?", true)
+	if len(m2.dockTasks()) != 0 {
+		t.Fatalf("a user message should sweep settled tasks, got %d", len(m2.dockTasks()))
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2578,9 +2578,9 @@ func (m *model) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.tasksFocus { // open the selected task's detail view
 			m.tasksFocus = false
-			// dockTasks is time-dependent (settled tasks age out after
-			// dockSettledGrace), so the strip can go empty — or shrink below
-			// taskSel — between the last paint and this keypress
+			// settled tasks linger in the dock until the user sends a new
+			// message, so the strip is stable between the last paint and this
+			// keypress; the list can still be empty (or smaller than taskSel)
 			if tasks := m.dockTasks(); len(tasks) > 0 {
 				m.openTask(tasks[min(m.taskSel, len(tasks)-1)].ID)
 			}
@@ -3356,10 +3356,13 @@ func (m *model) submitTurn(text string, authored bool) (tea.Model, tea.Cmd) {
 		}
 	}
 	m.discardFuture() // new activity while rewound kills the redo stack
-	// settled subagents already reported into the transcript; clear them off
-	// the dock strip so a new turn starts with only what's still running —
-	// except a task whose chat pane is open (its retained subagent is in use)
-	if m.agent != nil {
+	// Settled subagents stay in the dock until the user sends a new message, so
+	// they can review a finished subagent's transcript before moving on. A
+	// user-typed (authored) turn sweeps them; machine turns (steered reports,
+	// wake turns) don't, or a settling background task would clear its own row
+	// before the user ever saw it. A task whose chat pane is open is kept (its
+	// retained subagent is in use).
+	if authored && m.agent != nil {
 		var keep []string
 		if m.taskVP != nil {
 			keep = append(keep, m.taskVP.id)


### PR DESCRIPTION
## Change

Settled subagents used to age out of the dock after a 1-minute grace window — too short to review a finished subagent's transcript. Now they linger until the user sends a new message:

- `dockTasks` drops the age filter — settled tasks stay listed.
- The `ClearSettled` sweep in `submitTurn` is gated on `authored=true`, so a machine turn (a steered report, a wait wake) doesn't clear a task's row before the user ever saw the ✓. (Previously a settling background task's own steered-report turn would clear its own row immediately.)
- The `dockSettledGrace` constant is gone (no longer used); stale comments updated.

## Test

`TestSettledTasksLingerUntilUserMessage` — a settled task stays in the dock, a machine turn doesn't sweep it, a user-typed turn does. `golangci-lint` clean; TUI suite green.