### PR TITLE
tui: list catalog-advertised models in the compaction/subagent pickers

### DIFF
--- a/internal/tui/compact_cmd_test.go
+++ b/internal/tui/compact_cmd_test.go
@@ -120,6 +120,43 @@ func TestCompactCommandRejectsUnknownModel(t *testing.T) {
 	}
 }
 
+// A catalog-advertised id with no config entry is a valid pick: the catalog
+// fallback in Resolve routes it to the advertising provider.
+func TestCompactCommandSelectsCatalogModel(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := config.SaveCatalogs(map[string]config.Catalog{
+		"inference": {Models: []config.ModelInfoLite{{ID: "deepseek-v4-pro", ContextLength: 1048576}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m := compactCmdModel()
+	m.compactCommand([]string{"deepseek-v4-pro"})
+	if m.compactModel != "deepseek-v4-pro" || m.agent.CompactModel != "deepseek-v4-pro" || m.agent.CompactClient == nil {
+		t.Fatalf("catalog model should be picked and applied: %q / %q", m.compactModel, m.agent.CompactModel)
+	}
+	if m.cfg.CompactModel != "deepseek-v4-pro" {
+		t.Fatalf("config should persist the catalog pick, got %q", m.cfg.CompactModel)
+	}
+	if !strings.Contains(m.blocks[len(m.blocks)-1].text, "deepseek-v4-pro @ inference") {
+		t.Fatalf("the note should name the resolved provider, got %v", m.blocks[len(m.blocks)-1].text)
+	}
+}
+
+// A typo of a catalog id resolves fuzzy instead of dying on "unknown model".
+func TestCompactCommandResolvesFuzzy(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := config.SaveCatalogs(map[string]config.Catalog{
+		"inference": {Models: []config.ModelInfoLite{{ID: "deepseek-v4-pro", ContextLength: 1048576}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m := compactCmdModel()
+	m.compactCommand([]string{"deepseek-v4-pr"})
+	if m.compactModel != "deepseek-v4-pro" {
+		t.Fatalf("a fuzzy hit should pick the catalog model, got %q", m.compactModel)
+	}
+}
+
 func TestContextLimitFromCatalog(t *testing.T) {
 	m := compactCmdModel()
 	if got := m.contextLimitFor("inference", "kimi-k3-fast"); got != 131072 {

--- a/internal/tui/modelpicker.go
+++ b/internal/tui/modelpicker.go
@@ -128,6 +128,24 @@ func resolveModelFuzzy(cfg *config.Config, name string) (string, bool, []string)
 	return models[0], true, nil
 }
 
+// modelNamesFor lists every selectable model name: cfg.Models sorted
+// alphabetically, then catalog-advertised ids without a config entry (marked
+// "(new)"), sorted by name. The catalog fallback in Resolve makes the extra
+// ids usable without a config entry, so pickers list them alongside.
+func modelNamesFor(cfg *config.Config) []string {
+	names := make([]string, 0, len(cfg.Models))
+	for _, it := range buildModelItems(cfg) {
+		name := it.model
+		if it.fromCatalog {
+			name += dimNew
+		}
+		if len(names) == 0 || names[len(names)-1] != name {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
 // buildModelItems flattens the config into selectable routes, models sorted
 // alphabetically, providers in each model's declared order. Models advertised
 // by a provider's cached /models catalog but absent from cfg.Models follow in

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -83,9 +82,10 @@ type ppanel struct {
 
 	prepare string // panelGoal: text submitted when the editor closes
 
-	cands []string // panelCompact/panelSubagent: model names from config
-	list  []string // panelCompact/panelSubagent: "default (…)" + cands; panelTheme: {"auto","light","dark"}
-	midx  int      // panelCompact/panelSubagent/panelTheme/panelBrowser/panelMCP: selection
+	list []string // panelCompact/panelSubagent: "default (…)" + every known model (config then catalog "(new)"); panelTheme: {"auto","light","dark"}
+	midx int      // panelCompact/panelSubagent/panelTheme/panelBrowser/panelMCP: selection
+
+	note string // panelCompact/panelSubagent: dim footer note (stale catalog hint)
 
 	mcps []mcpRow // panelMCP: the two source toggles then one row per server
 
@@ -276,15 +276,10 @@ func (m *model) paletteItems() []paletteItem {
 			},
 			dynHint: func(m *model) string { return "/compact <model>" },
 			panel: func(m *model) *ppanel {
-				names := make([]string, 0, len(m.cfg.Models))
-				for name := range m.cfg.Models {
-					names = append(names, name)
-				}
-				sort.Strings(names)
+				names := modelNamesFor(m.cfg)
 				pp := &ppanel{
 					kind:  panelCompact,
 					title: "Compaction model",
-					cands: names,
 					list:  append([]string{"default (" + config.DefaultCompactModel + ")"}, names...),
 				}
 				for i, name := range pp.list {
@@ -292,6 +287,9 @@ func (m *model) paletteItems() []paletteItem {
 						pp.midx = i
 						break
 					}
+				}
+				if st := staleCatalogs(m.cfg, config.LoadCatalogs()); len(st) > 0 {
+					pp.note = "catalog stale for " + strings.Join(st, ", ") + " — /model refresh pulls newly announced models"
 				}
 				return pp
 			},
@@ -332,15 +330,10 @@ func (m *model) paletteItems() []paletteItem {
 			},
 			dynHint: func(m *model) string { return "config taskModel" },
 			panel: func(m *model) *ppanel {
-				names := make([]string, 0, len(m.cfg.Models))
-				for name := range m.cfg.Models {
-					names = append(names, name)
-				}
-				sort.Strings(names)
+				names := modelNamesFor(m.cfg)
 				pp := &ppanel{
 					kind:  panelSubagent,
 					title: "Subagent model",
-					cands: names,
 					list:  append([]string{"default (" + config.DefaultTaskModel + ")"}, names...),
 				}
 				for i, name := range pp.list {
@@ -348,6 +341,9 @@ func (m *model) paletteItems() []paletteItem {
 						pp.midx = i
 						break
 					}
+				}
+				if st := staleCatalogs(m.cfg, config.LoadCatalogs()); len(st) > 0 {
+					pp.note = "catalog stale for " + strings.Join(st, ", ") + " — /model refresh pulls newly announced models"
 				}
 				return pp
 			},
@@ -696,12 +692,8 @@ func (m *model) panelKey(msg tea.KeyMsg, pp *ppanel) (tea.Model, tea.Cmd) {
 				m.subagentModelCommand([]string{"off"})
 				pp.err = ""
 			} else {
-				name := pp.list[pp.midx]
-				args := []string{name}
-				if mdl := m.cfg.Models[name]; len(mdl.Providers) > 0 {
-					args = append(args, mdl.Providers[0])
-				}
-				m.subagentModelCommand(args)
+				name := strings.TrimSuffix(pp.list[pp.midx], dimNew)
+				m.subagentModelCommand([]string{name})
 				pp.err = ""
 				if m.cfg.TaskModel != name {
 					pp.err = "couldn't resolve " + name + " — kept previous"
@@ -727,12 +719,8 @@ func (m *model) panelKey(msg tea.KeyMsg, pp *ppanel) (tea.Model, tea.Cmd) {
 				m.compactCommand([]string{"off"})
 				pp.err = ""
 			} else {
-				name := pp.list[pp.midx]
-				args := []string{name}
-				if mdl := m.cfg.Models[name]; len(mdl.Providers) > 0 {
-					args = append(args, mdl.Providers[0])
-				}
-				m.compactCommand(args)
+				name := strings.TrimSuffix(pp.list[pp.midx], dimNew)
+				m.compactCommand([]string{name})
 				pp.err = ""
 				if m.compactModel != name {
 					pp.err = "couldn't resolve " + name + " — kept previous"
@@ -1019,14 +1007,21 @@ func (m *model) panelView(pp *ppanel) string {
 			if (i == 0 && m.cfg.TaskModel == "") || (i > 0 && name == m.cfg.TaskModel) {
 				cur = dimStyle.Render("  (current)")
 			}
+			line := name + cur
+			if strings.HasSuffix(name, dimNew) {
+				line = dimStyle.Render(line)
+			}
 			if i == pp.midx {
-				b.WriteString(botStyle.Render(" → "+name) + cur + "\n")
+				b.WriteString(botStyle.Render(" → "+line) + "\n")
 			} else {
-				b.WriteString("   " + name + cur + "\n")
+				b.WriteString("   " + line + "\n")
 			}
 		}
 		if pp.err != "" {
 			b.WriteString(errStyle.Render("  "+pp.err) + "\n")
+		}
+		if pp.note != "" {
+			b.WriteString(dimStyle.Render("  "+pp.note) + "\n")
 		}
 		b.WriteString("\n" + dimStyle.Render("  ↑/↓ select · enter/←/→ apply · esc back"))
 
@@ -1036,14 +1031,21 @@ func (m *model) panelView(pp *ppanel) string {
 			if (i == 0 && m.compactModel == "") || (i > 0 && name == m.compactModel) {
 				cur = dimStyle.Render("  (current)")
 			}
+			line := name + cur
+			if strings.HasSuffix(name, dimNew) {
+				line = dimStyle.Render(line)
+			}
 			if i == pp.midx {
-				b.WriteString(botStyle.Render(" → "+name) + cur + "\n")
+				b.WriteString(botStyle.Render(" → "+line) + "\n")
 			} else {
-				b.WriteString("   " + name + cur + "\n")
+				b.WriteString("   " + line + "\n")
 			}
 		}
 		if pp.err != "" {
 			b.WriteString(errStyle.Render("  "+pp.err) + "\n")
+		}
+		if pp.note != "" {
+			b.WriteString(dimStyle.Render("  "+pp.note) + "\n")
 		}
 		b.WriteString("\n" + dimStyle.Render("  ↑/↓ select · enter/←/→ apply · esc back"))
 

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -369,6 +370,47 @@ func TestPaletteCompactPanelDefaultRowRestores(t *testing.T) {
 	// into from the root list), the whole palette closed with it
 	if m.palette != nil && m.palette.top() != nil {
 		t.Fatal("enter should pop the panel")
+	}
+}
+
+// The compaction panel lists catalog-advertised models alongside the
+// configured ones (marked (new)), and selecting one applies it.
+func TestPaletteCompactPanelListsCatalogModels(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := config.SaveCatalogs(map[string]config.Catalog{
+		"inference": {FetchedAt: time.Now(), Models: []config.ModelInfoLite{{ID: "deepseek-v4-pro", ContextLength: 1048576}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m := compactCmdModel()
+	m.openPaletteOn("Compaction model")
+	pp := m.palette.top()
+	if pp == nil || pp.kind != panelCompact {
+		t.Fatal("openPaletteOn should land in the compaction panel")
+	}
+	found := -1
+	for i, name := range pp.list {
+		if strings.HasPrefix(name, "deepseek-v4-pro") {
+			found = i
+			if !strings.HasSuffix(name, dimNew) {
+				t.Fatalf("the catalog row should carry the (new) marker, got %q", name)
+			}
+		}
+	}
+	if found < 0 {
+		t.Fatalf("catalog models should be listed, got %v", pp.list)
+	}
+	for pp.midx != found { // walk onto the catalog row
+		tm, _ := m.paletteKey(tea.KeyMsg{Type: tea.KeyDown})
+		m = tm.(*model)
+	}
+	tm, _ := m.paletteKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = tm.(*model)
+	if m.compactModel != "deepseek-v4-pro" || m.agent.CompactModel != "deepseek-v4-pro" {
+		t.Fatalf("enter should pick the catalog model, got %q / %q", m.compactModel, m.agent.CompactModel)
+	}
+	if _, ok := m.cfg.Models["deepseek-v4-pro"]; ok {
+		t.Error("picking a catalog model must not write it into cfg.Models")
 	}
 }
 

--- a/internal/tui/taskmodel.go
+++ b/internal/tui/taskmodel.go
@@ -131,7 +131,9 @@ func (m *model) taskCommand(rest string) {
 
 // subagentModelCommand picks the model subagents run on. The pick persists to
 // the global config (taskModel/taskProvider); "off" restores the built-in
-// default. Driven from the ctrl+p "Subagent model" picker.
+// default. Driven from the ctrl+p "Subagent model" picker. The model may be a
+// config entry or a catalog-advertised id (the catalog fallback in Resolve
+// routes it); anything else resolves fuzzy before giving up.
 func (m *model) subagentModelCommand(args []string) {
 	if args[0] == "off" {
 		m.cfg.TaskModel, m.cfg.TaskProvider = "", ""
@@ -146,9 +148,17 @@ func (m *model) subagentModelCommand(args []string) {
 	if at, p, ok := strings.Cut(model, "@"); ok {
 		model, prov = at, p
 	}
-	if _, ok := m.cfg.Models[model]; !ok {
-		m.append(errStyle.Render("unknown model " + model))
-		return
+	if _, ok := m.cfg.Models[model]; !ok && !catalogAdvertises(m.cfg, model) {
+		resolved, ok2, cands := resolveModelFuzzy(m.cfg, model)
+		if !ok2 {
+			if len(cands) > 0 {
+				m.append(errStyle.Render("ambiguous model " + model + " — could be " + strings.Join(cands, ", ")))
+			} else {
+				m.append(errStyle.Render("unknown model " + model))
+			}
+			return
+		}
+		model = resolved
 	}
 	if len(args) > 1 {
 		prov = args[1]
@@ -162,12 +172,11 @@ func (m *model) subagentModelCommand(args []string) {
 	if err := m.cfg.Save(); err != nil {
 		m.append(errStyle.Render("config save failed: " + err.Error()))
 	}
-	if prov == "" {
-		if mdl := m.cfg.Models[model]; len(mdl.Providers) > 0 {
-			prov = mdl.Providers[0]
-		}
+	note := "◎ subagent model: " + model
+	if p := resolvedProvider(m.cfg, model, prov); p != "" {
+		note += " @ " + p
 	}
-	m.append(dimStyle.Render("◎ subagent model: " + model + " @ " + prov))
+	m.append(dimStyle.Render(note))
 }
 
 // taskDesc derives a short dock description from a /task prompt.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3823,7 +3823,9 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 }
 
 // compactCommand handles "/compact <args…>": off restores the built-in
-// default compaction model, "<model> [provider]" selects one (persisted).
+// default compaction model, "<model> [provider]" selects one (persisted). The
+// model may be a config entry or a catalog-advertised id (the catalog fallback
+// in Resolve routes it); anything else resolves fuzzy before giving up.
 func (m *model) compactCommand(args []string) {
 	if args[0] == "off" {
 		m.compactModel, m.compactProv = "", ""
@@ -3835,11 +3837,20 @@ func (m *model) compactCommand(args []string) {
 		m.append(dimStyle.Render("◎ compaction model: default (" + config.DefaultCompactModel + ")"))
 		return
 	}
-	if _, ok := m.cfg.Models[args[0]]; !ok {
-		m.append(errStyle.Render("unknown model " + args[0]))
-		return
+	name := args[0]
+	if _, ok := m.cfg.Models[name]; !ok && !catalogAdvertises(m.cfg, name) {
+		resolved, ok2, cands := resolveModelFuzzy(m.cfg, name)
+		if !ok2 {
+			if len(cands) > 0 {
+				m.append(errStyle.Render("ambiguous model " + name + " — could be " + strings.Join(cands, ", ")))
+			} else {
+				m.append(errStyle.Render("unknown model " + name))
+			}
+			return
+		}
+		name = resolved
 	}
-	m.compactModel = args[0]
+	m.compactModel = name
 	m.compactProv = ""
 	if len(args) > 1 {
 		m.compactProv = args[1]
@@ -3853,13 +3864,42 @@ func (m *model) compactCommand(args []string) {
 	if err := m.cfg.Save(); err != nil {
 		m.append(errStyle.Render("config save failed: " + err.Error()))
 	}
-	prov := m.compactProv
-	if prov == "" {
-		if mdl := m.cfg.Models[m.compactModel]; len(mdl.Providers) > 0 {
-			prov = mdl.Providers[0]
+	note := "◎ compaction model: " + m.compactModel
+	if prov := resolvedProvider(m.cfg, m.compactModel, m.compactProv); prov != "" {
+		note += " @ " + prov
+	}
+	m.append(dimStyle.Render(note))
+}
+
+// resolvedProvider reports which provider serves a picked model: the explicit
+// pick when given, else the model's first configured provider, else the
+// catalog's owner (for catalog-advertised picks without a config entry).
+func resolvedProvider(cfg *config.Config, model, prov string) string {
+	if prov != "" {
+		return prov
+	}
+	if mdl := cfg.Models[model]; len(mdl.Providers) > 0 {
+		return mdl.Providers[0]
+	}
+	cats := config.LoadCatalogs()
+	for name := range cfg.Providers {
+		if cat, ok := cats[name]; ok && cat.Find(model) != nil {
+			return name
 		}
 	}
-	m.append(dimStyle.Render("◎ compaction model: " + m.compactModel + " @ " + prov))
+	return ""
+}
+
+// catalogAdvertises reports whether a configured provider's cached /models
+// catalog lists the model id (making it resolvable without a config entry).
+func catalogAdvertises(cfg *config.Config, name string) bool {
+	cats := config.LoadCatalogs()
+	for p := range cfg.Providers {
+		if cat, ok := cats[p]; ok && cat.Find(name) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // compactPct returns the live threshold percent (the default when unset).


### PR DESCRIPTION
## Problem

The **Compaction model** palette panel (ctrl+p) only listed the 4 models from `cfg.Models` — the hardcoded `config.Default()` set or whatever is in `~/.whip/config.json` — even though the provider catalogs cached in `~/.whip/models.json` advertise hundreds of models, and:

- `/model`'s picker already merges those catalogs via `buildModelItems`
- `cfg.Resolve` already routes catalog-only ids via `resolveFromCatalog`
- tab-completion for `/compact <model>` already offered catalog models

So the picker's list *and* `compactCommand`/`subagentModelCommand`'s `cfg.Models` membership check were the only gates. Typing a catalog id manually got rejected with "unknown model".

## Fix

- **`modelNamesFor(cfg)`** (modelpicker.go): every selectable model name — config models sorted, then catalog-only ids marked `(new)`, deduped across multi-provider routes.
- **Both palette panels** (Compaction model + Subagent model) build from `modelNamesFor`; catalog rows render dimmed; a stale cache (>24h TTL) shows a dim *"catalog stale for … — /model refresh"* note.
- **`compactCommand` / `subagentModelCommand`** accept catalog ids and fall back to `resolveModelFuzzy` (unique fuzzy hit wins, ties named, unknowns rejected) — same UX as `/model`.
- **`resolvedProvider`** helper so the `◎ compaction model: x @ provider` note names the catalog owner for catalog-only picks (previously blank).
- Panel apply strips the `(new)` marker and drops the explicit provider arg — it read a zero-value `config.Model` for catalog picks, and `Resolve` already routes them to the advertising provider.

Picking a catalog model persists `compactModel`/`taskModel` without materializing a `cfg.Models` entry (same convention as `/model` on a catalog route); capabilities keep flowing from the catalog cache.

## Tests

- `TestCompactCommandSelectsCatalogModel` — catalog id picks, applies, persists, note names the provider
- `TestCompactCommandResolvesFuzzy` — typo of a catalog id resolves instead of erroring
- `TestPaletteCompactPanelListsCatalogModels` — end-to-end palette: catalog row listed with `(new)`, enter applies it, nothing written into `cfg.Models`

Full `go test ./internal/tui/` passes.