### PR TITLE
feat(session): whip -c continue / whip -r browse sessions for current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ install script above.
 Drop a `.mcp.json` in your repo and MCP servers just appear (`/mcp` to see
 them). ctrl+c once interrupts; twice quits.
 
+Sessions save automatically. Use `whip -c` to continue the most recent
+session in this directory, `whip -r` to browse this directory's previous
+sessions, or `whip --resume <id>` to open a known session from `whip sessions`.
+
 ## Docs
 
 The full setup, config reference, MCP, browser/computer-use, and how

--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -68,6 +68,8 @@ func main() {
 	providerFlag := flag.String("p", "", "provider to route the model through (default: model's first provider)")
 	versionFlag := flag.Bool("version", false, "print version")
 	resumeFlag := flag.String("resume", "", "resume a previous session by id (or unique prefix)")
+	continueFlag := flag.Bool("c", false, "continue the most recent session in this directory")
+	browseFlag := flag.Bool("r", false, "browse previous sessions in this directory")
 	benchFlag := flag.Bool("bench", false, "do full startup init (config, routing, key, agent) then exit; for `task benchmark`")
 	cautiousFlag := flag.Bool("cautious", false, "ask before running commands / writing files")
 	flag.Parse()
@@ -75,6 +77,11 @@ func main() {
 	if *versionFlag {
 		fmt.Println("whip", version)
 		return
+	}
+	start, err := sessionStart(*resumeFlag, *continueFlag, *browseFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "whip:", err)
+		os.Exit(2)
 	}
 
 	// `whip mcp ...` — server management and the MCP server mode.
@@ -163,7 +170,7 @@ func main() {
 	// notice still shows on the next launch.
 	go update.Check(version)
 	tui.Version = version // /report names the build in the bug-report bundle
-	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(cwd()), *resumeFlag, *cautiousFlag)
+	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(cwd()), *resumeFlag, start, *cautiousFlag)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "whip:", err)
 		os.Exit(1)
@@ -171,4 +178,20 @@ func main() {
 	if sessionID != "" {
 		fmt.Printf("session %s — resume with: whip --resume %s\n", sessionID, sessionID)
 	}
+}
+
+// sessionStart maps the mutually exclusive session-start flags to the TUI
+// mode. --resume deliberately keeps its established explicit-ID behavior;
+// -c and -r match Pi's current-project shortcuts.
+func sessionStart(resumeID string, continueRecent, browse bool) (tui.SessionStart, error) {
+	if (continueRecent && browse) || (resumeID != "" && (continueRecent || browse)) {
+		return tui.SessionStartNone, fmt.Errorf("choose only one of --resume, -c, or -r")
+	}
+	if continueRecent {
+		return tui.SessionStartContinue, nil
+	}
+	if browse {
+		return tui.SessionStartBrowse, nil
+	}
+	return tui.SessionStartNone, nil
 }

