### PR TITLE
feat(hooks): implement portable lifecycle hooks for command execution

### DIFF
--- a/.ai-docs/plans/lifecycle-hooks/README.md
+++ b/.ai-docs/plans/lifecycle-hooks/README.md
@@ -1,0 +1,124 @@
+# Lifecycle hooks: project policy and automation
+
+Branch: `main` (working tree)
+
+## What this does / Goal
+
+Add trusted command hooks at five lifecycle boundaries: `UserPromptSubmit`,
+`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, and `Stop`.
+
+Whip loads project-owned `.whip/hooks.json` files and plugin hook files under
+`.agents/plugins/*/hooks/hooks.json`. This gives projects a portable way to
+enforce policy, add context, audit tool use, and run quality gates without
+adding a runtime or dependency.
+
+Example: block a dangerous tool call before execution, then require tests to
+pass before the agent can stop.
+
+## Non-goals
+
+- Embedded JavaScript, Python, WASM, or a general plugin ABI.
+- Mutating tool schemas, model requests, or tool arguments in v1.
+- Async, session, file-change, shell, or installer hooks.
+- Replacing Whip's permission system.
+- Persisting hook state in SQLite or introducing another config dialect.
+
+## Design
+
+Primary surfaces:
+
+- `internal/hooks/{types,config,runner}.go`: discovery, normalization, matching,
+  execution, and decisions.
+- `internal/tools/bashrun/bashrun.go`: bounded subprocess I/O and exact exits.
+- `internal/agent/{agent,subagent,background}.go`: lifecycle integration.
+- `internal/tui/{tui,registry,shell}.go`: trust, `/hooks`, and `/cd` reloads.
+- `cmd/whip/{run,acp}.go`: headless and ACP setup.
+
+### Hook package and protocol
+
+- Discover user plugins, project plugins, then the project hook file; preserve
+  deterministic file and declaration order.
+- Normalize both formats into one immutable, read-safe `hooks.Manager`.
+- Send versioned JSON on stdin and expose stable `WHIP_*` environment values.
+- Match selectors against native Whip tool names; invalid entries emit visible
+  warnings while valid entries still load.
+- Accept allow/block/deny decisions from JSON stdout and exit code `2`; other
+  non-zero exits fail open unless a `PreToolUse` hook sets
+  `on_failure: block`.
+- `Stop` failures always fail open, and stop rejection is capped at three
+  retries to prevent loops.
+- Apply output, time, command-count, and environment-size limits. Skip async
+  tools rather than reporting misleading post-execution results.
+
+### Safe subprocess execution
+
+Extend `bashrun.Options` with stdin, environment, working directory, separate
+stdout/stderr capture, and byte limits. Extend `bashrun.Result` with stderr and
+the exact exit code. Reuse its process-group cancellation and `KillAll`
+behavior; add no dependency and keep existing callers compatible.
+
+### Agent loop
+
+The agent consumes a narrow hook-runner interface so tests can use fakes and
+the loop does not depend on configuration details.
+
+- `UserPromptSubmit` may append context or reject the turn before the model.
+- `PreToolUse` may block before tool execution.
+- `PostToolUse` and `PostToolUseFailure` may append context after completion.
+- `Stop` may reject completion and return feedback to the model.
+- Emit hook lifecycle events for observability; store durable decisions as
+  ordinary conversation messages, requiring no database migration.
+
+### Concurrency, frontends, and trust
+
+- Run hooks serially within one event; independent tool calls remain parallel.
+- Run pre-hooks before path/global mutation locks and never hold those locks
+  across subprocess I/O.
+- Copy/swap the active manager safely so `/cd` stays busy-safe and race-free.
+- Subagents inherit the parent runner while each worktree event carries its
+  explicit working directory.
+- Interactive project hooks load only after `checkTrust`; `/cd` and ACP load
+  them only when `config.Trusted(dir)` is true. User hooks are already trusted,
+  and `whip run` retains its existing trusted-directory contract.
+- `WHIP_DISABLE_HOOKS=1` disables all hooks for recovery and CI isolation.
+
+## Test plan
+
+- Loader tests for both formats, precedence, ordering, selectors, and partial
+  validation failures.
+- Runner tests for JSON/env input, decision parsing, exit semantics, limits,
+  timeout, cancellation, and process cleanup.
+- Compatibility tests for existing `bashrun` callers.
+- Agent-loop tests with a fake provider and hook runner for all five events.
+- Concurrency tests for parallel tools, same-path mutations, `/cd`, manager
+  replacement, subagents, and worktree directories.
+- Frontend tests for trust gating, `/hooks`, headless JSON output, and ACP.
+- Run `go test -race ./...` and `task check`.
+
+## Docs plan
+
+- Document configuration, payloads, trust, limits, and troubleshooting in
+  `docs/lifecycle-hooks.md`.
+- Update `docs/README.md`, `docs/features.md`, `docs/roadmap.md`, and
+  `docs/concurrency.md`.
+- Record protocol and safety decisions in the lifecycle-hook documentation.
+
+## Tasks
+
+- [x] Add normalized hook types, loaders, matching, validation, and tests.
+- [x] Extend `bashrun` with bounded structured I/O and exact exit reporting.
+- [x] Implement the hook runner, decisions, limits, and cancellation.
+- [x] Integrate the five events into the agent loop and event stream.
+- [x] Wire subagents, worktrees, safe manager replacement, and explicit cwd.
+- [x] Add TUI, headless, and ACP trust/loading behavior plus `/hooks`.
+- [x] Write user and concurrency documentation.
+- [x] Run race, integration, and adversarial subprocess tests, then `task check`.
+
+## Completion notes
+
+- The adversarial pass made manager + working-directory publication one atomic
+  `SetHookScope` operation and synchronized process-wide child-marker snapshots.
+- Hook-annotated and hook-blocked tool results re-enter the normal bounded tool
+  output path; the original failure status survives annotation and truncation.
+- Interactive bash timeout, cancellation, and inactivity markers route through
+  `PostToolUseFailure`, matching non-interactive command failures.

--- a/cmd/whip/acp.go
+++ b/cmd/whip/acp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/context-labs/whip/internal/acp"
 	"github.com/context-labs/whip/internal/agent"
 	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/hooks"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/lsp"
 	"github.com/context-labs/whip/internal/mcp"
@@ -127,6 +128,15 @@ func acpCLI(args []string) error {
 		// supported level, else off — so a non-reasoning model never sends an
 		// effort parameter the provider would reject.
 		ag.Effort = tui.DefaultEffortFor(config.LoadCatalogs(), provName, ag.Model, cfg.DefaultEffort)
+		hookMgr := hooks.Load(hooks.LoadOptions{
+			WorkingDir:     wd,
+			IncludeProject: config.Trusted(wd),
+		})
+		ag.SetHookScope(hookMgr, wd)
+		for _, warning := range hookMgr.Warnings() {
+			config.LogEvent("hooks.load", warning)
+			fmt.Fprintln(os.Stderr, "whip: hooks:", warning)
+		}
 
 		// Skills + memory ride the system prompt. The TUI refreshes these per
 		// turn; ACP sessions refresh at session creation — a new skill lands

--- a/cmd/whip/main_test.go
+++ b/cmd/whip/main_test.go
@@ -8,6 +8,21 @@ import (
 	"time"
 )
 
+// Hook discovery uses the platform home directory. Isolate the whole test
+// binary so no CLI test can load or execute a developer's real plugins.
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "whip-cli-test-home")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("HOME", home); err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(home)
+	os.Exit(code)
+}
+
 // The system prompt always carries the built-in operating rules (the safety
 // rails); ~/.whip/me.md appends the user's standing instructions after them.
 func TestSystemPromptAppendsUserMe(t *testing.T) {

--- a/cmd/whip/run.go
+++ b/cmd/whip/run.go
@@ -16,12 +16,15 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/context-labs/whip/internal/agent"
 	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/hooks"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/session"
 	"github.com/context-labs/whip/internal/tui"
@@ -99,7 +102,8 @@ func runCLI(args []string) error {
 
 	// System prompt: -system-file wins over -system (a file is the deliberate
 	// choice; a stray -system alongside it is almost certainly stale).
-	sys := systemPrompt(cwd(), time.Now())
+	workingDir := cwd()
+	sys := systemPrompt(workingDir, time.Now())
 	if *systemFlag != "" {
 		sys = *systemFlag
 	}
@@ -150,6 +154,7 @@ func runCLI(args []string) error {
 			}
 		}
 	}
+	ag.SetSessionID(sessionID)
 
 	// ctrl+c cancels the turn; -timeout caps the whole run.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -167,9 +172,18 @@ func runCLI(args []string) error {
 			fmt.Fprintf(os.Stderr, format+"\n", a...)
 		}
 	}
+	hookMgr := hooks.Load(hooks.LoadOptions{WorkingDir: workingDir, IncludeProject: true})
+	ag.SetHookScope(hookMgr, workingDir)
+	for _, warning := range hookMgr.Warnings() {
+		config.LogEvent("hooks.load", warning)
+		note("hooks: %s", warning)
+	}
 	if *format == "json" {
 		enc := json.NewEncoder(os.Stdout)
+		var emitMu sync.Mutex
 		emit = func(v any) {
+			emitMu.Lock()
+			defer emitMu.Unlock()
 			if err := enc.Encode(v); err != nil {
 				fmt.Fprintln(os.Stderr, "whip: json encode:", err)
 			}
@@ -184,9 +198,32 @@ func runCLI(args []string) error {
 		ev.OnToolEnd = func(_, name, result string) {
 			emit(map[string]string{"type": "tool_end", "name": name, "result": result})
 		}
+		ev.OnHook = func(event hooks.Event, outcome hooks.Outcome) {
+			emit(map[string]string{
+				"type":     "hook",
+				"event":    string(event),
+				"blocked":  strconv.FormatBool(outcome.Blocked),
+				"ran":      strconv.Itoa(outcome.Ran),
+				"reason":   outcome.Reason,
+				"context":  outcome.AdditionalContext,
+				"failures": strings.Join(outcome.Failures, "; "),
+			})
+		}
 	} else {
 		ev.OnText = func(d string) { fmt.Fprint(os.Stdout, d) }
 		ev.OnToolStart = func(_, name, args string) { note("⚒ %s", name) }
+		ev.OnHook = func(event hooks.Event, outcome hooks.Outcome) {
+			if outcome.Blocked {
+				note("hook %s blocked: %s", event, outcome.Reason)
+			}
+			failureLabel := "failed open"
+			if outcome.Blocked {
+				failureLabel = "failure"
+			}
+			for _, failure := range outcome.Failures {
+				note("hook %s %s: %s", event, failureLabel, failure)
+			}
+		}
 	}
 
 	// Subagent routing: same default chain as the TUI (taskModel → built-in

--- a/cmd/whip/run_test.go
+++ b/cmd/whip/run_test.go
@@ -36,6 +36,7 @@ func runFixture(t *testing.T, reply string, reqs *[]llm.Request) {
 
 	home := t.TempDir()
 	t.Setenv("WHIP_HOME", home)
+	t.Setenv("HOME", home) // lifecycle discovery must never execute real user plugins in tests
 	cfg := fmt.Sprintf(`{
 		"defaultModel": "test",
 		"providers": {"testprov": {"baseUrl": %q, "api": "openai-completions", "apiKey": "k"}},
@@ -51,6 +52,10 @@ func runFixture(t *testing.T, reply string, reqs *[]llm.Request) {
 // non-TTY empty stdin, like `whip run "…" < /dev/null`).
 func runCapture(t *testing.T, stdinData string, args ...string) (string, error) {
 	t.Helper()
+	// Headless mode intentionally trusts project hooks. Run every fixture from
+	// an empty directory so repository-local hooks on a developer's checkout
+	// can never affect or execute during CLI tests.
+	t.Chdir(t.TempDir())
 
 	oldIn := os.Stdin
 	inR, inW, err := os.Pipe()
@@ -123,6 +128,40 @@ func TestRunJSONStream(t *testing.T) {
 	}
 	if !sawText || !sawDone {
 		t.Fatalf("want a text event and a done event, got:\n%s", out)
+	}
+}
+
+func TestRunJSONIncludesFlatHookEvents(t *testing.T) {
+	var reqs []llm.Request
+	runFixture(t, "all done", &reqs)
+	hookPath := filepath.Join(os.Getenv("HOME"), ".agents", "plugins", "policy", "hooks", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hookConfig := `{"hooks":{"UserPromptSubmit":[{"hooks":[{"command":"printf '{\"decision\":\"allow\",\"additionalContext\":\"ci policy\"}'"}]}]}}`
+	if err := os.WriteFile(hookPath, []byte(hookConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runCapture(t, "", "--format", "json", "go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hookEvent map[string]string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		var event map[string]string
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("line not JSON: %q: %v", line, err)
+		}
+		if event["type"] == "hook" {
+			hookEvent = event
+		}
+	}
+	if hookEvent["event"] != "UserPromptSubmit" || hookEvent["ran"] != "1" || hookEvent["context"] != "ci policy" {
+		t.Fatalf("flat hook event = %v", hookEvent)
+	}
+	if len(reqs) != 1 || !strings.Contains(reqs[0].Messages[1].Content, "ci policy") {
+		t.Fatalf("hook context did not reach provider: %+v", reqs)
 	}
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -188,6 +188,8 @@ How it works, from the top down:
   storage. Start here.
 - [agent-loop.md](agent-loop.md) — `Agent.Turn` in detail: the
   stream-tools-repeat cycle, parallel tool execution, compaction, steering.
+- [lifecycle-hooks.md](lifecycle-hooks.md) — command hooks for policy,
+  context, and quality gates.
 - [concurrency.md](concurrency.md) — the two channel patterns
   behind parallel tool calls (per-path locks) and background subagents.
 - [tools.md](tools.md) — the tool set the model gets: bash, file

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -159,3 +159,29 @@ for file A never wakes file B, and the loop breaks on the edited file's push
 plus one 50ms trailing wake (still deadline-bounded) for sibling frames —
 gopls fans pushes out across the whole package, so sibling errors land a
 tick after the edited file's.
+
+## 5. Lifecycle hooks = immutable snapshots outside mutation locks
+
+`internal/hooks.Manager` is fully built before publication and never mutated.
+The TUI's `/cd` path discovers a replacement, then `Agent.SetHookScope` swaps
+the runner and explicit working directory under a short `RWMutex` critical
+section. Each lifecycle event snapshots those two values and releases the
+lock before starting a subprocess. Existing events finish on the old manager;
+new events use the new one. No command ever observes a half-reloaded config.
+
+Parallel tool calls share the immutable manager safely. Commands for one event
+run serially in declaration order, while different tool workers may run their
+hook chains concurrently. `PreToolUse` runs before acquiring the per-path or
+global mutation semaphore. The tool releases that semaphore before
+`PostToolUse`/`PostToolUseFailure`, so a slow hook cannot hold a file lock or
+form a lock/I/O cycle with another tool. Subagents inherit the runner snapshot
+but carry their own working directory (including an isolated worktree).
+
+Hook callbacks therefore follow the same rule as task callbacks: they may run
+on tool-worker goroutines and consumers must be concurrency-safe. The TUI only
+sends a message, headless mode serializes through its turn-owned encoder, and
+ACP writes actionable outcomes to its synchronized event log.
+
+`bashrun` also snapshots the process-wide `WHIP_*` child markers under an
+`RWMutex` before merging each command environment. Publishing the first
+session id therefore cannot race a background tool or hook subprocess spawn.

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,6 +34,31 @@ Tests: `parallel_test.go` — `TestToolCallsRunInParallel` (overlap measured via
 a concurrency counter), `TestSamePathEditsSerialize`, `TestToolMutationPath`,
 `TestCanonicalPathKey`.
 
+### Portable lifecycle hooks
+
+`internal/hooks/` loads command hooks from plugin files
+(`.agents/plugins/*/hooks/hooks.json`) and the project-owned
+`.whip/hooks.json` file into one immutable manager. Five boundaries cover the
+useful policy surface: prompt submission, before a tool, after tool success,
+after tool failure, and before the agent stops. Hooks can add model context;
+prompt/pre-tool/stop hooks can block. Stop rejection is capped at three
+revision rounds, and command failures fail open unless a pre-tool action
+explicitly requests `on_failure: block`.
+
+The agent depends only on `hooks.Runner`, so configuration stays outside the
+loop and tests use a recording fake. Pre-hooks run before file/global mutation
+locks and post-hooks after release. The manager is immutable and atomically
+swapped on `/cd`; subagents inherit it with an explicit working directory.
+The TUI exposes `/hooks`, headless JSON mode emits flat hook events, and ACP
+logs actionable outcomes. Project hooks obey folder trust in interactive and
+ACP modes; `WHIP_DISABLE_HOOKS=1` is the recovery switch.
+
+Full configuration and protocol: [lifecycle-hooks.md](lifecycle-hooks.md).
+
+Tests: `internal/hooks/{config,runner}_test.go`,
+`internal/agent/hooks_test.go`, `internal/tui/hooks_test.go`, and structured
+subprocess coverage in `internal/tools/bashrun/failure_test.go`.
+
 ### Bash output feedback: live streaming + truncation spill
 
 Two ways a bash command stops being a black box (pi's bash tool has both):

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -1,0 +1,139 @@
+# Lifecycle hooks
+
+Lifecycle hooks let trusted shell commands observe or stop an agent turn without
+adding a plugin runtime. Whip supports five boundaries:
+
+| Event | Matcher input | What the result can do |
+|---|---|---|
+| `UserPromptSubmit` | submitted prompt | block the turn or add prompt context |
+| `PreToolUse` | Whip tool name | block the call or add tool-result context |
+| `PostToolUse` | Whip tool name | add tool-result context |
+| `PostToolUseFailure` | Whip tool name | add tool-result context |
+| `Stop` | empty | ask the model to revise before finishing |
+
+## Configuration
+
+Whip discovers command hooks in this order:
+
+1. `~/.agents/plugins/*/hooks/hooks.json`
+2. `<project>/.agents/plugins/*/hooks/hooks.json`
+3. `<project>/.whip/hooks.json`
+
+Plugin and file names are sorted; commands within a rule keep declaration
+order. Commands run serially for one event. Different tool calls still run in
+parallel.
+
+Plugin hook files use a wrapped configuration:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(bash|write|edit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/scripts/check-policy.sh",
+            "timeout": 30,
+            "on_failure": "block"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The project-local file may omit the outer `hooks` object and accepts snake-case
+or PascalCase event names:
+
+```json
+{
+  "pre_tool_use": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {"command": ".whip/check-policy.sh", "timeout": 30}
+      ]
+    }
+  ]
+}
+```
+
+Plugin matchers are Go regular expressions. Project-file matchers also accept
+`*`, an exact tool name such as `bash`, or `/regular-expression/`. Matchers use
+Whip's native tool names, including names such as `mcp__server__tool`.
+`${PLUGIN_ROOT}` and the `PLUGIN_ROOT` environment variable point at the
+plugin directory; for `.whip/hooks.json` they point at the project. Quote
+the expansion in commands that must work when a directory contains spaces,
+for example `"$PLUGIN_ROOT/scripts/check-policy.sh"`.
+
+`async: true`, non-command actions, unknown events, invalid matchers, and
+invalid actions are skipped with a visible warning. A bad entry does not
+discard valid neighbors. Run `/hooks` to inspect loaded commands and warnings.
+
+## Command protocol
+
+Each command runs in the session working directory. It receives one JSON object
+on stdin (shown here with all possible fields):
+
+```json
+{
+  "version": 1,
+  "event": "PreToolUse",
+  "event_type": "PreToolUse",
+  "session_id": "abc123",
+  "working_dir": "/repo",
+  "matcher_context": "bash",
+  "tool_name": "bash",
+  "tool_input": {"command": "go test ./..."},
+  "tool_response": "...",
+  "tool_error": "...",
+  "tool_call_id": "call_1",
+  "message": "user prompt",
+  "last_assistant_message": "final draft"
+}
+```
+
+Fields that do not apply to the event are omitted. Hook environment variables
+are also set:
+
+- `WHIP_HOOK_EVENT`, `WHIP_PROJECT_DIR`, `WHIP_SESSION_ID`, `WHIP_TOOL_NAME`
+- `PLUGIN_ROOT`
+
+The command inherits Whip's environment. Write diagnostics to stderr; stdout
+is a strict decision channel. Empty stdout with exit code 0 allows the event.
+Otherwise print exactly one object:
+
+```json
+{"decision":"allow","additionalContext":"Run the focused parser tests too."}
+```
+
+`decision` may be `allow`, `block`, or `deny`. A block can
+include `reason`; exit code 2 also blocks and uses stderr as its reason. Only
+`UserPromptSubmit`, `PreToolUse`, and `Stop` can block. Post-event context is
+still accepted, but post-event block decisions do not undo a completed tool.
+
+Malformed output, a timeout, cancellation, or another non-zero exit is visible
+but fails open. A `PreToolUse` action may opt into fail-closed behavior with
+`"on_failure":"block"`. Stop-hook failures always fail open. A Stop rejection
+feeds its reason back to the model and retries at most three times.
+
+## Trust, recovery, and limits
+
+Project hooks are executable code. The TUI loads them only after the normal
+folder-trust prompt. `/cd` and ACP load project hooks only for a directory
+already recorded as trusted. `whip run` keeps its existing trusted-automation
+contract and loads project hooks without an interactive prompt. User plugins
+under `~/.agents/plugins` are treated as user-controlled code.
+
+Set `WHIP_DISABLE_HOOKS=1` to disable all hook discovery for recovery or CI.
+Current limits are 128 commands, 1 MiB per config, 32 KiB per command, 256 KiB
+per event payload, 64 KiB per output stream, composed event context, and
+environment, and a maximum 10-minute timeout. Defaults are 30 seconds for
+plugin files and 60 seconds for the project-local file.
+
+Hook subprocesses use the same process-group cancellation and exit cleanup as
+the `bash` tool. Pre-hooks run before file/global mutation locks; post-hooks
+run after those locks are released.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,6 +68,7 @@ parallel tool calls and background subagents).
 - [x] Streamed partial tool output (bash `onUpdate` throttled at 100ms in pi) — `bashrun.Options.OnUpdate` fires accumulated-output snapshots at most every 100ms from the run's own goroutine; the bash tool picks it up via a per-call ctx value (`tools.WithOnUpdate` — parallel calls can't cross wires), `agent.Events.OnToolOutput` carries it with the tool-call id, and the TUI renders the last-3-lines tail under the running tool row until `toolEndMsg` collapses it
 - [x] Spill truncated bash output to a temp file and mention the path (pi bash tool) — when combined output exceeds `maxOutput` and gets tail-truncated, `bashrun.Spill` writes the full bytes to `$TMPDIR/whip-bash-<pid>/*.log` (0600) and the tool result appends `[full output (N bytes): <path>]` so the model can read/grep the rest; spill failure degrades silently, never breaks the result
 - [x] Inject `WHIP_SESSION_ID` / `WHIP_MODEL` env into bash children (pi injects `PI_*`) — already shipped: `bashrun.SetMarkers` stamps `WHIP=1`, `WHIP_SESSION_ID`, `WHIP_MODEL`, `WHIP_PID` on every child env (wired from `tui.go` on session create/resume); checkbox was stale
+- [x] Portable lifecycle hooks — command hooks at `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, and `Stop`; loads plugin and project-owned formats, supports context/block decisions, trust-gates project code, inherits into subagents/worktrees, and exposes `/hooks` plus headless/ACP telemetry ([protocol](lifecycle-hooks.md))
 
 ## Skills & subagents
 

--- a/internal/acp/bridge.go
+++ b/internal/acp/bridge.go
@@ -15,6 +15,7 @@ import (
 	acp "github.com/coder/acp-go-sdk"
 
 	"github.com/context-labs/whip/internal/agent"
+	"github.com/context-labs/whip/internal/hooks"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/mcp"
 	"github.com/context-labs/whip/internal/session"
@@ -253,6 +254,7 @@ func (b *Bridge) NewSession(ctx context.Context, params acp.NewSessionRequest) (
 			s.id = acp.SessionId(sid)
 		}
 	}
+	ag.SetSessionID(string(s.id))
 	b.mu.Lock()
 	if b.sessions == nil {
 		b.sessions = make(map[acp.SessionId]*acpSession)
@@ -296,6 +298,7 @@ func (b *Bridge) LoadSession(ctx context.Context, params acp.LoadSessionRequest)
 	// prompt; storeFrom tracks the in-memory index the next Save starts at.
 	ag.Messages = append(ag.Messages, msgs...)
 	s := newACPSession(acp.SessionId(meta.ID), ag, mgr)
+	ag.SetSessionID(meta.ID)
 	s.storeFrom = len(ag.Messages)
 	b.mu.Lock()
 	if b.sessions == nil {
@@ -433,7 +436,12 @@ func (b *Bridge) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Prom
 		OnThink:     func(d string) { _ = b.update(turnCtx, s.id, updateThoughtText(d)) },
 		OnToolStart: func(id, name, args string) { _ = b.update(turnCtx, s.id, startToolCall(id, name, args)) },
 		OnToolEnd:   func(id, name, result string) { _ = b.update(turnCtx, s.id, b.endTool(s, id, name, result)) },
-		OnUsage:     func(u llm.Usage) { b.sendUsage(turnCtx, s, u) },
+		OnHook: func(event hooks.Event, outcome hooks.Outcome) {
+			if outcome.Blocked || len(outcome.Failures) > 0 {
+				config_logf("session %s hook %s: blocked=%t failures=%v", s.id, event, outcome.Blocked, outcome.Failures)
+			}
+		},
+		OnUsage: func(u llm.Usage) { b.sendUsage(turnCtx, s, u) },
 	})
 
 	// Persist like run.go: best-effort, incremental. When the save lands and

--- a/internal/acp/bridge_lifecycle_test.go
+++ b/internal/acp/bridge_lifecycle_test.go
@@ -60,6 +60,9 @@ func TestNewSessionAdvertisesModes(t *testing.T) {
 	if resp.SessionId == "" {
 		t.Fatal("empty sessionId")
 	}
+	if got := f.bridge.getSession(resp.SessionId).ag.SessionIDValue(); got != string(resp.SessionId) {
+		t.Fatalf("agent session scope = %q, want %q", got, resp.SessionId)
+	}
 	if resp.Modes == nil || resp.Modes.CurrentModeId != ModeAuto || len(resp.Modes.AvailableModes) != 2 {
 		t.Fatalf("modes = %+v", resp.Modes)
 	}

--- a/internal/acp/load_test.go
+++ b/internal/acp/load_test.go
@@ -114,6 +114,9 @@ func TestLoadSessionReplaysHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("session/load: %v", err)
 	}
+	if got := f2.bridge.getSession(id).ag.SessionIDValue(); got != string(id) {
+		t.Fatalf("loaded agent session scope = %q, want %q", got, id)
+	}
 
 	// Replay arrived before the response (LoadSession returned), and contains
 	// user chunk → tool card (completed) → agent chunk.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,11 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/context-labs/whip/internal/hooks"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/tools"
 )
@@ -28,11 +30,12 @@ type Events struct {
 	// OnToolOutput streams partial output for a running tool call (bash only —
 	// throttled snapshots, ~100ms apart). Fires from tool worker goroutines.
 	OnToolOutput func(id, outputSoFar string)
-	OnSteer      func(text string)                // a steered message was injected
-	OnCompact    func(took, kept int)             // context was auto-compacted (messages removed/kept)
-	OnCompacted  func(summary string, cutoff int) // a compaction ran; record it (raw log survives)
-	OnUsage      func(u llm.Usage)                // a request reported its token usage
-	OnRetry      func(ev llm.RetryEvent)          // a transient request failure is being retried
+	OnSteer      func(text string)                              // a steered message was injected
+	OnCompact    func(took, kept int)                           // context was auto-compacted (messages removed/kept)
+	OnCompacted  func(summary string, cutoff int)               // a compaction ran; record it (raw log survives)
+	OnUsage      func(u llm.Usage)                              // a request reported its token usage
+	OnRetry      func(ev llm.RetryEvent)                        // a transient request failure is being retried
+	OnHook       func(event hooks.Event, outcome hooks.Outcome) // a lifecycle hook chain settled
 	// OnDecay fires when the per-turn decay pass rewrote n history messages
 	// (superseded reads / aged tool outputs). The caller must re-persist the
 	// affected prefix — the store's Save(from=1) INSERT OR REPLACEs it.
@@ -141,6 +144,14 @@ type Agent struct {
 	// ComputerDisabled, when true, keeps computer_exec out of the tool set
 	// (config computer.enabled=false).
 	ComputerDisabled bool
+
+	// hookMu guards the replaceable lifecycle runner and its explicit working
+	// directory. SetHookScope may run from the TUI's /cd path while
+	// tool workers are active; workers snapshot both and release the lock
+	// before any hook subprocess I/O.
+	hookMu     sync.RWMutex
+	hookRunner hooks.Runner
+	workingDir string
 
 	// OnOrphanedSteer, when set by the TUI, receives steered messages that lost
 	// the race against a turn's final loop boundary (a Steer landing after the
@@ -258,11 +269,13 @@ func (a *Agent) Usage() llm.Usage {
 }
 
 func New(client *llm.Client, model string, maxTokens int, systemPrompt string) *Agent {
+	wd, _ := os.Getwd()
 	a := &Agent{
-		Client:    client,
-		Model:     model,
-		MaxTokens: maxTokens,
-		Messages:  []llm.Message{{Role: "system", Content: systemPrompt}},
+		Client:     client,
+		Model:      model,
+		MaxTokens:  maxTokens,
+		Messages:   []llm.Message{{Role: "system", Content: systemPrompt}},
+		workingDir: wd,
 	}
 	a.Tools = tools.All()
 	if !a.BrowserDisabled {
@@ -278,6 +291,53 @@ func New(client *llm.Client, model string, maxTokens int, systemPrompt string) *
 	a.files = newFileLocks()
 	a.bg = newTaskRegistry()
 	return a
+}
+
+// SetHooks atomically replaces the lifecycle runner used by future events.
+// In-flight events keep the immutable runner snapshot they already took.
+func (a *Agent) SetHooks(runner hooks.Runner) {
+	a.hookMu.Lock()
+	a.hookRunner = runner
+	a.hookMu.Unlock()
+}
+
+// SetHookScope atomically replaces the lifecycle runner and command working
+// directory. Reload paths use this instead of two independent setters so an
+// event can never pair a new manager with the previous directory.
+func (a *Agent) SetHookScope(runner hooks.Runner, dir string) {
+	a.hookMu.Lock()
+	a.hookRunner = runner
+	a.workingDir = dir
+	a.hookMu.Unlock()
+}
+
+// SetWorkingDir publishes the directory included in hook payloads and used as
+// each hook command's cwd. It is separate from os.Chdir so ACP sessions and
+// subagent worktrees can carry their own roots.
+func (a *Agent) SetWorkingDir(dir string) {
+	a.hookMu.Lock()
+	a.workingDir = dir
+	a.hookMu.Unlock()
+}
+
+func (a *Agent) hookSnapshot() (hooks.Runner, string) {
+	a.hookMu.RLock()
+	defer a.hookMu.RUnlock()
+	return a.hookRunner, a.workingDir
+}
+
+func (a *Agent) runHook(ctx context.Context, req hooks.Request, ev Events) hooks.Outcome {
+	runner, dir := a.hookSnapshot()
+	if runner == nil {
+		return hooks.Outcome{}
+	}
+	req.SessionID = a.SessionIDValue()
+	req.WorkingDir = dir
+	outcome := runner.Run(ctx, req)
+	if ev.OnHook != nil && (outcome.Ran > 0 || outcome.Blocked || outcome.AdditionalContext != "" || len(outcome.Failures) > 0) {
+		ev.OnHook(req.Event, outcome)
+	}
+	return outcome
 }
 
 // MessagesSnapshot returns a copy of the conversation safe to read while a
@@ -374,6 +434,19 @@ func (a *Agent) TurnWithImages(ctx context.Context, input string, parts []llm.Co
 }
 
 func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart, authored bool, ev Events) (string, error) {
+	promptHook := a.runHook(ctx, hooks.Request{
+		Event:          hooks.UserPromptSubmit,
+		MatcherContext: input,
+		Message:        input,
+	}, ev)
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	if promptHook.Blocked {
+		return "", fmt.Errorf("prompt blocked by hook: %s", hookReason(promptHook))
+	}
+	input = withHookContext(input, hooks.UserPromptSubmit, promptHook.AdditionalContext)
+
 	// Decay old tool output before the new user message lands: the pass only
 	// prunes history outside the hot window, and running it pre-append keeps
 	// the new message (and this turn's tool results) inside the window where
@@ -395,6 +468,7 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 	a.Messages = append(a.Messages, msg)
 	a.msgsMu.Unlock()
 	rounds := 0
+	stopBlocks := 0
 	for {
 		if a.MaxTurns > 0 && rounds >= a.MaxTurns {
 			return "", fmt.Errorf("max turns (%d) reached — the model kept calling tools; re-run with a higher -max-turns or a more specific prompt", a.MaxTurns)
@@ -484,6 +558,32 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 			a.msgsMu.Unlock()
 		}
 		if len(msg.ToolCalls) == 0 && len(steered) == 0 {
+			// Three rejected completions already produced three revision rounds.
+			// Accept the next draft without running Stop again; emitting another
+			// blocked outcome while ignoring it would make telemetry lie.
+			if stopBlocks >= maxStopHookRetries {
+				a.compacted = false
+				return msg.Content, nil
+			}
+			stopHook := a.runHook(ctx, hooks.Request{
+				Event:                hooks.Stop,
+				LastAssistantMessage: msg.Content,
+			}, ev)
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			if stopHook.Blocked {
+				stopBlocks++
+				feedback := "[Stop hook blocked completion] " + hookReason(stopHook)
+				feedback = withHookContext(feedback, hooks.Stop, stopHook.AdditionalContext)
+				if ev.OnSteer != nil {
+					ev.OnSteer(feedback)
+				}
+				a.msgsMu.Lock()
+				a.Messages = append(a.Messages, llm.Message{Role: "user", Content: feedback})
+				a.msgsMu.Unlock()
+				continue
+			}
 			a.compacted = false // reset for the next Turn
 			return msg.Content, nil
 		}
@@ -552,6 +652,35 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 		go func(i int, tc llm.ToolCall) {
 			defer wg.Done()
 			name, args := tc.Function.Name, tc.Function.Arguments
+			finish := func(out string, started time.Time, code int) {
+				ms := time.Since(started).Milliseconds()
+				if ev.OnToolEnd != nil {
+					ev.OnToolEnd(tc.ID, name, out)
+				}
+				outCh <- outcome{i, out, ms, code}
+			}
+
+			// Policy runs before mutation semaphores: hook subprocess I/O must
+			// never hold a file/global lock needed by another tool worker.
+			pre := a.runHook(ctx, hooks.Request{
+				Event:          hooks.PreToolUse,
+				MatcherContext: name,
+				ToolName:       name,
+				ToolInput:      json.RawMessage(args),
+				ToolCallID:     tc.ID,
+			}, ev)
+			if pre.Blocked || ctx.Err() != nil {
+				if ev.OnToolStart != nil {
+					ev.OnToolStart(tc.ID, name, args)
+				}
+				started := time.Now()
+				out := "Error: tool call blocked by hook: " + hookReason(pre)
+				if ctx.Err() != nil {
+					out = "Error: " + ctx.Err().Error()
+				}
+				finish(tools.Truncate(out), started, 1)
+				return
+			}
 
 			// Serialize against other mutations before starting. Acquiring here
 			// (before OnToolStart) keeps "running" rows honest: a tool only
@@ -563,7 +692,11 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 				release = a.files.acquireGlobal()
 			}
 			if release != nil {
-				defer release()
+				defer func() {
+					if release != nil {
+						release()
+					}
+				}()
 			}
 
 			if ev.OnToolStart != nil {
@@ -579,11 +712,33 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 				})
 			}
 			out := tools.Execute(callCtx, a.AllTools(), name, json.RawMessage(args))
-			ms := time.Since(start).Milliseconds()
-			if ev.OnToolEnd != nil {
-				ev.OnToolEnd(tc.ID, name, out)
+			code := toolExitCode(out)
+			if release != nil {
+				release()
+				release = nil
 			}
-			outCh <- outcome{i, out, ms, toolExitCode(out)}
+			postEvent := hooks.PostToolUse
+			postReq := hooks.Request{
+				Event:          postEvent,
+				MatcherContext: name,
+				ToolName:       name,
+				ToolInput:      json.RawMessage(args),
+				ToolResponse:   out,
+				ToolCallID:     tc.ID,
+			}
+			if code != 0 {
+				postEvent = hooks.PostToolUseFailure
+				postReq.Event = postEvent
+				postReq.ToolError = out
+				postReq.ToolResponse = ""
+			}
+			post := a.runHook(ctx, postReq, ev)
+			out = tools.Truncate(withHookContext(
+				out,
+				postEvent,
+				joinHookContext(pre.AdditionalContext, post.AdditionalContext),
+			))
+			finish(out, start, code)
 		}(i, tc)
 	}
 
@@ -604,10 +759,45 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 // by prefixing their output; 0 means success, 1 means the tool reported a
 // failure. Best-effort: the exact status lives in the tool, not the output.
 func toolExitCode(out string) int {
-	if strings.HasPrefix(out, "error") || strings.HasPrefix(out, "Error") {
+	if strings.HasPrefix(out, "error") || strings.HasPrefix(out, "Error") ||
+		strings.Contains(out, "\n((exit:") || strings.HasSuffix(out, "(command timed out)") ||
+		strings.HasSuffix(out, "\n(timed out)") || strings.HasSuffix(out, "\n(cancelled)") ||
+		strings.HasSuffix(out, "\n(timed out waiting for input)") {
 		return 1
 	}
 	return 0
+}
+
+const maxStopHookRetries = 3
+
+func hookReason(outcome hooks.Outcome) string {
+	if reason := strings.TrimSpace(outcome.Reason); reason != "" {
+		return reason
+	}
+	if context := strings.TrimSpace(outcome.AdditionalContext); context != "" {
+		return context
+	}
+	return "blocked by lifecycle policy"
+}
+
+func withHookContext(base string, event hooks.Event, additional string) string {
+	additional = strings.TrimSpace(additional)
+	if additional == "" {
+		return base
+	}
+	return base + fmt.Sprintf("\n\n<hook_context event=%q>\n%s\n</hook_context>", event, additional)
+}
+
+func joinHookContext(first, second string) string {
+	first = strings.TrimSpace(first)
+	second = strings.TrimSpace(second)
+	if first == "" {
+		return second
+	}
+	if second == "" {
+		return first
+	}
+	return first + "\n\n" + second
 }
 
 // compactKeepBack counts assistant turns (and any tool results they pulled in)

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/context-labs/whip/internal/hooks"
 	"github.com/context-labs/whip/internal/llm"
 )
 
@@ -377,6 +378,7 @@ func (a *Agent) RegisterBackground(description, prompt string, o SubModel) *Back
 // the same to the model either way.
 func (a *Agent) LaunchBackground(t *BackgroundTask, worktreePath string) {
 	if worktreePath != "" {
+		t.sub.SetWorkingDir(worktreePath)
 		t.sub.Steer("Work entirely inside the git worktree at " + worktreePath + " (run `cd " + worktreePath + "` first; it is your own branch, isolated from other agents). Commit your changes there.")
 	}
 	a.launchBackground(t)
@@ -553,6 +555,13 @@ func (r *taskRegistry) emitter(id string) Events {
 			for _, e := range r.emitLocked(id, 0, "", "", false) {
 				if e.OnCompact != nil {
 					e.OnCompact(took, kept)
+				}
+			}
+		},
+		OnHook: func(event hooks.Event, outcome hooks.Outcome) {
+			for _, e := range r.emitLocked(id, 0, "", "", false) {
+				if e.OnHook != nil {
+					e.OnHook(event, outcome)
 				}
 			}
 		},

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -1,6 +1,9 @@
 package agent
 
-import "github.com/context-labs/whip/internal/llm"
+import (
+	"github.com/context-labs/whip/internal/hooks"
+	"github.com/context-labs/whip/internal/llm"
+)
 
 // FanIn multiplexes several Events values into one: every fired callback is
 // invoked on each source that implements it. A background worker runs its
@@ -55,6 +58,13 @@ func FanIn(evs ...Events) Events {
 			for _, e := range evs {
 				if e.OnCompact != nil {
 					e.OnCompact(took, kept)
+				}
+			}
+		},
+		OnHook: func(event hooks.Event, outcome hooks.Outcome) {
+			for _, e := range evs {
+				if e.OnHook != nil {
+					e.OnHook(event, outcome)
 				}
 			}
 		},

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1,0 +1,444 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/context-labs/whip/internal/hooks"
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools"
+)
+
+func hookToolCall(id, name, args string) llm.ToolCall {
+	call := llm.ToolCall{ID: id, Type: "function"}
+	call.Function.Name = name
+	call.Function.Arguments = args
+	return call
+}
+
+type recordingHookRunner struct {
+	mu       sync.Mutex
+	requests []hooks.Request
+	run      func(hooks.Request) hooks.Outcome
+}
+
+func (r *recordingHookRunner) Run(_ context.Context, req hooks.Request) hooks.Outcome {
+	r.mu.Lock()
+	r.requests = append(r.requests, req)
+	fn := r.run
+	r.mu.Unlock()
+	if fn != nil {
+		return fn(req)
+	}
+	return hooks.Outcome{}
+}
+
+func (r *recordingHookRunner) snapshot() []hooks.Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]hooks.Request(nil), r.requests...)
+}
+
+func TestPromptHookAddsContextAndReceivesSession(t *testing.T) {
+	var providerUser string
+	srv := textServer(t, func(_ int, req llm.Request) string {
+		for _, msg := range req.Messages {
+			if msg.Role == "user" {
+				providerUser = msg.Content
+			}
+		}
+		return "done"
+	})
+	defer srv.Close()
+
+	runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		if req.Event == hooks.UserPromptSubmit {
+			return hooks.Outcome{AdditionalContext: "follow the repository policy", Ran: 1}
+		}
+		return hooks.Outcome{}
+	}}
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.SetHooks(runner)
+	ag.SetWorkingDir("/workspace/project")
+	ag.SetSessionID("session-7")
+
+	var events []hooks.Event
+	final, err := ag.Turn(t.Context(), "ship it", Events{
+		OnHook: func(event hooks.Event, _ hooks.Outcome) { events = append(events, event) },
+	})
+	if err != nil || final != "done" {
+		t.Fatalf("Turn = %q, %v", final, err)
+	}
+	if !strings.Contains(providerUser, "ship it") || !strings.Contains(providerUser, "follow the repository policy") {
+		t.Fatalf("provider user message did not include hook context: %q", providerUser)
+	}
+	requests := runner.snapshot()
+	if len(requests) != 2 || requests[0].Event != hooks.UserPromptSubmit || requests[1].Event != hooks.Stop {
+		t.Fatalf("hook sequence = %+v", requests)
+	}
+	if requests[0].SessionID != "session-7" || requests[0].WorkingDir != "/workspace/project" {
+		t.Fatalf("hook scope = %+v", requests[0])
+	}
+	if len(events) != 1 || events[0] != hooks.UserPromptSubmit {
+		t.Fatalf("event callback sequence = %v", events)
+	}
+}
+
+func TestPromptHookBlocksBeforeConversationMutation(t *testing.T) {
+	runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		return hooks.Outcome{Blocked: true, Reason: "prompt rejected", Ran: 1}
+	}}
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag.SetHooks(runner)
+
+	_, err := ag.Turn(t.Context(), "do not send", Events{})
+	if err == nil || !strings.Contains(err.Error(), "prompt rejected") {
+		t.Fatalf("blocked prompt error = %v", err)
+	}
+	if len(ag.Messages) != 1 {
+		t.Fatalf("blocked prompt mutated conversation: %+v", ag.Messages)
+	}
+}
+
+func TestToolHooksBlockAndAnnotateResults(t *testing.T) {
+	var ran atomic.Int32
+	testTool := tools.Tool{
+		Def: llm.NewTool("probe", "probe", `{"type":"object"}`),
+		Run: func(context.Context, json.RawMessage) (string, error) {
+			ran.Add(1)
+			return "tool output", nil
+		},
+	}
+
+	t.Run("pre policy blocks execution", func(t *testing.T) {
+		ran.Store(0)
+		runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+			if req.Event == hooks.PreToolUse {
+				return hooks.Outcome{Blocked: true, Reason: "unsafe command", Ran: 1}
+			}
+			return hooks.Outcome{}
+		}}
+		ag := New(nil, "m", 100, "sys")
+		ag.Tools = []tools.Tool{testTool}
+		ag.SetHooks(runner)
+		out := ag.runTools(t.Context(), []llm.ToolCall{hookToolCall("call-1", "probe", `{}`)}, Events{})
+		if ran.Load() != 0 {
+			t.Fatal("blocked tool executed")
+		}
+		if len(out) != 1 || !strings.Contains(out[0], "unsafe command") {
+			t.Fatalf("blocked output = %v", out)
+		}
+		requests := runner.snapshot()
+		if len(requests) != 1 || requests[0].Event != hooks.PreToolUse {
+			t.Fatalf("blocked hook sequence = %+v", requests)
+		}
+	})
+
+	t.Run("pre policy block stays bounded", func(t *testing.T) {
+		t.Setenv("TMPDIR", t.TempDir())
+		ran.Store(0)
+		reason := strings.Repeat("x", 60_000)
+		runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+			if req.Event == hooks.PreToolUse {
+				return hooks.Outcome{Blocked: true, Reason: reason, Ran: 1}
+			}
+			return hooks.Outcome{}
+		}}
+		ag := New(nil, "m", 100, "sys")
+		ag.Tools = []tools.Tool{testTool}
+		ag.SetHooks(runner)
+		out := ag.runTools(t.Context(), []llm.ToolCall{hookToolCall("bounded-block", "probe", `{}`)}, Events{})
+		if ran.Load() != 0 {
+			t.Fatal("blocked tool executed")
+		}
+		if len(out) != 1 {
+			t.Fatalf("tool results = %d, want 1", len(out))
+		}
+		if !strings.Contains(out[0], "bytes elided from the middle") || len(out[0]) >= len(reason) {
+			t.Fatalf("blocked tool result was not bounded: lengths=%d", len(out[0]))
+		}
+	})
+
+	t.Run("pre and post context reaches model", func(t *testing.T) {
+		ran.Store(0)
+		runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+			switch req.Event {
+			case hooks.PreToolUse:
+				return hooks.Outcome{AdditionalContext: "pre context", Ran: 1}
+			case hooks.PostToolUse:
+				return hooks.Outcome{AdditionalContext: "post context", Ran: 1}
+			default:
+				return hooks.Outcome{}
+			}
+		}}
+		ag := New(nil, "m", 100, "sys")
+		ag.Tools = []tools.Tool{testTool}
+		ag.SetHooks(runner)
+		out := ag.runTools(t.Context(), []llm.ToolCall{hookToolCall("call-2", "probe", `{}`)}, Events{})
+		if ran.Load() != 1 {
+			t.Fatalf("tool runs = %d", ran.Load())
+		}
+		if !strings.Contains(out[0], "tool output") || !strings.Contains(out[0], "pre context") || !strings.Contains(out[0], "post context") {
+			t.Fatalf("annotated output = %q", out[0])
+		}
+		requests := runner.snapshot()
+		if len(requests) != 2 || requests[1].Event != hooks.PostToolUse || requests[1].ToolResponse != "tool output" {
+			t.Fatalf("success hook sequence = %+v", requests)
+		}
+	})
+}
+
+func TestFailedToolFiresPostToolUseFailure(t *testing.T) {
+	runner := &recordingHookRunner{}
+	ag := New(nil, "m", 100, "sys")
+	ag.Tools = []tools.Tool{{
+		Def: llm.NewTool("fail", "fail", `{"type":"object"}`),
+		Run: func(context.Context, json.RawMessage) (string, error) {
+			return "", errors.New("boom")
+		},
+	}}
+	ag.SetHooks(runner)
+	out := ag.runTools(t.Context(), []llm.ToolCall{hookToolCall("call-fail", "fail", `{}`)}, Events{})
+	if len(out) != 1 || out[0] != "Error: boom" {
+		t.Fatalf("failure output = %v", out)
+	}
+	requests := runner.snapshot()
+	if len(requests) != 2 || requests[1].Event != hooks.PostToolUseFailure || requests[1].ToolError != "Error: boom" {
+		t.Fatalf("failure hook sequence = %+v", requests)
+	}
+}
+
+func TestHookContextKeepsToolResultBounded(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	additional := strings.Repeat("x", 60_000)
+	runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		if req.Event == hooks.PostToolUse {
+			return hooks.Outcome{AdditionalContext: additional, Ran: 1}
+		}
+		return hooks.Outcome{}
+	}}
+	ag := New(nil, "m", 100, "sys")
+	ag.Tools = []tools.Tool{{
+		Def: llm.NewTool("probe", "probe", `{"type":"object"}`),
+		Run: func(context.Context, json.RawMessage) (string, error) {
+			return "tool output", nil
+		},
+	}}
+	ag.SetHooks(runner)
+
+	out := ag.runTools(t.Context(), []llm.ToolCall{hookToolCall("bounded", "probe", `{}`)}, Events{})
+	if len(out) != 1 {
+		t.Fatalf("tool results = %d, want 1", len(out))
+	}
+	if !strings.Contains(out[0], "bytes elided from the middle") {
+		t.Fatalf("hook-annotated tool result was not bounded: lengths=%d", len(out[0]))
+	}
+	if len(out[0]) >= len(additional) {
+		t.Fatalf("bounded result length = %d, want less than original context %d", len(out[0]), len(additional))
+	}
+}
+
+func TestFailedToolStatusSurvivesLargeHookContext(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		if req.Event == hooks.PostToolUseFailure {
+			return hooks.Outcome{AdditionalContext: strings.Repeat("x", 60_000), Ran: 1}
+		}
+		return hooks.Outcome{}
+	}}
+	ag := New(nil, "m", 100, "sys")
+	ag.Tools = []tools.Tool{{
+		Def: llm.NewTool("failed-command", "failed command", `{"type":"object"}`),
+		Run: func(context.Context, json.RawMessage) (string, error) {
+			return "partial\n((exit: exit status 2))", nil
+		},
+	}}
+	ag.SetHooks(runner)
+	calls := []llm.ToolCall{hookToolCall("failed-with-context", "failed-command", `{}`)}
+	out := ag.runTools(t.Context(), calls, Events{})
+
+	if calls[0].ExitCode != 1 {
+		t.Fatalf("tool exit code = %d, want failure after hook annotation", calls[0].ExitCode)
+	}
+	if len(out) != 1 {
+		t.Fatalf("tool results = %d, want 1", len(out))
+	}
+	if !strings.Contains(out[0], "bytes elided from the middle") {
+		t.Fatalf("failed hook-annotated result was not bounded: lengths=%d", len(out[0]))
+	}
+	requests := runner.snapshot()
+	if len(requests) != 2 || requests[1].Event != hooks.PostToolUseFailure {
+		t.Fatalf("failure hook sequence = %+v", requests)
+	}
+}
+
+func TestToolExitCodeClassifiesBashFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want int
+	}{
+		{name: "success", out: "ok", want: 0},
+		{name: "tool error", out: "Error: boom", want: 1},
+		{name: "non-interactive exit", out: "oops\n((exit: exit status 2))", want: 1},
+		{name: "non-interactive timeout", out: "partial\n(command timed out)", want: 1},
+		{name: "interactive timeout", out: "partial\n(timed out)", want: 1},
+		{name: "interactive cancellation", out: "partial\n(cancelled)", want: 1},
+		{name: "interactive inactivity timeout", out: "partial\n(timed out waiting for input)", want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toolExitCode(tt.out); got != tt.want {
+				t.Fatalf("toolExitCode(%q) = %d, want %d", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStopHookRetriesAreBounded(t *testing.T) {
+	srv := textServer(t, func(n int, _ llm.Request) string { return fmt.Sprintf("draft-%d", n) })
+	defer srv.Close()
+
+	var stops atomic.Int32
+	runner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		if req.Event == hooks.Stop {
+			stops.Add(1)
+			return hooks.Outcome{Blocked: true, Reason: "needs revision", Ran: 1}
+		}
+		return hooks.Outcome{}
+	}}
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.SetHooks(runner)
+	final, err := ag.Turn(t.Context(), "answer", Events{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final != "draft-4" || stops.Load() != maxStopHookRetries {
+		t.Fatalf("bounded stop result = %q, calls = %d", final, stops.Load())
+	}
+	feedback := 0
+	for _, msg := range ag.Messages {
+		if msg.Role == "user" && strings.Contains(msg.Content, "Stop hook blocked completion") {
+			feedback++
+		}
+	}
+	if feedback != maxStopHookRetries {
+		t.Fatalf("stop feedback messages = %d, want %d", feedback, maxStopHookRetries)
+	}
+}
+
+func TestSubagentInheritsHookRunnerAndScope(t *testing.T) {
+	runner := &recordingHookRunner{}
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag.SetHooks(runner)
+	ag.SetWorkingDir("/workspace/project")
+	ag.SetSessionID("session-parent")
+
+	sub := ag.newSub(SubModel{})
+	gotRunner, gotDir := sub.hookSnapshot()
+	if gotRunner != runner || gotDir != "/workspace/project" {
+		t.Fatalf("subagent hook scope = %T, %q", gotRunner, gotDir)
+	}
+	if sub.SessionIDValue() != "session-parent" {
+		t.Fatalf("subagent session = %q", sub.SessionIDValue())
+	}
+}
+
+func TestBackgroundSubagentHooksUseWorktreeDirectory(t *testing.T) {
+	srv := textServer(t, func(_ int, _ llm.Request) string { return "done" })
+	defer srv.Close()
+
+	runner := &recordingHookRunner{}
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.SetHooks(runner)
+	ag.SetWorkingDir("/workspace/project")
+	worktree := t.TempDir()
+	task := ag.RegisterBackground("worktree scope", "inspect", SubModel{})
+	ag.LaunchBackground(task, worktree)
+
+	select {
+	case <-task.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background subagent did not finish")
+	}
+	requests := runner.snapshot()
+	if len(requests) != 2 || requests[0].Event != hooks.UserPromptSubmit || requests[1].Event != hooks.Stop {
+		t.Fatalf("background hook sequence = %+v", requests)
+	}
+	for _, req := range requests {
+		if req.WorkingDir != worktree {
+			t.Fatalf("background hook working directory = %q, want %q", req.WorkingDir, worktree)
+		}
+	}
+}
+
+func TestHookManagerSwapDoesNotWaitForHookIO(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	oldRunner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		if req.Event == hooks.PreToolUse {
+			close(started)
+			<-release
+			return hooks.Outcome{AdditionalContext: "old manager", Ran: 1}
+		}
+		return hooks.Outcome{}
+	}}
+	newRunner := &recordingHookRunner{run: func(req hooks.Request) hooks.Outcome {
+		if req.Event == hooks.PostToolUse {
+			return hooks.Outcome{AdditionalContext: "new manager", Ran: 1}
+		}
+		return hooks.Outcome{}
+	}}
+	ag := New(nil, "m", 100, "sys")
+	ag.Tools = []tools.Tool{{
+		Def: llm.NewTool("probe", "probe", `{"type":"object"}`),
+		Run: func(context.Context, json.RawMessage) (string, error) { return "done", nil },
+	}}
+	ag.SetHookScope(oldRunner, "/old")
+
+	result := make(chan []string, 1)
+	go func() {
+		result <- ag.runTools(t.Context(), []llm.ToolCall{hookToolCall("swap", "probe", `{}`)}, Events{})
+	}()
+	select {
+	case <-started:
+	case <-t.Context().Done():
+		t.Fatal("pre-hook did not start")
+	}
+
+	swapped := make(chan struct{})
+	go func() {
+		ag.SetHookScope(newRunner, "/new")
+		close(swapped)
+	}()
+	select {
+	case <-swapped:
+	case <-time.After(time.Second):
+		t.Fatal("manager swap waited for hook subprocess I/O")
+	}
+	close(release)
+
+	select {
+	case out := <-result:
+		if len(out) != 1 || !strings.Contains(out[0], "old manager") || !strings.Contains(out[0], "new manager") {
+			t.Fatalf("result across manager swap = %v", out)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tool did not finish after releasing pre-hook")
+	}
+	oldRequests := oldRunner.snapshot()
+	newRequests := newRunner.snapshot()
+	if len(oldRequests) != 1 || oldRequests[0].WorkingDir != "/old" {
+		t.Fatalf("old manager scope = %+v", oldRequests)
+	}
+	if len(newRequests) != 1 || newRequests[0].WorkingDir != "/new" {
+		t.Fatalf("new manager scope = %+v", newRequests)
+	}
+}

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -48,6 +48,9 @@ func (a *Agent) newSub(o SubModel) *Agent {
 	sub.Effort = a.Effort
 	sub.ContextLimit = o.ContextLimit
 	sub.Tools = tools.All()
+	runner, dir := a.hookSnapshot()
+	sub.SetHookScope(runner, dir)
+	sub.SetSessionID(a.SessionIDValue())
 	return sub
 }
 

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -48,7 +48,12 @@ func TestProfileScanFindsPortFile(t *testing.T) {
 	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	prof := filepath.Join(home, ".config", "google-chrome")
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	dirs := profileDirs()
+	if len(dirs) == 0 {
+		t.Fatal("no profile directories for this platform")
+	}
+	prof := dirs[0]
 	if err := os.MkdirAll(prof, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/computer/embed_darwin.go
+++ b/internal/computer/embed_darwin.go
@@ -11,10 +11,12 @@ package computer
 
 import (
 	_ "embed"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 )
+
+const helperFilename = "whip-computer"
 
 // helperBinary is empty until `task driver` builds the Swift driver and
 // copies it into internal/computer/bin/ (go:embed needs the file at build
@@ -29,7 +31,7 @@ func helperDest() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".whip", "bin", "whip-computer"), nil
+	return filepath.Join(home, ".whip", "bin", helperFilename), nil
 }
 
 // ensureHelperBinary extracts the embedded helper to ~/.whip/bin (once —
@@ -51,19 +53,30 @@ func ensureHelperBinary() (string, error) {
 				return abs, nil
 			}
 		}
-		return "", fmt.Errorf("no whip-computer helper embedded and none built — run `task driver` (macOS, needs Xcode CLT)")
+		return "", errors.New("no whip-computer helper embedded and none built — run `task driver` (macOS, needs Xcode CLT)")
 	}
-	if existing, err := os.ReadFile(dest); err == nil && bytesEqual(existing, helperBinary) {
+	dir := filepath.Dir(dest)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	if existing, err := root.ReadFile(helperFilename); err == nil && bytesEqual(existing, helperBinary) {
 		return dest, nil
 	}
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+	tmp := helperFilename + ".tmp"
+	if err := root.WriteFile(tmp, helperBinary, 0o600); err != nil {
 		return "", err
 	}
-	tmp := dest + ".tmp"
-	if err := os.WriteFile(tmp, helperBinary, 0o755); err != nil {
+	if err := root.Chmod(tmp, 0o700); err != nil {
+		_ = root.Remove(tmp)
 		return "", err
 	}
-	if err := os.Rename(tmp, dest); err != nil {
+	if err := root.Rename(tmp, helperFilename); err != nil {
+		_ = root.Remove(tmp)
 		return "", err
 	}
 	return dest, nil

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -1,0 +1,337 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	maxConfigBytes  = 1 << 20
+	maxCommandBytes = 32 << 10
+	maxActions      = 128
+	maxTimeout      = 10 * time.Minute
+)
+
+type configFlavor int
+
+const (
+	flavorPlugin configFlavor = iota
+	flavorProject
+)
+
+// LoadOptions control hook discovery. User plugins are always included;
+// IncludeProject gates every project-owned executable configuration.
+type LoadOptions struct {
+	WorkingDir     string
+	HomeDir        string
+	IncludeProject bool
+}
+
+// Manager is an immutable, concurrent-safe set of normalized hook commands.
+type Manager struct {
+	actions        map[Event][]action
+	warnings       []string
+	disabled       bool
+	projectEnabled bool
+}
+
+// Load discovers user plugins first, project plugins second, and the project's
+// hook file last. Files and plugin directories are sorted
+// so command order is stable across filesystems.
+func Load(opts LoadOptions) *Manager {
+	m := &Manager{
+		actions:        make(map[Event][]action),
+		projectEnabled: opts.IncludeProject,
+	}
+	if os.Getenv("WHIP_DISABLE_HOOKS") == "1" {
+		m.disabled = true
+		return m
+	}
+	if opts.WorkingDir == "" {
+		opts.WorkingDir, _ = os.Getwd()
+	}
+	if opts.HomeDir == "" {
+		opts.HomeDir, _ = os.UserHomeDir()
+	}
+
+	seen := map[string]bool{}
+	if opts.HomeDir != "" {
+		m.loadPlugins(filepath.Join(opts.HomeDir, ".agents", "plugins"), "user plugin", seen)
+	}
+	if opts.IncludeProject && opts.WorkingDir != "" {
+		m.loadPlugins(filepath.Join(opts.WorkingDir, ".agents", "plugins"), "project plugin", seen)
+		m.loadFile(
+			filepath.Join(opts.WorkingDir, ".whip", "hooks.json"),
+			"project hook",
+			opts.WorkingDir,
+			flavorProject,
+			seen,
+		)
+	}
+	return m
+}
+
+// Entries returns loaded commands in execution order.
+func (m *Manager) Entries() []Entry {
+	if m == nil {
+		return []Entry{}
+	}
+	out := make([]Entry, 0, m.Count())
+	for _, event := range eventOrder {
+		for _, a := range m.actions[event] {
+			out = append(out, Entry{
+				Event:   event,
+				Source:  a.source,
+				Matcher: a.matcher.String(),
+				Command: a.command,
+			})
+		}
+	}
+	return out
+}
+
+// Warnings returns a defensive copy of discovery and validation problems.
+func (m *Manager) Warnings() []string {
+	if m == nil {
+		return []string{}
+	}
+	return append([]string{}, m.warnings...)
+}
+
+// Count returns the number of runnable commands.
+func (m *Manager) Count() int {
+	if m == nil {
+		return 0
+	}
+	n := 0
+	for _, actions := range m.actions {
+		n += len(actions)
+	}
+	return n
+}
+
+// Disabled reports whether WHIP_DISABLE_HOOKS=1 suppressed discovery.
+func (m *Manager) Disabled() bool { return m != nil && m.disabled }
+
+// ProjectEnabled reports whether project hook files were trusted and loaded.
+func (m *Manager) ProjectEnabled() bool { return m != nil && m.projectEnabled }
+
+func (m *Manager) loadPlugins(base, label string, seen map[string]bool) {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			m.warn("%s: %v", base, err)
+		}
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		root := filepath.Join(base, entry.Name())
+		m.loadFile(
+			filepath.Join(root, "hooks", "hooks.json"),
+			label+" "+entry.Name(),
+			root,
+			flavorPlugin,
+			seen,
+		)
+	}
+}
+
+type rawRule struct {
+	Matcher *string     `json:"matcher"`
+	Hooks   []rawAction `json:"hooks"`
+}
+
+type rawAction struct {
+	Type      string `json:"type"`
+	Command   string `json:"command"`
+	Timeout   int    `json:"timeout"`
+	Async     bool   `json:"async"`
+	OnFailure string `json:"on_failure"`
+}
+
+func (m *Manager) loadFile(path, source, pluginRoot string, flavor configFlavor, seen map[string]bool) {
+	clean := filepath.Clean(path)
+	if seen[clean] {
+		return
+	}
+	seen[clean] = true
+	info, err := os.Stat(clean)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			m.warn("%s: %v", clean, err)
+		}
+		return
+	}
+	if info.Size() > maxConfigBytes {
+		m.warn("%s: config exceeds %d bytes", clean, maxConfigBytes)
+		return
+	}
+	data, err := os.ReadFile(clean)
+	if err != nil {
+		m.warn("%s: %v", clean, err)
+		return
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		m.warn("%s: invalid json: %v", clean, err)
+		return
+	}
+	events := root
+	if wrapped, ok := root["hooks"]; ok {
+		if err := json.Unmarshal(wrapped, &events); err != nil {
+			m.warn("%s: hooks must be an object: %v", clean, err)
+			return
+		}
+	}
+
+	keys := make([]string, 0, len(events))
+	for key := range events {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		event, ok := parseEvent(key)
+		if !ok {
+			if key != "version" {
+				m.warn("%s: unsupported event %q", clean, key)
+			}
+			continue
+		}
+		var rules []rawRule
+		if err := json.Unmarshal(events[key], &rules); err != nil {
+			m.warn("%s: event %s must be an array: %v", clean, event, err)
+			continue
+		}
+		for ruleIndex, rule := range rules {
+			match, err := compileMatcher(rule.Matcher, flavor)
+			if err != nil {
+				m.warn("%s: %s rule %d: %v", clean, event, ruleIndex+1, err)
+				continue
+			}
+			for actionIndex, raw := range rule.Hooks {
+				if m.Count() >= maxActions {
+					m.warn("hook limit reached (%d); remaining commands skipped", maxActions)
+					return
+				}
+				a, ok := normalizeAction(
+					raw,
+					event,
+					match,
+					source,
+					pluginRoot,
+					flavor,
+				)
+				if !ok {
+					m.warn("%s: %s rule %d action %d is invalid", clean, event, ruleIndex+1, actionIndex+1)
+					continue
+				}
+				m.actions[event] = append(m.actions[event], a)
+			}
+		}
+	}
+}
+
+func normalizeAction(
+	raw rawAction,
+	event Event,
+	match matcher,
+	source string,
+	pluginRoot string,
+	flavor configFlavor,
+) (action, bool) {
+	typ := raw.Type
+	if typ == "" {
+		typ = "command"
+	}
+	if typ != "command" || raw.Async || raw.Command == "" || len(raw.Command) > maxCommandBytes {
+		return action{}, false
+	}
+	if raw.Timeout < 0 {
+		return action{}, false
+	}
+	timeout := 30 * time.Second
+	if flavor == flavorProject {
+		timeout = 60 * time.Second
+	}
+	if raw.Timeout > 0 {
+		seconds := min(raw.Timeout, int(maxTimeout/time.Second))
+		timeout = time.Duration(seconds) * time.Second
+	}
+	onFailureBlock := false
+	if event == PreToolUse {
+		switch raw.OnFailure {
+		case "", "allow":
+		case "block":
+			onFailureBlock = true
+		default:
+			return action{}, false
+		}
+	}
+	return action{
+		event:          event,
+		source:         source,
+		pluginRoot:     pluginRoot,
+		command:        raw.Command,
+		timeout:        timeout,
+		matcher:        match,
+		onFailureBlock: onFailureBlock,
+	}, true
+}
+
+func parseEvent(name string) (Event, bool) {
+	normalized := strings.ToLower(strings.ReplaceAll(name, "_", ""))
+	for _, event := range eventOrder {
+		if strings.ToLower(string(event)) == normalized {
+			return event, true
+		}
+	}
+	return "", false
+}
+
+type matcher struct {
+	raw string
+	re  *regexp.Regexp
+}
+
+func (m matcher) Match(s string) bool { return m.re == nil || m.re.MatchString(s) }
+
+func (m matcher) String() string {
+	if m.raw == "" {
+		return "<all>"
+	}
+	return m.raw
+}
+
+func compileMatcher(raw *string, flavor configFlavor) (matcher, error) {
+	if raw == nil || *raw == "" {
+		return matcher{}, nil
+	}
+	pattern := *raw
+	if flavor == flavorProject && pattern == "*" {
+		return matcher{raw: pattern}, nil
+	}
+	if flavor == flavorProject && len(pattern) >= 2 && strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") {
+		pattern = pattern[1 : len(pattern)-1]
+	} else if flavor == flavorProject && !strings.ContainsAny(pattern, `\.^$|?*+()[]{}`) {
+		pattern = "^(?:" + regexp.QuoteMeta(pattern) + ")$"
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return matcher{}, fmt.Errorf("invalid matcher %q: %w", *raw, err)
+	}
+	return matcher{raw: *raw, re: re}, nil
+}
+
+func (m *Manager) warn(format string, args ...any) {
+	m.warnings = append(m.warnings, fmt.Sprintf(format, args...))
+}

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -1,0 +1,188 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadDiscoveryOrderAndFormats(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	writeHookConfig(t, filepath.Join(home, ".agents", "plugins", "z-last", "hooks", "hooks.json"), `{
+  "hooks": {"PreToolUse": [{"matcher":"^bash$","hooks":[{"command":"echo user-z"}]}]}
+}`)
+	writeHookConfig(t, filepath.Join(home, ".agents", "plugins", "a-first", "hooks", "hooks.json"), `{
+  "hooks": {"PreToolUse": [{"hooks":[{"command":"echo user-a"}]}]}
+}`)
+	writeHookConfig(t, filepath.Join(project, ".agents", "plugins", "project", "hooks", "hooks.json"), `{
+  "hooks": {"PreToolUse": [{"hooks":[{"command":"echo project"}]}]}
+}`)
+	writeHookConfig(t, filepath.Join(project, ".whip", "hooks.json"), `{
+	  "pre_tool_use": [{"matcher":"*","hooks":[{"command":"echo project-file"}]}]
+}`)
+
+	m := Load(LoadOptions{WorkingDir: project, HomeDir: home, IncludeProject: true})
+	entries := m.Entries()
+	if len(entries) != 4 {
+		t.Fatalf("entries = %d, want 4; warnings=%v", len(entries), m.Warnings())
+	}
+	want := []string{"echo user-a", "echo user-z", "echo project", "echo project-file"}
+	for i := range want {
+		if entries[i].Command != want[i] {
+			t.Fatalf("entry %d command = %q, want %q", i, entries[i].Command, want[i])
+		}
+	}
+	if !entries[1].EventMatches("bash") || entries[1].EventMatches("read") {
+		t.Fatal("plugin matcher should use its regular expression")
+	}
+	if !entries[3].EventMatches("anything") {
+		t.Fatal("project '*' matcher should match every tool")
+	}
+}
+
+func TestLoadTrustDisableAndWarnings(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	writeHookConfig(t, filepath.Join(home, ".agents", "plugins", "user", "hooks", "hooks.json"), `{
+  "hooks": {"Stop": [{"hooks":[{"command":"echo user"}]}]}
+}`)
+	writeHookConfig(t, filepath.Join(project, ".agents", "plugins", "project", "hooks", "hooks.json"), `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"[","hooks":[{"command":"echo bad matcher"}]},
+      {"hooks":[{"command":"echo valid"},{"command":"echo async","async":true}]}
+    ],
+    "FutureEvent": [{"hooks":[{"command":"echo future"}]}]
+  }
+}`)
+
+	userOnly := Load(LoadOptions{WorkingDir: project, HomeDir: home})
+	if userOnly.Count() != 1 || userOnly.ProjectEnabled() {
+		t.Fatalf("untrusted load = %d entries, project=%v", userOnly.Count(), userOnly.ProjectEnabled())
+	}
+
+	trusted := Load(LoadOptions{WorkingDir: project, HomeDir: home, IncludeProject: true})
+	if trusted.Count() != 2 {
+		t.Fatalf("valid entries should survive neighboring errors: count=%d warnings=%v", trusted.Count(), trusted.Warnings())
+	}
+	warnings := strings.Join(trusted.Warnings(), "\n")
+	for _, want := range []string{"invalid matcher", "action 2 is invalid", "unsupported event"} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("warnings missing %q:\n%s", want, warnings)
+		}
+	}
+
+	t.Setenv("WHIP_DISABLE_HOOKS", "1")
+	disabled := Load(LoadOptions{WorkingDir: project, HomeDir: home, IncludeProject: true})
+	if !disabled.Disabled() || disabled.Count() != 0 {
+		t.Fatalf("disabled manager = disabled:%v count:%d", disabled.Disabled(), disabled.Count())
+	}
+}
+
+func TestPluginRootExpandsFromEnvironment(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	home := t.TempDir()
+	root := filepath.Join(home, ".agents", "plugins", "portable plugin")
+	writeHookConfig(t, filepath.Join(root, "hooks", "hooks.json"), `{
+  "hooks": {"Stop": [{"hooks":[{"command":"printf '%s' \"$PLUGIN_ROOT\" > \"$PLUGIN_ROOT/seen\""}]}]}
+}`)
+	m := Load(LoadOptions{HomeDir: home})
+	out := m.Run(t.Context(), Request{Event: Stop, WorkingDir: home})
+	if out.Ran != 1 || len(out.Failures) != 0 {
+		t.Fatalf("plugin-root hook outcome = %+v, warnings = %v", out, m.Warnings())
+	}
+	seen, err := os.ReadFile(filepath.Join(root, "seen"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(seen) != root {
+		t.Fatalf("PLUGIN_ROOT = %q, want %q", seen, root)
+	}
+}
+
+func TestNormalizeActionClampsTimeoutBeforeDurationConversion(t *testing.T) {
+	a, ok := normalizeAction(
+		rawAction{Command: "exit 0", Timeout: int(maxTimeout/time.Second) + 1},
+		PreToolUse,
+		matcher{},
+		"test",
+		t.TempDir(),
+		flavorPlugin,
+	)
+	if !ok || a.timeout != maxTimeout {
+		t.Fatalf("normalized timeout = %s, ok=%v", a.timeout, ok)
+	}
+}
+
+func TestCompileProjectMatchers(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		match   []string
+		reject  []string
+	}{
+		{
+			name:    "wildcard",
+			pattern: "*",
+			match:   []string{"bash", "mcp__server__tool"},
+		},
+		{
+			name:    "exact native tool name",
+			pattern: "bash",
+			match:   []string{"bash"},
+			reject:  []string{"bashful", "prefix-bash"},
+		},
+		{
+			name:    "slash regular expression",
+			pattern: `/^(read|write)$/`,
+			match:   []string{"read", "write"},
+			reject:  []string{"edit", "reader"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := compileMatcher(&tt.pattern, flavorProject)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, value := range tt.match {
+				if !got.Match(value) {
+					t.Errorf("matcher %q did not match %q", tt.pattern, value)
+				}
+			}
+			for _, value := range tt.reject {
+				if got.Match(value) {
+					t.Errorf("matcher %q unexpectedly matched %q", tt.pattern, value)
+				}
+			}
+		})
+	}
+}
+
+func writeHookConfig(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// EventMatches is a test-only adapter that keeps matcher internals private in
+// production while making discovery normalization observable.
+func (e Entry) EventMatches(context string) bool {
+	pattern := e.Matcher
+	if pattern == "<all>" || pattern == "*" {
+		return true
+	}
+	m, err := compileMatcher(&pattern, flavorPlugin)
+	if err != nil {
+		panic(fmt.Sprintf("compiled entry matcher became invalid: %v", err))
+	}
+	return m.Match(context)
+}

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -1,0 +1,260 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/context-labs/whip/internal/tools/bashrun"
+)
+
+const (
+	maxPayloadBytes = 256 << 10
+	maxOutputBytes  = 64 << 10
+	maxEnvBytes     = 64 << 10
+)
+
+type payload struct {
+	Version              int    `json:"version"`
+	Event                Event  `json:"event"`
+	EventType            Event  `json:"event_type"`
+	SessionID            string `json:"session_id,omitempty"`
+	MatcherContext       string `json:"matcher_context,omitempty"`
+	ToolName             string `json:"tool_name,omitempty"`
+	ToolInput            any    `json:"tool_input,omitempty"`
+	ToolResponse         string `json:"tool_response,omitempty"`
+	ToolError            string `json:"tool_error,omitempty"`
+	Message              string `json:"message,omitempty"`
+	LastAssistantMessage string `json:"last_assistant_message,omitempty"`
+	WorkingDir           string `json:"working_dir,omitempty"`
+	ToolCallID           string `json:"tool_call_id,omitempty"`
+}
+
+type commandDecision struct {
+	Decision          string `json:"decision"`
+	Reason            string `json:"reason"`
+	AdditionalContext string `json:"additionalContext"`
+}
+
+type actionResult struct {
+	blocked           bool
+	reason            string
+	additionalContext string
+	failure           string
+}
+
+// Run executes matching commands serially in discovery order. Manager is
+// immutable after Load, so concurrent tool calls may safely share it.
+func (m *Manager) Run(ctx context.Context, req Request) Outcome {
+	out := Outcome{Failures: []string{}}
+	if m == nil || m.disabled {
+		return out
+	}
+	for _, a := range m.actions[req.Event] {
+		if !a.matcher.Match(req.MatcherContext) {
+			continue
+		}
+		out.Ran++
+		result := runAction(ctx, a, req)
+		if result.failure != "" {
+			out.Failures = append(out.Failures, a.source+": "+result.failure)
+			if req.Event == PreToolUse && a.onFailureBlock {
+				out.Blocked = true
+				out.Reason = fmt.Sprintf("policy hook %s could not complete: %s", a.source, result.failure)
+				break
+			}
+		}
+		if result.additionalContext != "" {
+			combined, ok := joinContext(out.AdditionalContext, result.additionalContext)
+			if !ok {
+				failure := fmt.Sprintf("additional context exceeds %d bytes across hook chain", maxOutputBytes)
+				out.Failures = append(out.Failures, a.source+": "+failure)
+				if req.Event == PreToolUse && a.onFailureBlock {
+					out.Blocked = true
+					out.Reason = fmt.Sprintf("policy hook %s could not complete: %s", a.source, failure)
+					break
+				}
+			} else {
+				out.AdditionalContext = combined
+			}
+		}
+		if result.blocked && canBlock(req.Event) {
+			out.Blocked = true
+			out.Reason = result.reason
+			if out.Reason == "" {
+				out.Reason = "blocked by " + a.source
+			}
+			break
+		}
+	}
+	return out
+}
+
+func runAction(ctx context.Context, a action, req Request) actionResult {
+	data, err := json.Marshal(makePayload(req))
+	if err != nil {
+		return actionResult{failure: "encode payload: " + err.Error()}
+	}
+	if len(data) > maxPayloadBytes {
+		return actionResult{failure: fmt.Sprintf("payload exceeds %d bytes", maxPayloadBytes)}
+	}
+	data = append(data, '\n')
+	env := hookEnv(a, req)
+	if envBytes(os.Environ(), env) > maxEnvBytes {
+		return actionResult{failure: fmt.Sprintf("environment exceeds %d bytes", maxEnvBytes)}
+	}
+	res := bashrun.Run(ctx, bashrun.Options{
+		Command:        a.command,
+		Stdin:          data,
+		Env:            env,
+		Dir:            req.WorkingDir,
+		Timeout:        a.timeout,
+		SeparateOutput: true,
+		MaxOutputBytes: maxOutputBytes,
+	})
+	return interpret(res)
+}
+
+func makePayload(req Request) payload {
+	var input any
+	if len(req.ToolInput) > 0 {
+		if err := json.Unmarshal(req.ToolInput, &input); err != nil {
+			input = map[string]string{"_raw": string(req.ToolInput)}
+		}
+	}
+	return payload{
+		Version:              1,
+		Event:                req.Event,
+		EventType:            req.Event,
+		SessionID:            req.SessionID,
+		MatcherContext:       req.MatcherContext,
+		ToolName:             req.ToolName,
+		ToolInput:            input,
+		ToolResponse:         req.ToolResponse,
+		ToolError:            req.ToolError,
+		Message:              req.Message,
+		LastAssistantMessage: req.LastAssistantMessage,
+		WorkingDir:           req.WorkingDir,
+		ToolCallID:           req.ToolCallID,
+	}
+}
+
+func hookEnv(a action, req Request) []string {
+	return []string{
+		"PLUGIN_ROOT=" + a.pluginRoot,
+		"WHIP_HOOK_EVENT=" + string(req.Event),
+		"WHIP_PROJECT_DIR=" + req.WorkingDir,
+		"WHIP_SESSION_ID=" + req.SessionID,
+		"WHIP_TOOL_NAME=" + req.ToolName,
+	}
+}
+
+func envBytes(groups ...[]string) int {
+	values := make(map[string]string)
+	loose := 0
+	for _, env := range groups {
+		for _, item := range env {
+			key, value, ok := strings.Cut(item, "=")
+			if !ok {
+				loose += len(item) + 1
+				continue
+			}
+			values[key] = value
+		}
+	}
+	total := loose
+	for key, value := range values {
+		total += len(key) + len(value) + 2 // '=' plus environment NUL
+	}
+	return total
+}
+
+func interpret(res bashrun.Result) actionResult {
+	stderr := strings.TrimSpace(res.Stderr)
+	stdout := strings.TrimSpace(res.Stdout)
+	if res.ExitCode == 2 {
+		reason := stderr
+		if d, ok := decodeDecision(stdout); ok && d.Reason != "" {
+			reason = d.Reason
+		}
+		return actionResult{blocked: true, reason: reason}
+	}
+	if res.TimedOut {
+		return actionResult{failure: "timed out"}
+	}
+	if res.Killed {
+		return actionResult{failure: res.Exit}
+	}
+	if res.Truncated {
+		return actionResult{failure: fmt.Sprintf("output exceeds %d bytes", maxOutputBytes)}
+	}
+	if !utf8.ValidString(res.Stdout) {
+		return actionResult{failure: "stdout is not valid utf-8"}
+	}
+	if stdout == "" {
+		if res.ExitCode == 0 {
+			return actionResult{}
+		}
+		return actionResult{failure: exitFailure(res, stderr)}
+	}
+	decision, ok := decodeDecision(stdout)
+	if !ok {
+		return actionResult{failure: "stdout is not one json decision object"}
+	}
+	switch strings.ToLower(decision.Decision) {
+	case "block", "deny":
+		return actionResult{
+			blocked:           true,
+			reason:            decision.Reason,
+			additionalContext: decision.AdditionalContext,
+		}
+	case "allow":
+		if res.ExitCode != 0 {
+			return actionResult{failure: exitFailure(res, stderr)}
+		}
+		return actionResult{additionalContext: decision.AdditionalContext}
+	case "":
+		if res.ExitCode == 0 && decision.AdditionalContext != "" {
+			return actionResult{additionalContext: decision.AdditionalContext}
+		}
+	}
+	return actionResult{failure: "stdout contains an unrecognized decision"}
+}
+
+func decodeDecision(stdout string) (commandDecision, bool) {
+	if stdout == "" || !strings.HasPrefix(stdout, "{") {
+		return commandDecision{}, false
+	}
+	var decision commandDecision
+	if err := json.Unmarshal([]byte(stdout), &decision); err != nil {
+		return commandDecision{}, false
+	}
+	return decision, true
+}
+
+func exitFailure(res bashrun.Result, stderr string) string {
+	if stderr != "" {
+		return fmt.Sprintf("exit %d: %s", res.ExitCode, stderr)
+	}
+	if res.Exit != "" {
+		return res.Exit
+	}
+	return fmt.Sprintf("exit %d", res.ExitCode)
+}
+
+func canBlock(event Event) bool {
+	return event == UserPromptSubmit || event == PreToolUse || event == Stop
+}
+
+func joinContext(current, next string) (string, bool) {
+	if current == "" {
+		return next, len(next) <= maxOutputBytes
+	}
+	if len(next) > maxOutputBytes-2 || len(current) > maxOutputBytes-2-len(next) {
+		return current, false
+	}
+	return current + "\n\n" + next, true
+}

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -1,0 +1,214 @@
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunPayloadEnvironmentAndContext(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	root := t.TempDir()
+	wd := t.TempDir()
+	m := managerWith(action{
+		event:      PreToolUse,
+		source:     "test plugin",
+		pluginRoot: root,
+		command: `payload=$(cat)
+printf '%s' "$payload" > "$PLUGIN_ROOT/payload.json"
+printf '%s|%s|%s|%s' "$WHIP_HOOK_EVENT" "$WHIP_SESSION_ID" "$WHIP_TOOL_NAME" "$WHIP_PROJECT_DIR" > "$PLUGIN_ROOT/env.txt"
+printf '{"decision":"allow","additionalContext":"from hook"}'`,
+		timeout: time.Second,
+	})
+	req := Request{
+		Event:          PreToolUse,
+		SessionID:      "session-1",
+		WorkingDir:     wd,
+		MatcherContext: "bash",
+		ToolName:       "bash",
+		ToolInput:      json.RawMessage(`{"command":"go test ./..."}`),
+		ToolCallID:     "call-1",
+	}
+	out := m.Run(t.Context(), req)
+	if out.Blocked || out.Ran != 1 || out.AdditionalContext != "from hook" || len(out.Failures) != 0 {
+		t.Fatalf("outcome = %+v", out)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "payload.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("payload json: %v\n%s", err, data)
+	}
+	if got["version"] != float64(1) || got["event"] != "PreToolUse" || got["event_type"] != "PreToolUse" || got["working_dir"] != wd {
+		t.Fatalf("payload fields = %v", got)
+	}
+	if got["session_id"] != "session-1" || got["tool_call_id"] != "call-1" {
+		t.Fatalf("payload identity fields = %v", got)
+	}
+	env, err := os.ReadFile(filepath.Join(root, "env.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(env) != "PreToolUse|session-1|bash|"+wd {
+		t.Fatalf("hook environment = %q", env)
+	}
+}
+
+func TestRunDecisionAndFailureSemantics(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	tests := []struct {
+		name           string
+		command        string
+		onFailureBlock bool
+		blocked        bool
+		failure        bool
+		reason         string
+	}{
+		{name: "exit two blocks", command: `printf 'no deletes' >&2; exit 2`, blocked: true, reason: "no deletes"},
+		{name: "json deny blocks", command: `printf '{"decision":"deny","reason":"policy"}'`, blocked: true, reason: "policy"},
+		{name: "malformed fails open", command: `printf 'debug log'`, failure: true},
+		{name: "malformed can fail closed", command: `printf 'debug log'`, onFailureBlock: true, blocked: true, failure: true},
+		{name: "nonzero allow is failure", command: `printf '{"decision":"allow"}'; exit 1`, failure: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := managerWith(action{
+				event:          PreToolUse,
+				source:         "test",
+				command:        tt.command,
+				timeout:        time.Second,
+				onFailureBlock: tt.onFailureBlock,
+			})
+			out := m.Run(t.Context(), Request{Event: PreToolUse, WorkingDir: t.TempDir()})
+			if out.Blocked != tt.blocked {
+				t.Fatalf("blocked = %v, want %v (%+v)", out.Blocked, tt.blocked, out)
+			}
+			if (len(out.Failures) > 0) != tt.failure {
+				t.Fatalf("failures = %v, want failure=%v", out.Failures, tt.failure)
+			}
+			if tt.failure && !strings.HasPrefix(out.Failures[0], "test: ") {
+				t.Fatalf("failure does not identify its hook source: %v", out.Failures)
+			}
+			if tt.reason != "" && !strings.Contains(out.Reason, tt.reason) {
+				t.Fatalf("reason = %q, want %q", out.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestRunStopFailureAlwaysFailsOpen(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	m := managerWith(action{
+		event:          Stop,
+		source:         "test",
+		command:        `sleep 2`,
+		timeout:        50 * time.Millisecond,
+		onFailureBlock: true,
+	})
+	out := m.Run(t.Context(), Request{Event: Stop, WorkingDir: t.TempDir()})
+	if out.Blocked || len(out.Failures) != 1 {
+		t.Fatalf("stop failures must be visible but fail open: %+v", out)
+	}
+}
+
+func TestRunCommandsStayOrdered(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	root := t.TempDir()
+	logPath := filepath.Join(root, "order")
+	m := managerWith(
+		action{event: PostToolUse, source: "one", command: `printf '1' >> "$PLUGIN_ROOT/order"`, pluginRoot: root, timeout: time.Second},
+		action{event: PostToolUse, source: "two", command: `printf '2' >> "$PLUGIN_ROOT/order"`, pluginRoot: root, timeout: time.Second},
+	)
+	out := m.Run(t.Context(), Request{Event: PostToolUse, WorkingDir: root})
+	if out.Ran != 2 || len(out.Failures) != 0 {
+		t.Fatalf("outcome = %+v", out)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "12" {
+		t.Fatalf("command order = %q", data)
+	}
+}
+
+func TestRunResourceLimitsAndCancellation(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	t.Run("payload", func(t *testing.T) {
+		m := managerWith(action{event: UserPromptSubmit, source: "test", command: "exit 0", timeout: time.Second})
+		out := m.Run(t.Context(), Request{
+			Event:      UserPromptSubmit,
+			WorkingDir: t.TempDir(),
+			Message:    strings.Repeat("x", maxPayloadBytes),
+		})
+		if out.Ran != 1 || len(out.Failures) != 1 || !strings.Contains(out.Failures[0], "payload exceeds") {
+			t.Fatalf("payload limit outcome = %+v", out)
+		}
+	})
+
+	t.Run("output", func(t *testing.T) {
+		m := managerWith(action{
+			event:   PreToolUse,
+			source:  "test",
+			command: `yes x | head -c 70000`,
+			timeout: time.Second,
+		})
+		out := m.Run(t.Context(), Request{Event: PreToolUse, WorkingDir: t.TempDir()})
+		if len(out.Failures) != 1 || !strings.Contains(out.Failures[0], "output exceeds") {
+			t.Fatalf("output limit outcome = %+v", out)
+		}
+	})
+
+	t.Run("composed context", func(t *testing.T) {
+		command := `printf '{"decision":"allow","additionalContext":"'; yes x | tr -d '\n' | head -c 40000; printf '"}'`
+		m := managerWith(
+			action{event: PreToolUse, source: "one", command: command, timeout: time.Second},
+			action{event: PreToolUse, source: "two", command: command, timeout: time.Second},
+		)
+		out := m.Run(t.Context(), Request{Event: PreToolUse, WorkingDir: t.TempDir()})
+		if out.Blocked || len(out.AdditionalContext) != 40000 {
+			t.Fatalf("composed context outcome = blocked:%v context:%d", out.Blocked, len(out.AdditionalContext))
+		}
+		if len(out.Failures) != 1 || !strings.Contains(out.Failures[0], "additional context exceeds") {
+			t.Fatalf("composed context failures = %v", out.Failures)
+		}
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		t.Setenv("WHIP_HOOK_TEST_OVERSIZE", strings.Repeat("x", maxEnvBytes))
+		m := managerWith(action{event: PreToolUse, source: "test", command: "exit 0", timeout: time.Second})
+		out := m.Run(t.Context(), Request{Event: PreToolUse, WorkingDir: t.TempDir()})
+		if len(out.Failures) != 1 || !strings.Contains(out.Failures[0], "environment exceeds") {
+			t.Fatalf("environment limit outcome = %+v", out)
+		}
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		m := managerWith(action{event: PreToolUse, source: "test", command: "sleep 30", timeout: time.Minute})
+		ctx, cancel := context.WithCancel(t.Context())
+		time.AfterFunc(50*time.Millisecond, cancel)
+		start := time.Now()
+		out := m.Run(ctx, Request{Event: PreToolUse, WorkingDir: t.TempDir()})
+		cancel()
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("cancelled hook ran for %s", elapsed)
+		}
+		if len(out.Failures) != 1 || !strings.Contains(out.Failures[0], "cancelled") {
+			t.Fatalf("cancellation outcome = %+v", out)
+		}
+	})
+}
+
+func managerWith(actions ...action) *Manager {
+	m := &Manager{actions: make(map[Event][]action)}
+	for _, a := range actions {
+		m.actions[a.event] = append(m.actions[a.event], a)
+	}
+	return m
+}

--- a/internal/hooks/types.go
+++ b/internal/hooks/types.go
@@ -1,0 +1,77 @@
+// Package hooks discovers and runs portable command-based lifecycle hooks.
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Event is a lifecycle boundary exposed to hook commands.
+type Event string
+
+const (
+	UserPromptSubmit   Event = "UserPromptSubmit"
+	PreToolUse         Event = "PreToolUse"
+	PostToolUse        Event = "PostToolUse"
+	PostToolUseFailure Event = "PostToolUseFailure"
+	Stop               Event = "Stop"
+)
+
+var eventOrder = []Event{
+	UserPromptSubmit,
+	PreToolUse,
+	PostToolUse,
+	PostToolUseFailure,
+	Stop,
+}
+
+// Request is the event data supplied by the agent loop. Fields that do not
+// apply to an event are omitted from the command's JSON payload.
+type Request struct {
+	Event                Event
+	SessionID            string
+	WorkingDir           string
+	MatcherContext       string
+	ToolName             string
+	ToolInput            json.RawMessage
+	ToolResponse         string
+	ToolError            string
+	Message              string
+	LastAssistantMessage string
+	ToolCallID           string
+}
+
+// Outcome is the composed result of every matching command for one event.
+// Failures are telemetry: they do not block except for a PreToolUse command
+// explicitly configured with on_failure=block.
+type Outcome struct {
+	Blocked           bool     `json:"blocked"`
+	Reason            string   `json:"reason,omitempty"`
+	AdditionalContext string   `json:"additional_context,omitempty"`
+	Ran               int      `json:"ran"`
+	Failures          []string `json:"failures,omitempty"`
+}
+
+// Entry describes one loaded command for status views.
+type Entry struct {
+	Event   Event
+	Source  string
+	Matcher string
+	Command string
+}
+
+type action struct {
+	event          Event
+	source         string
+	pluginRoot     string
+	command        string
+	timeout        time.Duration
+	matcher        matcher
+	onFailureBlock bool
+}
+
+// Runner is the narrow contract consumed by the agent loop.
+type Runner interface {
+	Run(ctx context.Context, req Request) Outcome
+}

--- a/internal/tools/bashrun/bashrun.go
+++ b/internal/tools/bashrun/bashrun.go
@@ -70,9 +70,20 @@ func passwdShell() string {
 type Result struct {
 	// Output is the combined stdout+stderr captured for the model.
 	Output string
+	// Stdout and Stderr are populated when Options.SeparateOutput is true.
+	// Output remains populated too so callers can keep using the combined
+	// stream while protocols inspect their decision and diagnostic channels
+	// independently.
+	Stdout string
+	Stderr string
 	// Exit is the human-readable exit status fed back to the model. It is
 	// empty for a clean exit 0.
 	Exit string
+	// ExitCode is the process exit status. It is -1 when the process did not
+	// start, timed out, was cancelled, or died by signal.
+	ExitCode int
+	// Truncated reports MaxOutputBytes capped at least one captured stream.
+	Truncated bool
 	// TimedOut reports the command exceeded its wall-clock timeout.
 	TimedOut bool
 	// Killed reports the command was killed by us (timeout, inactivity
@@ -85,6 +96,21 @@ type Result struct {
 // Options configure a single run.
 type Options struct {
 	Command string
+	// Stdin is delivered to the command in non-interactive mode. nil keeps the
+	// existing /dev/null behavior; an empty non-nil slice delivers immediate
+	// EOF after a zero-byte input.
+	Stdin []byte
+	// Env overlays the inherited environment. Per-run values replace ambient
+	// keys instead of leaving duplicate entries whose lookup semantics vary by
+	// platform.
+	Env []string
+	// Dir sets the command's working directory. Empty inherits the process cwd.
+	Dir string
+	// SeparateOutput captures stdout and stderr independently in Result while
+	// still maintaining Output as the combined stream.
+	SeparateOutput bool
+	// MaxOutputBytes caps each captured stream. <=0 leaves capture unbounded.
+	MaxOutputBytes int
 	// Timeout is the hard wall-clock cap. <=0 means 120s.
 	Timeout time.Duration
 	// Interactive runs the command in a PTY so sudo/ssh-like password prompts
@@ -130,12 +156,44 @@ func Run(ctx context.Context, opts Options) Result {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, userShell(), "-c", opts.Command)
-	cmd.Env = append(os.Environ(), ChildMarkers...)
+	cmd.Env = mergeEnv(os.Environ(), markersSnapshot(), opts.Env)
+	cmd.Dir = opts.Dir
+	if opts.Stdin != nil {
+		cmd.Stdin = bytes.NewReader(opts.Stdin)
+	}
 
 	if opts.Interactive {
 		return runInteractive(ctx, cmd, opts)
 	}
-	return runPiped(ctx, cmd, opts.OnUpdate)
+	return runPiped(ctx, cmd, opts)
+}
+
+// mergeEnv applies overlays in order while emitting each key once. Values
+// without '=' are preserved as distinct entries; exec.Cmd accepts them and
+// callers outside the hook protocol may already rely on that behavior.
+func mergeEnv(base []string, overlays ...[]string) []string {
+	out := make([]string, 0, len(base))
+	index := make(map[string]int, len(base))
+	apply := func(env []string) {
+		for _, item := range env {
+			key, _, ok := strings.Cut(item, "=")
+			if !ok {
+				out = append(out, item)
+				continue
+			}
+			if i, found := index[key]; found {
+				out[i] = item
+				continue
+			}
+			index[key] = len(out)
+			out = append(out, item)
+		}
+	}
+	apply(base)
+	for _, overlay := range overlays {
+		apply(overlay)
+	}
+	return out
 }
 
 // runPiped runs the command with stdout/stderr captured, stdin wired to
@@ -155,26 +213,29 @@ func Run(ctx context.Context, opts Options) Result {
 // runs (pi throttles its bash onUpdate at 100ms too).
 const updateInterval = 100 * time.Millisecond
 
-func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result {
+func runPiped(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 	// Hand-rolled pipes, NOT cmd.StdoutPipe: Wait() closes StdoutPipe's read
 	// ends the moment the child exits, discarding kernel-buffered output the
 	// drain goroutines haven't read yet (lost output on fast commands). With
 	// our own pipes Wait touches nothing and we control when reads end.
 	stdout, outW, err := os.Pipe()
 	if err != nil {
-		return Result{Exit: "pipe: " + err.Error()}
+		return Result{Exit: "pipe: " + err.Error(), ExitCode: -1}
 	}
 	stderr, errW, err := os.Pipe()
 	if err != nil {
 		_ = stdout.Close()
 		_ = outW.Close()
-		return Result{Exit: "pipe: " + err.Error()}
+		return Result{Exit: "pipe: " + err.Error(), ExitCode: -1}
 	}
 	cmd.Stdout = outW
 	cmd.Stderr = errW
-	if devNull := openDevNull(); devNull != nil {
-		cmd.Stdin = devNull
-		defer devNull.Close()
+	if cmd.Stdin == nil {
+		devNull := openDevNull()
+		if devNull != nil {
+			cmd.Stdin = devNull
+			defer devNull.Close()
+		}
 	}
 	// Setsid gives the child a new session with no controlling terminal, so a
 	// program that insists on /dev/tty fails immediately instead of grabbing
@@ -186,7 +247,7 @@ func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result 
 		_ = outW.Close()
 		_ = stderr.Close()
 		_ = errW.Close()
-		return Result{Exit: exitString(err)}
+		return Result{Exit: exitString(err), ExitCode: -1}
 	}
 	// Drop our copies of the write ends: the drains must see EOF when the
 	// child (and any grandchildren holding the pipes) are done writing.
@@ -197,18 +258,34 @@ func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result 
 
 	// Drain both pipes concurrently; the readers finish on pipe EOF (process
 	// exit) OR when we close them below after Wait returns.
-	var out bytes.Buffer
+	combinedLimit := opts.MaxOutputBytes
+	if opts.SeparateOutput && combinedLimit > 0 && combinedLimit <= int(^uint(0)>>1)/2 {
+		// stdout and stderr each receive their own budget below. Give the
+		// auxiliary combined view both budgets too, otherwise two individually
+		// valid streams could make Result.Truncated report a false positive.
+		combinedLimit *= 2
+	}
+	out := cappedBuffer{max: combinedLimit}
+	stdoutOnly := cappedBuffer{max: opts.MaxOutputBytes}
+	stderrOnly := cappedBuffer{max: opts.MaxOutputBytes}
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(2)
-	drain := func(r io.Reader) {
+	drain := func(r io.Reader, separate *cappedBuffer) {
 		defer wg.Done()
 		buf := make([]byte, 4096)
 		for {
 			n, rerr := r.Read(buf)
 			if n > 0 {
 				mu.Lock()
-				out.Write(buf[:n])
+				if opts.SeparateOutput {
+					before := separate.Len()
+					_, _ = separate.Write(buf[:n])
+					retained := separate.Len() - before
+					_, _ = out.Write(buf[:retained])
+				} else {
+					_, _ = out.Write(buf[:n])
+				}
 				mu.Unlock()
 			}
 			if rerr != nil {
@@ -216,13 +293,13 @@ func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result 
 			}
 		}
 	}
-	go drain(stdout)
-	go drain(stderr)
+	go drain(stdout, &stdoutOnly)
+	go drain(stderr, &stderrOnly)
 	// Stream throttled snapshots of the accumulated output to the caller so
 	// in-flight progress is visible before the command exits. One goroutine,
 	// owned by this run, exits when updatesDone closes below.
 	var updatesDone chan struct{}
-	if onUpdate != nil {
+	if opts.OnUpdate != nil {
 		updatesDone = make(chan struct{})
 		defer close(updatesDone)
 		go func() {
@@ -236,7 +313,7 @@ func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result 
 					mu.Lock()
 					snap := out.String()
 					mu.Unlock()
-					onUpdate(snap)
+					opts.OnUpdate(snap)
 				}
 			}
 		}()
@@ -273,16 +350,26 @@ func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result 
 	_ = stderr.Close()
 	wg.Wait()
 
-	res := Result{Output: out.String()}
+	res := Result{
+		Output:    out.String(),
+		ExitCode:  processExitCode(waitErr),
+		Truncated: out.truncated || stdoutOnly.truncated || stderrOnly.truncated,
+	}
+	if opts.SeparateOutput {
+		res.Stdout = stdoutOnly.String()
+		res.Stderr = stderrOnly.String()
+	}
 	if ctx.Err() == context.DeadlineExceeded {
 		res.TimedOut = true
 		res.Killed = true
 		res.Exit = "timed out"
+		res.ExitCode = -1
 		return res
 	}
 	if isCancelled(ctx, waitErr) {
 		res.Killed = true
 		res.Exit = "cancelled"
+		res.ExitCode = -1
 		return res
 	}
 	res.Exit = exitString(waitErr)
@@ -290,6 +377,35 @@ func runPiped(ctx context.Context, cmd *exec.Cmd, onUpdate func(string)) Result 
 		res.Killed = isKilledBySignal(waitErr)
 	}
 	return res
+}
+
+// cappedBuffer accepts every write while retaining at most max bytes. It is
+// used under runPiped's capture mutex, so it needs no synchronization of its
+// own and preserves io.Writer's "accepted all bytes" contract for io.Copy.
+type cappedBuffer struct {
+	bytes.Buffer
+	max       int
+	truncated bool
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if b.max <= 0 {
+		_, _ = b.Buffer.Write(p)
+		return n, nil
+	}
+	remaining := b.max - b.Len()
+	if remaining <= 0 {
+		b.truncated = b.truncated || n > 0
+		return n, nil
+	}
+	if len(p) > remaining {
+		_, _ = b.Buffer.Write(p[:remaining])
+		b.truncated = true
+		return n, nil
+	}
+	_, _ = b.Buffer.Write(p)
+	return n, nil
 }
 
 // runInteractive runs the command in a PTY. sudo, ssh, gpg and friends detect a
@@ -305,7 +421,7 @@ func runInteractive(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 	if err != nil {
 		// Fall back to the safe non-interactive path; an interactive failure
 		// must never hang the agent.
-		return runPiped(ctx, cmd, nil)
+		return runPiped(ctx, cmd, opts)
 	}
 	defer ptmx.Close()
 	track(cmd) // register for KillAll on whip exit
@@ -397,16 +513,18 @@ func runInteractive(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 			// command exited). Wait for the child and return.
 			if !ok || chunk == nil {
 				waitErr := cmd.Wait()
-				res := Result{Output: buf.String(), Interactive: true}
+				res := Result{Output: buf.String(), ExitCode: processExitCode(waitErr), Interactive: true}
 				if ctx.Err() == context.DeadlineExceeded {
 					res.TimedOut = true
 					res.Killed = true
 					res.Exit = "timed out"
+					res.ExitCode = -1
 					return res
 				}
 				if isCancelled(ctx, waitErr) {
 					res.Killed = true
 					res.Exit = "cancelled"
+					res.ExitCode = -1
 					return res
 				}
 				res.Exit = exitString(waitErr)
@@ -428,7 +546,7 @@ func runInteractive(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				stop()
 				_ = cmd.Wait()
-				res := Result{Output: buf.String(), Killed: true, Interactive: true}
+				res := Result{Output: buf.String(), ExitCode: -1, Killed: true, Interactive: true}
 				if errors.Is(ctxErr, context.DeadlineExceeded) {
 					res.TimedOut = true
 					res.Exit = "timed out"
@@ -443,6 +561,7 @@ func runInteractive(ctx context.Context, cmd *exec.Cmd, opts Options) Result {
 				res := Result{
 					Output:      buf.String(),
 					Exit:        "timed out waiting for input",
+					ExitCode:    -1,
 					Killed:      true,
 					Interactive: true,
 				}
@@ -470,6 +589,16 @@ func exitString(err error) string {
 		return fmt.Sprintf("(exit: %s)", exitErr)
 	}
 	return fmt.Sprintf("(exit: %v)", err)
+}
+
+func processExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 // isKilledBySignal reports whether the error was a kill-by-signal.

--- a/internal/tools/bashrun/failure_test.go
+++ b/internal/tools/bashrun/failure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +34,77 @@ func TestRunReportsUnstartableShell(t *testing.T) {
 		if res.Output != "" {
 			t.Fatalf("interactive=%v: nothing ran, so there is no output: %q", interactive, res.Output)
 		}
+	}
+}
+
+func TestRunStructuredIO(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	t.Setenv("HOOK_TEST", "ambient")
+	dir := t.TempDir()
+	realDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := Run(t.Context(), Options{
+		Command:        `read input; printf 'out:%s:%s:%s' "$input" "$HOOK_TEST" "$PWD"; printf 'diagnostic' >&2; exit 7`,
+		Stdin:          []byte("payload\n"),
+		Env:            []string{"HOOK_TEST=value"},
+		Dir:            dir,
+		SeparateOutput: true,
+	})
+	if res.ExitCode != 7 {
+		t.Fatalf("exit code = %d, want 7 (%+v)", res.ExitCode, res)
+	}
+	if res.Stdout != "out:payload:value:"+realDir {
+		t.Fatalf("stdout = %q", res.Stdout)
+	}
+	if res.Stderr != "diagnostic" {
+		t.Fatalf("stderr = %q", res.Stderr)
+	}
+	if !strings.Contains(res.Output, "out:payload:value:") || !strings.Contains(res.Output, "diagnostic") {
+		t.Fatalf("combined output lost a stream: %q", res.Output)
+	}
+}
+
+func TestRunCapsStructuredOutput(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	res := Run(t.Context(), Options{
+		Command:        `printf 'abcdefghij'`,
+		SeparateOutput: true,
+		MaxOutputBytes: 4,
+	})
+	if !res.Truncated {
+		t.Fatal("expected output cap to report truncation")
+	}
+	if res.Output != "abcd" || res.Stdout != "abcd" {
+		t.Fatalf("capped output = %q stdout = %q", res.Output, res.Stdout)
+	}
+}
+
+func TestRunStructuredOutputLimitAppliesPerStream(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+	res := Run(t.Context(), Options{
+		Command:        `printf 'abcd'; printf 'wxyz' >&2`,
+		SeparateOutput: true,
+		MaxOutputBytes: 4,
+	})
+	if res.Truncated {
+		t.Fatalf("individually bounded streams reported truncation: %+v", res)
+	}
+	if res.Stdout != "abcd" || res.Stderr != "wxyz" || len(res.Output) != 8 {
+		t.Fatalf("structured output = stdout %q stderr %q combined %q", res.Stdout, res.Stderr, res.Output)
+	}
+}
+
+func TestMergeEnvReplacesDuplicateKeys(t *testing.T) {
+	got := mergeEnv(
+		[]string{"A=old", "B=base", "A=stale", "loose"},
+		[]string{"A=marker", "C=marker"},
+		[]string{"A=hook", "C=hook"},
+	)
+	want := []string{"A=hook", "B=base", "loose", "C=hook"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("merged environment = %v, want %v", got, want)
 	}
 }
 

--- a/internal/tools/bashrun/markers.go
+++ b/internal/tools/bashrun/markers.go
@@ -3,15 +3,24 @@ package bashrun
 import (
 	"os"
 	"strconv"
+	"sync"
 )
 
-// ChildMarkers are the env vars every bash child gets so scripts can detect
-// they run under the agent (opencode sets AGENT=1, OPENCODE_PID). Session and
-// model are stamped per-run by the caller via SetMarkers.
-var ChildMarkers = []string{"WHIP=1"}
+var (
+	markersMu    sync.RWMutex
+	childMarkers = []string{"WHIP=1"}
+)
 
 // SetMarkers records the session/model markers appended to every child env.
 // Called once the session exists; idempotent.
 func SetMarkers(sessionID, model string) {
-	ChildMarkers = []string{"WHIP=1", "WHIP_SESSION_ID=" + sessionID, "WHIP_MODEL=" + model, "WHIP_PID=" + strconv.Itoa(os.Getpid())}
+	markersMu.Lock()
+	childMarkers = []string{"WHIP=1", "WHIP_SESSION_ID=" + sessionID, "WHIP_MODEL=" + model, "WHIP_PID=" + strconv.Itoa(os.Getpid())}
+	markersMu.Unlock()
+}
+
+func markersSnapshot() []string {
+	markersMu.RLock()
+	defer markersMu.RUnlock()
+	return append([]string(nil), childMarkers...)
 }

--- a/internal/tools/bashrun/markers_test.go
+++ b/internal/tools/bashrun/markers_test.go
@@ -2,7 +2,9 @@ package bashrun
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -15,5 +17,54 @@ func TestChildMarkers(t *testing.T) {
 		if !strings.Contains(res.Output, want) {
 			t.Fatalf("child env missing %q:\n%s", want, res.Output)
 		}
+	}
+}
+
+func TestMarkerSnapshotsStayAtomicDuringSessionPublication(t *testing.T) {
+	const iterations = 1_000
+	SetMarkers("session-initial", "model-initial")
+	start := make(chan struct{})
+	errCh := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range iterations {
+			SetMarkers(fmt.Sprintf("session-%d", i), fmt.Sprintf("model-%d", i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			markers := markersSnapshot()
+			if len(markers) == 1 { // the safe zero-session value
+				continue
+			}
+			if len(markers) != 4 {
+				select {
+				case errCh <- fmt.Sprintf("marker count = %d", len(markers)):
+				default:
+				}
+				return
+			}
+			session := strings.TrimPrefix(markers[1], "WHIP_SESSION_ID=session-")
+			model := strings.TrimPrefix(markers[2], "WHIP_MODEL=model-")
+			if session != model {
+				select {
+				case errCh <- fmt.Sprintf("mixed marker snapshot: %v", markers):
+				default:
+				}
+				return
+			}
+		}
+	}()
+	close(start)
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
 	}
 }

--- a/internal/tui/hooks.go
+++ b/internal/tui/hooks.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/hooks"
+)
+
+// reloadHooks builds a new immutable manager and swaps it into the active
+// agent. Project commands are included only after the folder trust gate; user
+// plugins remain available in every directory.
+func (m *model) reloadHooks(dir string, includeProject bool) {
+	mgr := hooks.Load(hooks.LoadOptions{
+		WorkingDir:     dir,
+		IncludeProject: includeProject,
+	})
+	m.hookMgr = mgr
+	if m.agent != nil {
+		m.agent.SetHookScope(mgr, dir)
+	}
+	for _, warning := range mgr.Warnings() {
+		config.LogEvent("hooks.load", warning)
+		m.append(errStyle.Render("hooks: " + warning))
+	}
+}
+
+func (m *model) hooksStatus() string {
+	if m.hookMgr == nil {
+		return "hooks: not loaded"
+	}
+	if m.hookMgr.Disabled() {
+		return "hooks: disabled by WHIP_DISABLE_HOOKS=1"
+	}
+	project := "project hooks enabled"
+	if !m.hookMgr.ProjectEnabled() {
+		project = "project hooks disabled (folder is not trusted)"
+	}
+
+	entries := m.hookMgr.Entries()
+	var b strings.Builder
+	fmt.Fprintf(&b, "hooks: %d command(s) · %s", len(entries), project)
+	for _, entry := range entries {
+		fmt.Fprintf(
+			&b,
+			"\n%s [%s] — %s: %s",
+			entry.Event,
+			entry.Matcher,
+			entry.Source,
+			hookCommandSummary(entry.Command),
+		)
+	}
+	if warnings := m.hookMgr.Warnings(); len(warnings) > 0 {
+		fmt.Fprintf(&b, "\n%d discovery warning(s); see the messages above", len(warnings))
+	}
+	return b.String()
+}
+
+const maxHookCommandRunes = 160
+
+func hookCommandSummary(command string) string {
+	if utf8.RuneCountInString(command) > maxHookCommandRunes {
+		runes := []rune(command)
+		command = string(runes[:maxHookCommandRunes]) + "…"
+	}
+	return strconv.Quote(command)
+}
+
+// hookNotice keeps normal successful hooks quiet while surfacing policy
+// blocks and fail-open command failures in the transcript.
+func hookNotice(event hooks.Event, outcome hooks.Outcome) string {
+	var details []string
+	if outcome.Blocked {
+		reason := strings.TrimSpace(outcome.Reason)
+		if reason == "" {
+			reason = "blocked"
+		}
+		details = append(details, reason)
+	}
+	if len(outcome.Failures) > 0 {
+		label := "failed open: "
+		if outcome.Blocked {
+			label = "failure: "
+		}
+		details = append(details, label+strings.Join(outcome.Failures, "; "))
+	}
+	if len(details) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("hook %s: %s", event, strings.Join(details, " · "))
+}

--- a/internal/tui/hooks_test.go
+++ b/internal/tui/hooks_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/context-labs/whip/internal/agent"
+	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/hooks"
+)
+
+func writeProjectHook(t *testing.T, project, command string) {
+	t.Helper()
+	path := filepath.Join(project, ".agents", "plugins", "policy", "hooks", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"hooks":{"UserPromptSubmit":[{"hooks":[{"command":` + strconv.Quote(command) + `}]}]}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReloadHooksWiresProjectPolicyAndStatus(t *testing.T) {
+	project := t.TempDir()
+	writeProjectHook(t, project, `printf 'repository policy' >&2; exit 2`)
+	m := shellModel()
+	m.agent = agent.New(nil, "m", 100, "sys")
+	m.reloadHooks(project, true)
+
+	if m.hookMgr.Count() != 1 {
+		t.Fatalf("loaded commands = %d, warnings = %v", m.hookMgr.Count(), m.hookMgr.Warnings())
+	}
+	if status := m.hooksStatus(); !strings.Contains(status, "1 command") ||
+		!strings.Contains(status, "project hooks enabled") ||
+		!strings.Contains(status, "repository policy") {
+		t.Fatalf("status = %q", status)
+	}
+	_, err := m.agent.Turn(context.Background(), "ship", agent.Events{})
+	if err == nil || !strings.Contains(err.Error(), "repository policy") {
+		t.Fatalf("wired project policy error = %v", err)
+	}
+}
+
+func TestHookCommandSummaryIsSingleLineAndBounded(t *testing.T) {
+	command := "printf 'first line'\n" + strings.Repeat("界", maxHookCommandRunes)
+	got := hookCommandSummary(command)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("summary contains a newline: %q", got)
+	}
+	if !strings.Contains(got, `\n`) || !strings.HasSuffix(got, "…\"") {
+		t.Fatalf("long command was not visibly truncated: %q", got)
+	}
+}
+
+func TestCDReloadsOnlyTrustedProjectHooks(t *testing.T) {
+	start := t.TempDir()
+	t.Chdir(start)
+	untrusted := t.TempDir()
+	trusted := t.TempDir()
+	writeProjectHook(t, untrusted, "exit 0")
+	writeProjectHook(t, trusted, "exit 0")
+	trustedScope, err := filepath.EvalSymlinks(trusted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := config.Trust(trustedScope); err != nil {
+		t.Fatal(err)
+	}
+
+	m := shellModel()
+	m.cdCommand(untrusted)
+	if m.hookMgr.ProjectEnabled() || m.hookMgr.Count() != 0 {
+		t.Fatalf("untrusted /cd loaded project commands: count=%d", m.hookMgr.Count())
+	}
+	m.cdCommand(trusted)
+	if !m.hookMgr.ProjectEnabled() || m.hookMgr.Count() != 1 {
+		t.Fatalf("trusted /cd did not reload project commands: count=%d warnings=%v", m.hookMgr.Count(), m.hookMgr.Warnings())
+	}
+}
+
+func TestHookNoticeReportsOnlyActionableOutcomes(t *testing.T) {
+	if got := hookNotice(hooks.PreToolUse, hooks.Outcome{Ran: 1}); got != "" {
+		t.Fatalf("successful hook should stay quiet: %q", got)
+	}
+	got := hookNotice(hooks.PreToolUse, hooks.Outcome{
+		Blocked:  true,
+		Reason:   "denied",
+		Failures: []string{"timeout"},
+	})
+	if !strings.Contains(got, "denied") || !strings.Contains(got, "failure: timeout") || strings.Contains(got, "failed open") {
+		t.Fatalf("actionable notice = %q", got)
+	}
+	got = hookNotice(hooks.PostToolUse, hooks.Outcome{Failures: []string{"timeout"}})
+	if !strings.Contains(got, "failed open: timeout") {
+		t.Fatalf("fail-open notice = %q", got)
+	}
+}

--- a/internal/tui/main_test.go
+++ b/internal/tui/main_test.go
@@ -18,6 +18,9 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(dir)
 	os.Setenv("WHIP_HOME", dir)
+	// Hook discovery reads the platform home directory, not WHIP_HOME. Keep
+	// tests from loading or executing a developer's real ~/.agents plugins.
+	os.Setenv("HOME", dir)
 	// Style tests assert ANSI-dark markdown output; pin a known dark theme so a
 	// test-binary with no tty (where detection reports unknown → neutral) still
 	// renders the dark style they expect. Per-test overrides (SetLightTheme,

--- a/internal/tui/registry.go
+++ b/internal/tui/registry.go
@@ -35,6 +35,7 @@ var registry = []registryEntry{
 	{Name: "/goal", Hint: "<text> — keep working until the goal is met (resume | clear | rounds <n>|default [--global])", Category: "Session"},
 	{Name: "/goal-from-context", Hint: "[n] — formulate a goal from the last n messages (default 8) and work until it's met", Category: "Session"},
 	{Name: "/help", Hint: "— show all commands and keybindings", Category: "App"},
+	{Name: "/hooks", Hint: "— show loaded lifecycle hooks and discovery warnings", Category: "Session"},
 	{Name: "/mcp", Hint: "[name] [reconnect|enable|disable] — MCP servers: status, reconnect, toggle", Category: "Session"},
 	{Name: "/me", Hint: "— edit your standing instructions (~/.whip/me.md) in $EDITOR", Category: "Agent"},
 	{Name: "/memory", Hint: "[n] [session] — saved memories: list what's injected each turn, mark entry n done", Category: "Session"},

--- a/internal/tui/registry_test.go
+++ b/internal/tui/registry_test.go
@@ -10,6 +10,7 @@ import (
 // class. The probe runs the bare command on a scratch model and fails if the
 // transcript reports an unknown command.
 func TestRegistryEntriesDispatch(t *testing.T) {
+	t.Chdir(t.TempDir())
 	for _, e := range slashRegistry() {
 		if !compactCmdModel().dispatches(e.Name) {
 			t.Errorf("%s is in the registry but the command switch doesn't handle it", e.Name)

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/context-labs/whip/internal/config"
 	"github.com/context-labs/whip/internal/tools"
 	"github.com/context-labs/whip/internal/tools/bashrun"
 )
@@ -130,5 +131,7 @@ func (m *model) cdCommand(arg string) {
 		m.append(errStyle.Render("/cd: " + err.Error()))
 		return
 	}
-	m.append(dimStyle.Render("→ " + cwd()))
+	dir := cwd()
+	m.reloadHooks(dir, config.Trusted(dir))
+	m.append(dimStyle.Render("→ " + dir))
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -26,6 +26,7 @@ import (
 	"github.com/context-labs/whip/internal/browser"
 	"github.com/context-labs/whip/internal/computer"
 	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/hooks"
 	"github.com/context-labs/whip/internal/llm"
 	"github.com/context-labs/whip/internal/lsp"
 	"github.com/context-labs/whip/internal/mcp"
@@ -200,6 +201,7 @@ type model struct {
 	mcpMgr       *mcp.Manager              // MCP server connections; nil when none configured
 	mcpSeen      map[string]bool           // servers whose first settle was announced
 	lspMgr       *lsp.Manager              // LSP diagnostics source for write/edit tool output
+	hookMgr      *hooks.Manager            // immutable lifecycle commands shared by active and replacement agents
 	// skillScan is the skills discovery seam (skills.Scan over DefaultDirs in
 	// the real model): a field so the context doctor can be tested against
 	// temp-dir skills instead of whatever the test machine happens to have.
@@ -345,6 +347,7 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 	m.applyCompactModel()
 	m.applyTaskModel()
 	m.agent.CompactThreshold = compactThresholdFor(cfg)
+	m.reloadHooks(cwd(), true)
 	m.wireTasks() // redraw the UI when background subagents start/settle
 
 	// MCP: merge whip's own config with imported claude (.mcp.json) and codex
@@ -2835,6 +2838,9 @@ func (m *model) applyCompactModel() {
 // every start/settle. OnChange runs on the worker goroutine, so it only sends
 // a message (never touches UI state directly).
 func (m *model) wireTasks() {
+	// Every agent replacement path converges here, so a new conversation keeps
+	// the current immutable hook set and working-directory scope.
+	m.agent.SetHookScope(m.hookMgr, cwd())
 	// Persist every start/settle to the session store so --resume can restore
 	// the dock. Headless-safe (no prog needed). The session id comes in as an
 	// argument — published via SetSessionID — so this worker-goroutine
@@ -3442,6 +3448,11 @@ func (m *model) submitTurn(text string, authored bool) (tea.Model, tea.Cmd) {
 				flush()
 				send(steeredMsg(s))
 			},
+			OnHook: func(event hooks.Event, outcome hooks.Outcome) {
+				if notice := hookNotice(event, outcome); notice != "" {
+					send(noticeMsg(notice))
+				}
+			},
 			OnCompacted: func(sum string, cutoff int) { send(compactMsg{summary: sum, cutoff: cutoff}) },
 			OnUsage:     func(u llm.Usage) { send(usageMsg(u)) },
 			// The decay pass rewrote n prefix messages in agent.Messages; drop
@@ -3498,7 +3509,7 @@ func busyCmd(text string) bool {
 		return false
 	}
 	switch fields[0] {
-	case "/help", "/theme", "/mouse", "/effort", "/subagents", "/tasks", "/subagent", "/cd", "/pwd", "/report", "/export", "/fork":
+	case "/help", "/theme", "/mouse", "/effort", "/subagents", "/tasks", "/subagent", "/cd", "/pwd", "/hooks", "/report", "/export", "/fork":
 		return true
 	case "/auth": // must run now even while busy: an inline key queued as a chat message would be sent to the model
 		return true
@@ -3581,6 +3592,9 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "/pwd":
 		m.append(dimStyle.Render(cwd()))
+		return m, nil
+	case "/hooks":
+		m.append(dimStyle.Render(m.hooksStatus()))
 		return m, nil
 	case "/subagent": // user-spawned background subagent — the LLM isn't the only driver
 		m.taskCommand(strings.TrimSpace(strings.TrimPrefix(text, "/subagent")))


### PR DESCRIPTION
  ## Summary

  Adds trusted, command-based lifecycle hooks for project policy, context injection, auditing, and quality gates.

  Supports five lifecycle events:

  - UserPromptSubmit
  - PreToolUse
  - PostToolUse
  - PostToolUseFailure
  - Stop

  ## What changed

  - Loads hooks from user and project plugins plus .whip/hooks.json.
  - Supports matcher-based commands, allow/block/deny decisions, additional context, timeouts, and fail-closed pre-tool policies.
  - Trust-gates project hooks and provides WHIP_DISABLE_HOOKS=1 for recovery.
  - Integrates hooks with the agent loop, subagents, worktrees, TUI, headless runs, and ACP sessions.
  - Adds /hooks to inspect loaded commands and validation warnings.
  - Extends bashrun with stdin, environment overlays, explicit working directories, separate bounded output streams, and exact exit codes.
  - Atomically swaps hook manager and working-directory scope during /cd.
  - Bounds hook-derived tool output and correctly classifies interactive command failures.
  - Documents configuration, protocol, limits, trust behavior, and concurrency guarantees.