### PR TITLE
tui: show a ⧉ copied badge top-right after a drag-copy (#82)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -482,7 +482,11 @@ relay: full device login + key mint, store round-trip, key validation),
   and ←/→ steppers for the compaction level — `palette.go`.
 - **Mouse**: `/mouse` toggles capture; with capture off the terminal's native
   selection works, with it on shift-drag selects. `"mouse": false` in config
-  disables capture at startup.
+  disables capture at startup. A drag that copies shows a transient "⧉ copied"
+  badge at the header's top-right (issue #82): it paints in place on the header
+  row — no rows added, so nothing shifts and mouse row math is untouched — and
+  a 2s tick takes it down (`copyBadge`/`copyBadgeMsg`/`copyBadgeView` in
+  `select.go`; tests: `TestCopyBadge` in `select_test.go`).
 - Queueing (enter while busy), steering (empty enter), history recall (↑/↓),
   `@file` mentions, `$skill` invocation, `/goal` loop, `/resume` session
   picker, `/effort` reasoning levels — see the roadmap for the full list.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ parallel tool calls and background subagents).
 - [x] Tool rows: icon + present-participle verb while running ("Reading file…"), collapse on completion to a claude-style `● Verb(subject)` header that keeps the path/command visible, result under a `⎿` marker, red on failure (opencode `routes/session/index.tsx:1836`; claude-code header/summary shape)
 - [x] Render tool calls as they stream, before execution starts (pi: `message_update` spawns `ToolExecutionComponent` keyed by tool-call id)
 - [x] Spinner with elapsed time + token count (% of context window) in status line (opencode `routes/session/footer.tsx`) — cost part done (status line shows session spend when the provider advertises pricing)