--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -185,7 +186,7 @@ func main() {
 // -c and -r match Pi's current-project shortcuts.
 func sessionStart(resumeID string, continueRecent, browse bool) (tui.SessionStart, error) {
 	if (continueRecent && browse) || (resumeID != "" && (continueRecent || browse)) {
-		return tui.SessionStartNone, fmt.Errorf("choose only one of --resume, -c, or -r")
+		return tui.SessionStartNone, errors.New("choose only one of --resume, -c, or -r")
 	}
 	if continueRecent {
 		return tui.SessionStartContinue, nil

--- a/cmd/whip/main_test.go
+++ b/cmd/whip/main_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/context-labs/whip/internal/tui"
 )
 
 // The system prompt always carries the built-in operating rules (the safety
@@ -28,5 +30,42 @@ func TestSystemPromptAppendsUserMe(t *testing.T) {
 	}
 	if !strings.Contains(p, "Standing instructions from the user") || !strings.Contains(p, "Always pnpm") {
 		t.Fatalf("user instructions should append:\n%s", p)
+	}
+}
+
+func TestSessionStart(t *testing.T) {
+	tests := []struct {
+		name           string
+		resumeID       string
+		continueRecent bool
+		browse         bool
+		want           tui.SessionStart
+		wantErr        string
+	}{
+		{name: "none", want: tui.SessionStartNone},
+		{name: "explicit id", resumeID: "abc", want: tui.SessionStartNone},
+		{name: "continue", continueRecent: true, want: tui.SessionStartContinue},
+		{name: "browse", browse: true, want: tui.SessionStartBrowse},
+		{name: "continue and browse conflict", continueRecent: true, browse: true, wantErr: "choose only one"},
+		{name: "id and continue conflict", resumeID: "abc", continueRecent: true, wantErr: "choose only one"},
+		{name: "id and browse conflict", resumeID: "abc", browse: true, wantErr: "choose only one"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sessionStart(tt.resumeID, tt.continueRecent, tt.browse)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("sessionStart error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("sessionStart = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -378,7 +378,8 @@ relay: full device login + key mint, store round-trip, key validation),
   disables capture at startup.
 - Queueing (enter while busy), steering (empty enter), history recall (↑/↓),
   `@file` mentions, `$skill` invocation, `/goal` loop, `/resume` session
-  picker, `/effort` reasoning levels — see the roadmap for the full list.
+  picker, `whip -c` continue and `whip -r` browse for this directory,
+  `/effort` reasoning levels — see the roadmap for the full list.
 - **Settings commands run mid-turn.** `/theme`, `/mouse`, `/effort`, `/subagents` (alias `/tasks`),
   `/help`, `/cd`, `/pwd`, and the non-submitting `/goal` forms (bare, `clear`,
   `rounds`) execute immediately while busy instead of queueing — queued text

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,7 +49,8 @@ parallel tool calls and background subagents).
 
 ## Sessions
 
-- [x] SQLite session store with `--resume` / `/resume` picker
+- [x] SQLite session store with `--resume <id>`, `-c` continue, and `-r` /
+  `/resume` pickers
 - [x] Session titles: auto-generate a short title from the first exchange
 - [x] `/rename` a session (opencode: ctrl+r prompt dialog) — `/rename [title]`, bare opens an inline prompt prefilled with the current title, draft preserved
 - [x] `/fork` a session (pi: tree-structured JSONL entries with `parentId` — `docs/session-format.md`; opencode forks from any message via a per-message action menu) — `/fork [name]` copies the conversation to a new session with an auto-suggested `(fork #N)` name; `f` in the rewind picker forks from any message

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -543,20 +543,34 @@ func TestRestoreTaskSettledAndVisible(t *testing.T) {
 // still complete while a subscriber is parked mid-callback, and the parked
 // subscriber must be released by Cancel (not by contending on mu first).
 func TestBroadcastBlockingSubscriberCannotDeadlock(t *testing.T) {
+	allowEvent := make(chan struct{}, 1)
 	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-allowEvent:
+		case <-r.Context().Done():
+			return
+		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"hi"}}]}`+"\n\n")
 		w.(http.Flusher).Flush() // deliver the delta while the stream stays open
-		// Park the handler (not the body read) so the connection closes on
-		// server shutdown even if a test assertion fails mid-way.
+		// Park the handler (not the body read) until cleanup unblocks the
+		// subscriber and server, even when an assertion fails mid-way.
 		select {
 		case <-release:
 		case <-r.Context().Done():
 		}
 	}))
-	t.Cleanup(func() { close(release) }) // before srv.Close so the handler unwinds first
-	defer srv.Close()
+	t.Cleanup(func() {
+		// The handler may still be waiting to emit or the subscriber may be
+		// parked mid-callback. Unblock both before Close waits for it.
+		select {
+		case allowEvent <- struct{}{}:
+		default:
+		}
+		close(release)
+		srv.Close()
+	})
 
 	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
 	task := ag.StartBackground("probe", "p", SubModel{})
@@ -571,6 +585,7 @@ func TestBroadcastBlockingSubscriberCannotDeadlock(t *testing.T) {
 	}) {
 		t.Fatal("task should accept a subscriber while running")
 	}
+	allowEvent <- struct{}{} // emit only after the subscriber is registered
 
 	select {
 	case <-inCallback:

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -433,6 +433,19 @@ func (s *Store) Recent(n int) ([]Meta, error) {
 	return scanMetas(rows)
 }
 
+// RecentForCWD returns up to n sessions from cwd, newest first. Startup
+// continue/browse intentionally stay within the current project; Recent is
+// still available for the cross-project /resume browser and `whip sessions`.
+func (s *Store) RecentForCWD(cwd string, n int) ([]Meta, error) {
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, updated_at FROM sessions
+		WHERE cwd=? AND EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)
+		ORDER BY updated_at DESC LIMIT ?`, cwd, n)
+	if err != nil {
+		return nil, err
+	}
+	return scanMetas(rows)
+}
+
 // UserHistory returns user-message contents across ALL sessions (every folder),
 // newest first and de-duplicated, for up-arrow input recall. Order is by the
 // session's last activity then the message's position within it, so the most

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -227,6 +227,37 @@ func TestUserHistory(t *testing.T) {
 	}
 }
 
