### PR TITLE
feat(tui): drag-select and copy the input box text

### DIFF
--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -33,9 +33,13 @@ import (
 // and copy reconstruction mimics the word-aware wrap rather than keeping a
 // parallel plain-text render of every block.
 
-// selPos is one endpoint of the drag, in viewport content coordinates.
+// selPos is one endpoint of the drag. For the transcript region, row is a
+// viewport content row (see selPoint); for the input region, row is an index
+// into inputLines. input marks which region the endpoint is in — a selection
+// is always confined to one region (anchor's), so the two never mix.
 type selPos struct {
-	row, col int // col is a display cell (wide runes count 2)
+	row, col int  // col is a display cell (wide runes count 2)
+	input    bool // true = endpoint is in the input box, not the transcript
 }
 
 // selection is the in-flight (dragging) or last-completed selection. It
@@ -69,6 +73,27 @@ func (m *model) selPoint(x, y int, clamp bool) (selPos, bool) {
 	row = max(min(row, last), first)
 	w := ansi.StringWidth(m.contentLine(row))
 	return selPos{row: row, col: max(min(x, w), 0)}, true
+}
+
+// inInputRow reports whether an absolute screen row is inside the input box.
+func (m *model) inInputRow(y int) bool {
+	return m.inputTop >= 0 && y >= m.inputTop && y < m.inputTop+len(m.inputLines)
+}
+
+// inputPoint converts absolute screen coords in the input box to a selection
+// endpoint (region=input). clamp=true (drag motion) clamps the row into the
+// box; clamp=false (a press) returns ok=false outside it.
+func (m *model) inputPoint(x, y int, clamp bool) (selPos, bool) {
+	if m.inputTop < 0 || len(m.inputLines) == 0 {
+		return selPos{}, false
+	}
+	row := y - m.inputTop
+	if !clamp && (row < 0 || row >= len(m.inputLines)) {
+		return selPos{}, false
+	}
+	row = max(min(row, len(m.inputLines)-1), 0)
+	w := ansi.StringWidth(m.inputLines[row])
+	return selPos{row: row, col: max(min(x, w), 0), input: true}, true
 }
 
 // contentLine returns the unstyled text on content row r, read from the
@@ -117,7 +142,14 @@ func (m *model) selText(s selection) string {
 	lo, hi := selOrder(s)
 	var lines []string
 	for r := lo.row; r <= hi.row; r++ {
-		ln := m.contentLine(r)
+		var ln string
+		if lo.input {
+			if r < len(m.inputLines) {
+				ln = m.inputLines[r]
+			}
+		} else {
+			ln = m.contentLine(r)
+		}
 		start, end := selCols(lo, hi, r, ansi.StringWidth(ln))
 		lines = append(lines, strings.TrimRight(cellSlice(ln, start, end-start), " \t"))
 	}
@@ -143,6 +175,23 @@ func selCols(lo, hi selPos, r, lineWidth int) (int, int) {
 		end = hi.col
 	}
 	return start, max(end, start)
+}
+
+// highlightInput repaints the selected range in reverse video on the input
+// box's rendered view. Called from viewBody when the selection lives in the
+// input region. Row r maps directly to input view line r (the input box is
+// not scrolled/trimmed the way the transcript viewport is).
+func (m *model) highlightInput(iv string) string {
+	if m.sel == nil || !m.sel.anchor.input {
+		return iv
+	}
+	lines := strings.Split(iv, "\n")
+	lo, hi := selOrder(*m.sel)
+	for r := lo.row; r <= hi.row && r < len(lines); r++ {
+		start, end := selCols(lo, hi, r, ansi.StringWidth(lines[r]))
+		lines[r] = reverseRange(lines[r], start, end)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // highlightSelection repaints the selected range in reverse video on the FULL
@@ -265,6 +314,12 @@ func (m *model) handleMouseSelect(msg tea.MouseMsg) (handled bool, cmd tea.Cmd) 
 		if msg.Button != tea.MouseButtonLeft {
 			return false, nil
 		}
+		// Input box: a press there starts an input-region selection. The textarea
+		// doesn't use mouse for editing, so consuming it costs nothing.
+		if p, ok := m.inputPoint(msg.X, msg.Y, false); ok {
+			m.sel = &selection{anchor: p, cur: p}
+			return true, nil
+		}
 		p, ok := m.selPoint(msg.X, msg.Y, false)
 		if !ok {
 			return false, nil
@@ -274,6 +329,14 @@ func (m *model) handleMouseSelect(msg tea.MouseMsg) (handled bool, cmd tea.Cmd) 
 	case tea.MouseActionMotion:
 		if m.sel == nil || m.sel.done {
 			return false, nil
+		}
+		// The drag stays in the anchor's region: input-anchored drags clamp into
+		// the input box; transcript-anchored drags clamp into the blocks.
+		if m.sel.anchor.input {
+			if p, ok := m.inputPoint(msg.X, msg.Y, true); ok {
+				m.sel.cur = p
+			}
+			return true, nil // the input box doesn't scroll; no edge tick
 		}
 		if p, ok := m.selPoint(msg.X, msg.Y, true); ok {
 			m.sel.cur = p
@@ -289,7 +352,11 @@ func (m *model) handleMouseSelect(msg tea.MouseMsg) (handled bool, cmd tea.Cmd) 
 			copyText(m.selText(*m.sel))
 			return true, nil
 		}
+		inputClick := m.sel.anchor.input
 		m.sel = nil
+		if inputClick {
+			return true, nil // a no-drag click in the input box is just focus
+		}
 		m.clickAt(msg.X, msg.Y) // no drag: the press was a click all along
 		return true, nil
 	}

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -121,19 +121,23 @@ func TestClickExpandsToolBlock(t *testing.T) {
 	}
 }
 
-// A press below the transcript (input box / dock rows) must NOT start a
-// selection — handleMouseSelect runs before the dock/input click handlers, so
-// consuming those presses would break their clicks. A drag that overshoots
-// past the last block still clamps (motion only).
+// A press on the header/status rows must NOT start a selection —
+// handleMouseSelect runs before the dock/effort click handlers, so consuming
+// those presses would break their clicks. The input box IS selectable now (a
+// press there starts an input-region selection). A drag that overshoots past
+// the last block still clamps (motion only).
 func TestPressOutsideTranscriptNotConsumed(t *testing.T) {
 	m := selTestModel()
-	lastY := blockRowY(m, m.blocks[1].y1)
-	for _, y := range []int{0, 1, lastY + 2, m.height - 1} {
+	m.View()
+	for _, y := range []int{0, 1, m.height - 1} { // header rows + status line
+		if m.inInputRow(y) {
+			continue // the input box is its own selectable region now
+		}
 		if handled, _ := m.handleMouseSelect(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 2, Y: y}); handled {
-			t.Fatalf("press on non-transcript row %d must not be consumed", y)
+			t.Fatalf("press on non-selectable row %d must not be consumed", y)
 		}
 		if m.sel != nil {
-			t.Fatalf("press on non-transcript row %d must not start a selection", y)
+			t.Fatalf("press on non-selectable row %d must not start a selection", y)
 		}
 	}
 	// but a drag that starts on the transcript and overshoots below clamps
@@ -154,6 +158,61 @@ func TestDragBackward(t *testing.T) {
 	m.handleMouseSelect(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 7, Y: y})
 	if got := m.selText(*m.sel); got != "block here" {
 		t.Fatalf("backward drag selected %q, want %q", got, "block here")
+	}
+}
+
+// A drag over the input box selects its text and copies it on release, with a
+// reverse-video highlight that does not move the box.
+func TestInputDragSelectsHighlightsCopies(t *testing.T) {
+	m := selTestModel()
+	m.input.SetValue("copy me from input")
+	tm, _ := m.Update(mkWinSize(80, 30))
+	m = tm.(*model)
+	m.View()
+	iy := m.inputTop
+	if iy < 0 {
+		t.Fatal("inputTop must be set after View")
+	}
+	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 2, Y: iy})
+	m = tm.(*model)
+	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft, X: 15, Y: iy})
+	m = tm.(*model)
+	if m.sel == nil || !m.sel.anchor.input {
+		t.Fatal("a drag over the input box must start an input-region selection")
+	}
+	if !strings.Contains(m.View(), "\x1b[7m") {
+		t.Fatalf("input selection must paint a highlight:\n%q", m.View())
+	}
+	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 15, Y: iy})
+	m = tm.(*model)
+	if m.sel == nil || !m.sel.done {
+		t.Fatal("release must keep a done selection for the highlight")
+	}
+	if got := m.selText(*m.sel); !strings.Contains(got, "copy me") {
+		t.Fatalf("input drag copied %q, want it to contain %q", got, "copy me")
+	}
+}
+
+// A no-drag click in the input box is just focus: no selection, and typing
+// afterward still reaches the textarea.
+func TestInputClickThenType(t *testing.T) {
+	m := selTestModel()
+	m.input.SetValue("")
+	tm, _ := m.Update(mkWinSize(80, 30))
+	m = tm.(*model)
+	m.View()
+	iy := m.inputTop
+	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 2, Y: iy})
+	m = tm.(*model)
+	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 2, Y: iy})
+	m = tm.(*model)
+	if m.sel != nil {
+		t.Fatal("a no-drag input click must leave no selection")
+	}
+	tm, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hello")})
+	m = tm.(*model)
+	if m.input.Value() != "hello" {
+		t.Fatalf("typing after an input click broke: input=%q", m.input.Value())
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -178,10 +178,10 @@ type model struct {
 
 	pendingForkID string // busy-forked copy awaiting the turn's end to switch into ("" = none)
 
-	mouseOn      bool       // runtime mouse-capture state (toggle with /mouse)
-	sel          *selection // in-flight/last drag selection over the transcript
-	selDragX     int        // last drag pointer position (edge auto-scroll re-checks it)
-	selDragY     int
+	mouseOn  bool       // runtime mouse-capture state (toggle with /mouse)
+	sel      *selection // in-flight/last drag selection over the transcript
+	selDragX int        // last drag pointer position (edge auto-scroll re-checks it)
+	selDragY int
 	// Input box selection tracking: View records the input's absolute screen
 	// rows so drag-select can hit-test/extract/highlight it. inputBodyOff is
 	// the line offset within viewBody where the input starts; inputTop is the
@@ -190,10 +190,10 @@ type model struct {
 	inputTop     int
 	inputLines   []string // the input box's rendered lines, ANSI-stripped
 	vpLead       int      // top blank rows viewportView last dropped (selection row mapping)
-	viewTop      int    // screen row of the view's first line (View tracks it; mouse Y is absolute)
-	viewH        int    // height of the last rendered view
-	themeHow     string // how auto theme detection resolved (env var, OSC query, …) — captured at startup/theme change for /report; never re-queried
-	compactModel string // config model name for compaction summaries; "" = the built-in default
+	viewTop      int      // screen row of the view's first line (View tracks it; mouse Y is absolute)
+	viewH        int      // height of the last rendered view
+	themeHow     string   // how auto theme detection resolved (env var, OSC query, …) — captured at startup/theme change for /report; never re-queried
+	compactModel string   // config model name for compaction summaries; "" = the built-in default
 	compactProv  string
 	// updateLatest is a pending newer release tag ("" when none), picked up
 	// from update.Pending at startup; the notice it renders is durable, so a

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -182,7 +182,14 @@ type model struct {
 	sel          *selection // in-flight/last drag selection over the transcript
 	selDragX     int        // last drag pointer position (edge auto-scroll re-checks it)
 	selDragY     int
-	vpLead       int    // top blank rows viewportView last dropped (selection row mapping)
+	// Input box selection tracking: View records the input's absolute screen
+	// rows so drag-select can hit-test/extract/highlight it. inputBodyOff is
+	// the line offset within viewBody where the input starts; inputTop is the
+	// absolute screen row (viewTop + inputBodyOff), -1 when hidden.
+	inputBodyOff int
+	inputTop     int
+	inputLines   []string // the input box's rendered lines, ANSI-stripped
+	vpLead       int      // top blank rows viewportView last dropped (selection row mapping)
 	viewTop      int    // screen row of the view's first line (View tracks it; mouse Y is absolute)
 	viewH        int    // height of the last rendered view
 	themeHow     string // how auto theme detection resolved (env var, OSC query, …) — captured at startup/theme change for /report; never re-queried
@@ -3782,6 +3789,23 @@ func (m *model) View() string {
 		m.viewH = lipgloss.Height(v)
 		m.viewTop = max(min(m.viewTop, m.height-m.viewH), 0)
 	}
+	// Record the input box's absolute screen rows for drag-select. The input is
+	// hidden during interactive bash (iactive), so there's nothing to select.
+	if m.iactive != nil || m.height == 0 {
+		m.inputTop = -1
+		m.inputLines = nil
+	} else {
+		m.inputTop = m.viewTop + m.inputBodyOff
+		iv := m.input.View()
+		if m.namePrompt != nil && m.namePrompt.mask {
+			iv = m.namePrompt.label + " ┃ " + m.namePrompt.maskedValue(m.input.Value())
+		}
+		raw := strings.Split(iv, "\n")
+		m.inputLines = make([]string, len(raw))
+		for i, ln := range raw {
+			m.inputLines[i] = strings.TrimRight(ansi.Strip(ln), " \t")
+		}
+	}
 	return v
 }
 
@@ -3882,6 +3906,9 @@ func (m *model) viewBody() string {
 	if m.rew != nil {
 		b.WriteString(m.rewindView() + "\n\n")
 	}
+	// Record where the input box starts (line offset within this viewBody) so
+	// View can convert it to an absolute screen row for drag-select hit-testing.
+	m.inputBodyOff = strings.Count(b.String(), "\n")
 	if m.iactive == nil {
 		if m.namePrompt != nil {
 			b.WriteString(m.namePrompt.label + " ")
@@ -3889,12 +3916,12 @@ func (m *model) viewBody() string {
 				// Secrets never echo: render the mask instead of the input's
 				// live view (which would show the key in the clear). The "┃ "
 				// prompt matches how the textarea renders its own first line.
-				b.WriteString("┃ " + m.namePrompt.maskedValue(m.input.Value()))
+				b.WriteString(m.highlightInput("┃ " + m.namePrompt.maskedValue(m.input.Value())))
 			} else {
-				b.WriteString(m.input.View())
+				b.WriteString(m.highlightInput(m.input.View()))
 			}
 		} else {
-			b.WriteString(m.input.View())
+			b.WriteString(m.highlightInput(m.input.View()))
 		}
 	}
 	if m.quit1 {


### PR DESCRIPTION
## Problem
Drag-to-copy only covered the transcript output. The input box (where you type your prompt) wasn't selectable — you couldn't highlight/copy text you'd typed or recalled there.

## Change
Extends whip's in-app drag selection to the input box, so click-drag over the input highlights and copies its text just like the transcript.

- `selPos` gains an `input` flag; a selection stays confined to its anchor's region, so transcript and input never mix in one drag.
- `View()` records the input box's absolute screen rows (`inputTop`) and rendered, ANSI-stripped lines (`inputLines`) for hit-testing and extraction. Handles the masked `namePrompt` case and the hidden interactive-bash case.
- `handleMouseSelect`: a press in the input box starts an input-region selection; drags clamp into the anchor's region; a no-drag input click is plain focus (not a tool-block `clickAt`), and typing still works afterward.
- New `highlightInput` paints the reverse-video selection on the input's own rendered lines; `selText` extracts from `inputLines` for that region.

## Tests
- `TestInputDragSelectsHighlightsCopies` — drag over the input selects, highlights, copies.
- `TestInputClickThenType` — a no-drag input click leaves no selection and typing still reaches the textarea.
- Updated `TestPressOutsideTranscriptNotConsumed` — the input box is its own selectable region now.

Full `internal/tui` suite passes; `go vet` clean.