-- [ ] Toast-style transient notifications for command success/failure (opencode `ui/toast.tsx` — 102 lines)
+- [ ] Toast-style transient notifications for command success/failure (opencode `ui/toast.tsx` — 102 lines) — partially: drag-copy shows a transient "⧉ copied" badge at the header's top-right (issue #82; `copyBadgeView` in `select.go`)
 - [ ] Desktop notification/sound when a turn finishes and the terminal is blurred (opencode `attention.ts` — "when: blurred" is the detail that makes it not-annoying)
 
 ## Sessions

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -301,6 +301,47 @@ func copyText(s string) {
 // selection can keep growing past what's on screen.
 type selScrollTick struct{}
 
+// copyBadgeMsg is the timer that clears the "copied" badge (issue #82).
+type copyBadgeMsg struct{}
+
+// copyBadgeFor is how long the badge stays up. The opencode toast this is
+// modeled on (ui/toast.tsx) uses 5s; a copy acknowledgment doesn't need that
+// long — 2s matches the other transient hints (quit/esc arm windows).
+const copyBadgeFor = 2 * time.Second
+
+// showCopyBadge paints the "⧉ copied" badge at the header's top-right and
+// arms the timer that takes it down. It paints IN PLACE over the header's
+// right edge (same trick as the selection highlight): no rows are added, so
+// the layout, the transcript, and all mouse row math stay exactly where they
+// were. A repeat copy retriggers the 2s window — that's fine: the badge is
+// idempotent, the superseded tick just clears it a little early.
+func (m *model) showCopyBadge() tea.Cmd {
+	m.copyBadge = true
+	return tea.Tick(copyBadgeFor, func(time.Time) tea.Msg { return copyBadgeMsg{} })
+}
+
+// copyBadgeView overlays the badge onto the rendered header line, right-aligned
+// (the header's own right-aligned ⚡ control hides beneath it — the badge is
+// the transient guest).
+func (m *model) copyBadgeView(header string) string {
+	if !m.copyBadge {
+		return header
+	}
+	badge := toolStyle.Render("⧉ copied")
+	i := strings.IndexByte(header, '\n') // the header is viewBody's first line
+	if i < 0 {
+		i = len(header)
+	}
+	line, rest := header[:i], header[i:]
+	budget := max(m.width-ansi.StringWidth(badge), 0)
+	if bw := ansi.StringWidth(line); bw < budget {
+		line += strings.Repeat(" ", budget-bw) // push the badge to the right edge
+	} else {
+		line = ansi.Truncate(line, budget, "") // narrow header: make room
+	}
+	return line + badge + rest
+}
+
 // handleMouseSelect runs the selection state machine for one mouse event. It
 // returns handled=true when the event is consumed by selection: a left press
 // inside the transcript block range (the viewport must NOT see it — a click
@@ -351,7 +392,7 @@ func (m *model) handleMouseSelect(msg tea.MouseMsg) (handled bool, cmd tea.Cmd) 
 		if m.sel.anchor != m.sel.cur { // a real drag: copy, keep the highlight
 			m.sel.done = true
 			copyText(m.selText(*m.sel))
-			return true, nil
+			return true, m.showCopyBadge()
 		}
 		inputClick := m.sel.anchor.input
 		m.sel = nil

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -83,6 +84,60 @@ func TestDragSelectsHighlightsCopies(t *testing.T) {
 	m = tm.(*model)
 	if m.sel != nil {
 		t.Fatal("keypress must clear the selection highlight")
+	}
+}
+
+// A real drag's release shows the "⧉ copied" badge at the header's top-right
+// (issue #82): the badge paints IN PLACE on the header row (no rows added, so
+// nothing shifts), and the 2s tick takes it down.
+func TestCopyBadge(t *testing.T) {
+	m := selTestModel()
+	y := blockRowY(m, m.blocks[1].y0)
+	before := m.View()
+	if strings.Contains(before, "copied") {
+		t.Fatal("no badge before any copy")
+	}
+
+	tm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 0, Y: y})
+	m = tm.(*model)
+	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft, X: 6, Y: y})
+	m = tm.(*model)
+	tm, cmd = m.Update(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 6, Y: y})
+	m = tm.(*model)
+	if !m.copyBadge || cmd == nil {
+		t.Fatalf("release must show the badge and arm its clear tick (badge=%v cmd=%v)", m.copyBadge, cmd != nil)
+	}
+
+	after := m.View()
+	rowOf := func(v, substr string) int {
+		for i, l := range strings.Split(v, "\n") {
+			if strings.Contains(ansi.Strip(l), substr) {
+				return i
+			}
+		}
+		return -1
+	}
+	// top-right: same header row as before, badge ends at the right edge
+	if r := rowOf(after, "copied"); r != 0 {
+		t.Fatalf("badge must paint on the header row, got row %d:\n%q", r, after)
+	}
+	hdr := strings.Split(after, "\n")[0]
+	if ansi.StringWidth(hdr) != m.width || !strings.HasSuffix(ansi.Strip(hdr), "copied") {
+		t.Fatalf("badge must sit at the top-right edge (width %d, want %d): %q", ansi.StringWidth(hdr), m.width, hdr)
+	}
+	// painting in place: the transcript didn't move
+	if rowOf(before, "second block here") != rowOf(after, "second block here") {
+		t.Fatal("the badge must not shift the transcript")
+	}
+	if lipgloss.Height(after) != lipgloss.Height(before) {
+		t.Fatal("the badge must not change the view height")
+	}
+
+	// the tick clears it
+	tm, _ = m.Update(copyBadgeMsg{})
+	m = tm.(*model)
+	if m.copyBadge || strings.Contains(m.View(), "copied") {
+		t.Fatal("copyBadgeMsg must take the badge down")
 	}
 }
 

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -98,11 +98,11 @@ func TestCopyBadge(t *testing.T) {
 		t.Fatal("no badge before any copy")
 	}
 
-	tm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 0, Y: y})
+	tm, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 0, Y: y})
 	m = tm.(*model)
 	tm, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft, X: 6, Y: y})
 	m = tm.(*model)