+func TestRecentForCWD(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	save := func(cwd, text string) string {
+		t.Helper()
+		id, err := st.Create(cwd, "m", "p")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := st.Save(id, 1, []llm.Message{{Role: "system"}, {Role: "user", Content: text}}, "m", "p"); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+
+	projectID := save("/projects/whip", "current project")
+	save("/projects/other", "another project")
+
+	recent, err := st.RecentForCWD("/projects/whip", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 1 || recent[0].ID != projectID {
+		t.Fatalf("RecentForCWD returned %+v, want only %s", recent, projectID)
+	}
+}
+
 // History recall must skip messages whip injected on the user's behalf
 // (steered background-task results, goal-continuation prompts) — only genuinely
 // typed submissions are recalled.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -234,6 +234,17 @@ type picker struct {
 	previews map[string][2]string // id -> last user, last assistant
 }
 
+// SessionStart selects a persisted conversation when the interactive TUI
+// starts. An explicit --resume id remains separate from these convenience
+// modes because it may name a session from another directory.
+type SessionStart int
+
+const (
+	SessionStartNone SessionStart = iota
+	SessionStartContinue
+	SessionStartBrowse
+)
+
 // newInput builds the prompt textarea with whip's keybindings and styling.
 // Newlines come from ctrl+j / shift+enter / alt+enter; plain enter submits.
 func newInput() textarea.Model {
@@ -277,7 +288,7 @@ var (
 
 // Run starts the interactive session. It returns the id of the session that
 // was active on exit ("" if nothing was said).
-func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, cautious bool) (string, error) {
+func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, start SessionStart, cautious bool) (string, error) {
 	// Trust gate first: before whip reads a single file, ask whether this
 	// folder's contents may steer the model. Persisted per absolute path in
 	// ~/.whip/trusted.json (claude-code's per-project trust dialog).
@@ -396,6 +407,15 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 		}
 		if err := m.resume(resumeID); err != nil {
 			return "", err
+		}
+	} else {
+		switch start {
+		case SessionStartContinue:
+			if err := m.continueRecent(); err != nil {
+				return "", err
+			}
+		case SessionStartBrowse:
+			m.openPickerForCWD(cwd())
 		}
 	}
 	// Pick up whatever the update check recorded: a notice from an earlier
@@ -2947,21 +2967,55 @@ func (p *picker) loadPreview(store *session.Store) {
 
 // openPicker starts the /resume browser on recent sessions.
 func (m *model) openPicker() {
+	m.openPickerForCWD("")
+}
+
+// openPickerForCWD starts the /resume browser, optionally limiting it to a
+// project directory. Startup `whip -r` uses the scoped form; /resume keeps
+// its established cross-project behavior.
+func (m *model) openPickerForCWD(wd string) {
 	if m.store == nil {
 		m.append(errStyle.Render("session store unavailable"))
 		return
 	}
-	metas, err := m.store.Recent(50)
+	var (
+		metas []session.Meta
+		err   error
+	)
+	if wd == "" {
+		metas, err = m.store.Recent(50)
+	} else {
+		metas, err = m.store.RecentForCWD(wd, 50)
+	}
 	if err != nil {
 		m.append(errStyle.Render(err.Error()))
 		return
 	}
 	if len(metas) == 0 {
-		m.append(dimStyle.Render("(no previous sessions)"))
+		message := "(no previous sessions)"
+		if wd != "" {
+			message = "(no previous sessions in this directory)"
+		}
+		m.append(dimStyle.Render(message))
 		return
 	}
 	m.picker = &picker{metas: metas, previews: map[string][2]string{}}
 	m.picker.loadPreview(m.store)
+}
+
+// continueRecent resumes the latest persisted conversation for this directory.
+func (m *model) continueRecent() error {
+	if m.store == nil {
+		return errors.New("cannot continue: session store unavailable")
+	}
+	metas, err := m.store.RecentForCWD(cwd(), 1)
+	if err != nil {
+		return err
+	}
+	if len(metas) == 0 {
+		return errors.New("no previous session in this directory")
+	}
+	return m.resume(metas[0].ID)
 }
 
 // openMenu starts tab completion: every candidate for the token's prefix is

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/session"
+)
+
+func TestOpenPickerForCWDScopesSessions(t *testing.T) {
+	st, err := session.Open(filepath.Join(t.TempDir(), "sessions.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	save := func(cwd, content string) string {
+		t.Helper()
+		id, err := st.Create(cwd, "model", "provider")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := st.Save(id, 1, []llm.Message{{Role: "system"}, {Role: "user", Content: content}}, "model", "provider"); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+
+	currentID := save("/projects/whip", "current project")
+	otherID := save("/projects/other", "another project")
+	m := &model{store: st}
+
+	m.openPickerForCWD("/projects/whip")
+	if m.picker == nil || len(m.picker.metas) != 1 || m.picker.metas[0].ID != currentID {
+		t.Fatalf("scoped picker = %+v, want only %s", m.picker, currentID)
+	}
+
+	m.picker = nil
+	m.openPicker()
+	if m.picker == nil || len(m.picker.metas) != 2 {
+		t.Fatalf("/resume picker = %+v, want both sessions", m.picker)
+	}
+	ids := map[string]bool{}
+	for _, meta := range m.picker.metas {
+		ids[meta.ID] = true
+	}
+	if !ids[currentID] || !ids[otherID] {
+		t.Fatalf("/resume picker omitted a session: %+v", m.picker.metas)
+	}
+}


### PR DESCRIPTION
## What

Pi-style session-resume shortcuts for the interactive TUI, scoped to the current project directory:

- **`whip -c`** — resume the most recent session in this directory
- **`whip -r`** — open the session picker limited to this directory's sessions
- **`whip --resume <id>`** — unchanged; still resumes an explicit session id, cross-project

The three flags are mutually exclusive — combining any two exits with code 2 and a clear error.

## How

- `session.RecentForCWD(cwd, n)` — new store query that filters by `cwd` and skips sessions with no messages, so "continue" never lands on an empty/abandoned session. The existing cross-project `Recent` (used by `/resume` and `whip sessions`) is untouched.
- `tui.SessionStart` enum (`None`/`Continue`/`Browse`) threads the startup mode into `tui.Run`; `-r` opens the same picker as `/resume` but scoped via `openPickerForCWD`.
- `cmd/whip.sessionStart` validates the flag combinations.

## Tests

- Flag-combination table test (`TestSessionStart`)
- `RecentForCWD` directory scoping (`TestRecentForCWD`)
- Picker scoping: `-r` shows only this-directory sessions, `/resume` still shows all (`TestOpenPickerForCWDScopesSessions`)

Also includes a CI-flake fix: `TestBroadcastBlockingSubscriberCannotDeadlock` now gates the SSE emission until the subscriber is registered and unblocks the parked handler before server close.

Docs updated: README, `docs/features.md`, `docs/roadmap.md`.