### PR TITLE
feat(agent): finalize on max-turns instead of erroring

### DIFF
--- a/cmd/whip/run.go
+++ b/cmd/whip/run.go
@@ -35,7 +35,7 @@ func runCLI(args []string) error {
 	resumeFlag := fs.String("resume", "", "continue this session id (see `whip sessions`) instead of starting fresh")
 	systemFlag := fs.String("system", "", "override the system prompt for this run")
 	systemFileFlag := fs.String("system-file", "", "read the system prompt from this file (wins over -system)")
-	maxTurnsFlag := fs.Int("max-turns", 0, "cap the tool-call loop at N rounds (0 = uncapped); a capped run exits non-zero")
+	maxTurnsFlag := fs.Int("max-turns", 0, "cap the tool-call loop at N rounds (0 = uncapped); on the cap, the model makes one final no-tools answer instead of erroring")
 	timeoutFlag := fs.Duration("timeout", 0, "wall-clock cap on the whole run (e.g. 30s, 5m); 0 = no timeout")
 	quietFlag := fs.Bool("quiet", false, "suppress the stderr tool/session notes (clean stdout for -format json piping)")
 	noSessionFlag := fs.Bool("no-session", false, "run without persisting a session (one-off jobs don't clutter whip sessions)")

--- a/cmd/whip/run_test.go
+++ b/cmd/whip/run_test.go
@@ -215,13 +215,21 @@ func TestRunSystemOverride(t *testing.T) {
 	}
 }
 
-// -max-turns caps the tool loop; a capped run errors non-zero.
+// -max-turns caps the tool loop; on the cap the model makes one final no-tools
+// answer instead of erroring.
 func TestRunMaxTurns(t *testing.T) {
-	// a server that always calls a tool (never finishes)
+	// Loops tool calls while tools are offered; answers with text once the
+	// final (no-tools) request arrives — like a real model.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"read","arguments":"{\"path\":\"/tmp/x\"}"}}]}}]}`+"\n\n")
-		fmt.Fprint(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n")
+		if len(req.Tools) == 0 {
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"final answer"},"finish_reason":"stop"}]}`+"\n\n")
+		} else {
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"read","arguments":"{\"path\":\"/tmp/x\"}"}}]}}]}`+"\n\n")
+			fmt.Fprint(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n")
+		}
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
 	defer srv.Close()