-	tm, cmd = m.Update(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 6, Y: y})
+	tm, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 6, Y: y})
 	m = tm.(*model)
 	if !m.copyBadge || cmd == nil {
 		t.Fatalf("release must show the badge and arm its clear tick (badge=%v cmd=%v)", m.copyBadge, cmd != nil)
@@ -121,7 +121,7 @@ func TestCopyBadge(t *testing.T) {
 	if r := rowOf(after, "copied"); r != 0 {
 		t.Fatalf("badge must paint on the header row, got row %d:\n%q", r, after)
 	}
-	hdr := strings.Split(after, "\n")[0]
+	hdr, _, _ := strings.Cut(after, "\n")
 	if ansi.StringWidth(hdr) != m.width || !strings.HasSuffix(ansi.Strip(hdr), "copied") {
 		t.Fatalf("badge must sit at the top-right edge (width %d, want %d): %q", ansi.StringWidth(hdr), m.width, hdr)
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -181,10 +181,11 @@ type model struct {
 
 	pendingForkID string // busy-forked copy awaiting the turn's end to switch into ("" = none)
 
-	mouseOn  bool       // runtime mouse-capture state (toggle with /mouse)
-	sel      *selection // in-flight/last drag selection over the transcript
-	selDragX int        // last drag pointer position (edge auto-scroll re-checks it)
-	selDragY int
+	mouseOn   bool       // runtime mouse-capture state (toggle with /mouse)
+	sel       *selection // in-flight/last drag selection over the transcript
+	selDragX  int        // last drag pointer position (edge auto-scroll re-checks it)
+	selDragY  int
+	copyBadge bool // "⧉ copied" badge on the header's top-right (issue #82); a 2s tick clears it
 	// Input box selection tracking: View records the input's absolute screen
 	// rows so drag-select can hit-test/extract/highlight it. inputBodyOff is
 	// the line offset within viewBody where the input starts; inputTop is the
@@ -1666,6 +1667,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// drag parked past the viewport edge: keep scrolling + extending the
 		// selection until the drag ends or the viewport hits its limit
 		return m, m.selEdgeScroll()
+
+	case copyBadgeMsg:
+		m.copyBadge = false // the copied acknowledgment has shown long enough
+		return m, nil
 
 	case tea.KeyMsg:
 		m.sel = nil // any keypress clears a finished selection highlight
@@ -3905,7 +3910,7 @@ func (m *model) currentView() string {
 // (WindowSizeMsg handler) and the next render re-anchors to the bottom.
 func (m *model) View() string {
 	m.syncInputPlaceholder()
-	v := m.viewBody()
+	v := m.copyBadgeView(m.viewBody()) // in-place header overlay; height is unchanged
 	if m.height > 0 {
 		m.viewH = lipgloss.Height(v)
 		m.viewTop = max(min(m.viewTop, m.height-m.viewH), 0)


### PR DESCRIPTION
Closes #82.

## What

When a drag-select auto-copies to the clipboard on release, show a transient **⧉ copied** badge at the **top-right** of the screen.

Previously a drag-copy gave no on-screen confirmation — the only feedback was the selection highlight, which reads as *selected*, not *copied*. The user couldn't tell the copy actually happened.

## How

- `internal/tui/select.go`: on a real drag's release, `showCopyBadge()` sets `copyBadge` and arms a 2s `tea.Tick` (the same pattern as the quit/esc arm windows). `copyBadgeView` paints the badge **in place** over the header row's right edge.
- Painting in place (rather than adding a row) means the layout, transcript, and all mouse row math stay exactly where they were — the header's right-aligned ⚡ effort control simply hides beneath the badge for its 2s. This matches how the selection highlight already repaints rows without moving text.
- A `copyBadgeMsg` case in `Update` clears the badge when the tick fires.

Modelled on opencode's `ui/toast.tsx` (single-slot top-right toast, 5s); 2s here matches whip's other transient hints. Documented in `docs/features.md`; roadmap toast item annotated as partially done.

## Test

`TestCopyBadge` (in `select_test.go`) drives a full Update-path drag and pins: the badge paints on the header row at the right edge, the view height and transcript rows don't shift, and the tick takes the badge down.

`task check`: gofmt/vet/tests green (`internal/tui` and all packages pass; the only failure is `internal/browser`'s live-Chrome remote-debugging test, which also fails on a clean main in this environment).