@@ -234,9 +242,12 @@ func TestRunMaxTurns(t *testing.T) {
 	}`, srv.URL)
 	os.WriteFile(filepath.Join(home, "config.json"), []byte(cfg), 0o600)
 
-	_, err := runCapture(t, "", "-max-turns", "2", "-no-session", "loop forever")
-	if err == nil || !strings.Contains(err.Error(), "max turns") {
-		t.Fatalf("a capped run should error with 'max turns', got %v", err)
+	out, err := runCapture(t, "", "-max-turns", "2", "-no-session", "loop forever")
+	if err != nil {
+		t.Fatalf("a capped run should finalize, not error: %v", err)
+	}
+	if !strings.Contains(out, "final answer") {
+		t.Fatalf("capped run should return the forced final answer, got %q", out)
 	}
 }
 
@@ -362,9 +373,17 @@ func TestRunJSONToolEvents(t *testing.T) {
 	if err := os.WriteFile(target, []byte("file body"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	// a server that always answers with a read tool call: only -max-turns ends it
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// Answers with a read tool call while tools are offered; once -max-turns
+	// forces a no-tools call, answers with text.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
 		w.Header().Set("Content-Type", "text/event-stream")
+		if len(req.Tools) == 0 {
+			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}`+"\n\n")
+			fmt.Fprint(w, "data: [DONE]\n\n")
+			return
+		}
 		args, _ := json.Marshal(map[string]string{"path": target})
 		call, _ := json.Marshal(string(args))
 		fmt.Fprintf(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"read","arguments":%s}}]}}]}`+"\n\n", call)
@@ -385,8 +404,8 @@ func TestRunJSONToolEvents(t *testing.T) {
 	}
 
 	out, err := runCapture(t, "", "-format", "json", "-max-turns", "2", "-quiet", "-no-session", "read it")
-	if err == nil {
-		t.Fatal("a capped run should error")
+	if err != nil {
+		t.Fatalf("a capped run should finalize, not error: %v", err)
 	}
 	seen := map[string]string{}
 	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
@@ -394,7 +413,7 @@ func TestRunJSONToolEvents(t *testing.T) {
 		if uerr := json.Unmarshal([]byte(line), &ev); uerr != nil {
 			t.Fatalf("stdout should be NDJSON, got %q: %v", line, uerr)
 		}
-		seen[ev["type"]] = ev["name"] + ev["result"] + ev["error"]
+		seen[ev["type"]] = ev["name"] + ev["result"] + ev["error"] + ev["text"]
 	}
 	if seen["tool_start"] != "read" {
 		t.Errorf("a tool call should emit tool_start for the tool, got %q", seen["tool_start"])
@@ -402,8 +421,8 @@ func TestRunJSONToolEvents(t *testing.T) {
 	if !strings.Contains(seen["tool_end"], "file body") {
 		t.Errorf("tool_end should carry the tool result, got %q", seen["tool_end"])
 	}
-	if !strings.Contains(seen["error"], "max turns") {
-		t.Errorf("a failed run should end with an error event, got %q", seen["error"])
+	if _, ok := seen["done"]; !ok {
+		t.Errorf("a finalized run should end with a done event, got %v", seen)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -397,7 +397,9 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 	rounds := 0
 	for {
 		if a.MaxTurns > 0 && rounds >= a.MaxTurns {
-			return "", fmt.Errorf("max turns (%d) reached — the model kept calling tools; re-run with a higher -max-turns or a more specific prompt", a.MaxTurns)
+			// Cap reached: instead of failing, make one final no-tools call so
+			// the model produces an answer from what it already gathered.
+			return a.finalAnswer(ctx, ev)
 		}
 		rounds++
 		if err := a.maybeCompact(ctx, ev); err != nil {
@@ -832,4 +834,31 @@ func (a *Agent) ManualCompact(ctx context.Context, ev Events) error {
 		ev.OnCompacted(sum, cutoff)
 	}
 	return nil
+}
+
+// finalAnswer makes one last completion with tools disabled, so a run that hit
+// the tool-turn cap still returns the model's best answer instead of an error.
+// A system nudge tells the model to stop calling tools and answer now.
+func (a *Agent) finalAnswer(ctx context.Context, ev Events) (string, error) {
+	msgs := append(append([]llm.Message(nil), a.Messages...),
+		llm.Message{Role: "system", Content: "You have reached the tool-call limit. Do NOT request any more tools. Give your final answer now using only what you have already gathered."})
+	a.Client.OnRetry = ev.OnRetry
+	msg, usage, err := a.Client.Stream(ctx, llm.Request{
+		Model:           a.Model,
+		Messages:        msgs,
+		Tools:           nil, // no tools — force a text answer
+		ReasoningEffort: a.Effort,
+		Temperature:     a.Temperature,
+		TopP:            a.TopP,
+	}, ev.OnText, ev.OnThink, ev.OnToolCall)
+	a.Client.OnRetry = nil
+	a.AddUsage(usage)
+	if ev.OnUsage != nil {
+		ev.OnUsage(usage)
+	}
+	if err != nil {
+		return "", err
+	}
+	a.compacted = false
+	return msg.Content, nil
 }


### PR DESCRIPTION
## What
When a `whip run` hits `-max-turns`, the agent used to return an error (`max turns reached — the model kept calling tools`) with **no answer**. Now the cap triggers one final completion with **tools disabled** and a nudge to answer from what it already gathered, so the run returns the model's best answer instead of failing.

## Why
Headless callers (e.g. [loupe](https://github.com/context-labs/loupe) PR reviews) lost the entire run when an agentic pass explored a beat too long. A forced final answer salvages the work.

## Change
- `internal/agent/agent.go`: on `rounds >= MaxTurns`, call a new `finalAnswer` (one `Stream` with `Tools: nil` + a "no more tools, answer now" system nudge) and return its content.
- Updated `-max-turns` help text and the two tests that asserted the old non-zero-exit behavior (mocks now return text when the request carries no tools, like a real model).

`go test ./...` passes.