### PR TITLE
tui: share one type-to-filter across every model picker

### DIFF
--- a/internal/tui/modelpicker.go
+++ b/internal/tui/modelpicker.go
@@ -25,11 +25,77 @@ type modelItem struct {
 	fromCatalog bool
 }
 
+// modelFilter is the shared type-to-filter for every model-selecting surface
+// (/model picker routes, palette model panels): a query plus the row indexes
+// it matches. Matches are tiered fuzzy (substring of the model or provider,
+// then subsequence), ranked best-first via matchTier. An empty query matches
+// everything (match == nil); a non-empty query with no hits yields an empty
+// (non-nil) match so views can render "no models match".
+type modelFilter struct {
+	query string
+	match []int // indexes into the caller's list, in ranked order; nil = no query
+}
+
+// apply refilters the rows with the given scoring function; empty query
+// restores the full list. score returns the match tier for row i (lower is
+// better, negative = no match).
+func (f *modelFilter) apply(rows int, score func(i int) int) {
+	q := strings.ToLower(strings.TrimSpace(f.query))
+	if q == "" {
+		f.match = nil
+		return
+	}
+	type hit struct {
+		i, tier int
+	}
+	var hits []hit
+	for i := range rows {
+		if tier := score(i); tier >= 0 {
+			hits = append(hits, hit{i, tier})
+		}
+	}
+	sort.SliceStable(hits, func(a, b int) bool { return hits[a].tier < hits[b].tier })
+	f.match = make([]int, 0, len(hits))
+	for _, h := range hits {
+		f.match = append(f.match, h.i)
+	}
+}
+
+// view returns the indexes into rows the filter currently shows (all rows in
+// order when the query is empty).
+func (f *modelFilter) view(rows int) []int {
+	if f.match == nil {
+		idx := make([]int, rows)
+		for i := range idx {
+			idx[i] = i
+		}
+		return idx
+	}
+	return f.match
+}
+
+// typeRunes appends typed runes to the query; backspace trims one. Both
+// return whether the query changed (so callers re-apply).
+func (f *modelFilter) typeRunes(rs []rune) bool {
+	if len(rs) == 0 {
+		return false
+	}
+	f.query += string(rs)
+	return true
+}
+
+func (f *modelFilter) backspace() bool {
+	if f.query == "" {
+		return false
+	}
+	f.query = f.query[:len(f.query)-1]
+	return true
+}
+
 // modelPicker is the /model browser: models grouped, providers indented under them.
 type modelPicker struct {
 	items      []modelItem
-	filtered   []modelItem // items matching query (nil == all)
-	query      string      // type-to-filter text
+	filter     modelFilter // type-to-filter over items
 	idx        int
 	staleHints []string // providers whose cached catalog is past its TTL
 	// sessionOnly marks a picker opened by /model-for-session: the selection
@@ -39,37 +105,36 @@ type modelPicker struct {
 
 // view returns the items the picker is currently showing.
 func (p *modelPicker) view() []modelItem {
-	if p.filtered != nil {
-		return p.filtered
+	idx := p.filter.view(len(p.items))
+	out := make([]modelItem, len(idx))
+	for i, j := range idx {
+		out[i] = p.items[j]
 	}
-	return p.items
+	return out
 }
 
-// applyQuery refilters items; empty query restores the full list. Matches are
-// fuzzy (tiered: substring of the model or provider, then subsequence), ranked
-// best-first. A query with no matches yields an empty (non-nil) filtered
-// slice — nil means "no query".
+// applyQuery refilters items; empty query restores the full list.
 func (p *modelPicker) applyQuery() {
-	q := strings.ToLower(strings.TrimSpace(p.query))
-	if q == "" {
-		p.filtered = nil
-		return
-	}
-	type hit struct {
-		item modelItem
-		tier int
-	}
-	var hits []hit
-	for _, it := range p.items {
-		if tier := bestTier(it.model, it.provider, q); tier >= 0 {
-			hits = append(hits, hit{it, tier})
+	q := strings.ToLower(strings.TrimSpace(p.filter.query))
+	p.filter.apply(len(p.items), func(i int) int {
+		it := p.items[i]
+		return bestTier(it.model, it.provider, q)
+	})
+}
+
+// applyModelList filters a plain list of model names (palette compact/subagent
+// panels, whose rows are names, not routes). The "(new)" catalog marker and
+// the leading "default (…)" row are stripped for scoring so the query matches
+// the real name.
+func (f *modelFilter) applyModelList(list []string) {
+	q := strings.ToLower(strings.TrimSpace(f.query))
+	f.apply(len(list), func(i int) int {
+		name := strings.TrimSuffix(list[i], dimNew)
+		if inner, ok := strings.CutPrefix(name, "default ("); ok {
+			name = strings.TrimSuffix(inner, ")")
 		}
-	}
-	sort.SliceStable(hits, func(a, b int) bool { return hits[a].tier < hits[b].tier })
-	p.filtered = make([]modelItem, 0, len(hits))
-	for _, h := range hits {
-		p.filtered = append(p.filtered, h.item)
-	}
+		return bestTier(name, "", q)
+	})
 }
 
 // bestTier is the best (lowest non-negative) match tier of the model and
@@ -244,8 +309,7 @@ func (m *model) modelPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			p.idx++
 		}
 	case tea.KeyBackspace:
-		if p.query != "" {
-			p.query = p.query[:len(p.query)-1]
+		if p.filter.backspace() {
 			p.applyQuery()
 			p.idx = 0
 		}
@@ -259,7 +323,7 @@ func (m *model) modelPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.mpicker = nil
 		m.switchModel(it.model, it.provider, !sessionOnly)
 	case tea.KeyRunes, tea.KeySpace:
-		p.query += string(msg.Runes)
+		p.filter.typeRunes(msg.Runes)
 		p.applyQuery()
 		if p.idx >= len(p.view()) {
 			p.idx = max(len(p.view())-1, 0)
@@ -272,7 +336,7 @@ func (m *model) modelPickerView() string {
 	p := m.mpicker
 	view := p.view()
 	var rows []string
-	rows = append(rows, "  "+botStyle.Render("/")+p.query+dimStyle.Render("▏"))
+	rows = append(rows, "  "+botStyle.Render("/")+p.filter.query+dimStyle.Render("▏"))
 	lastModel := ""
 	for i, it := range view {
 		heading := " " + it.model
@@ -298,7 +362,7 @@ func (m *model) modelPickerView() string {
 		}
 	}
 	if len(view) == 0 {
-		rows = append(rows, dimStyle.Render("  no models match "+strconv.Quote(p.query)))
+		rows = append(rows, dimStyle.Render("  no models match "+strconv.Quote(p.filter.query)))
 	}
 	rows = append(rows, dimStyle.Render(fmt.Sprintf("  (%d/%d) type to filter · ↑/↓ select · enter switch · esc cancel", p.idx+1, len(view))))
 	if len(p.staleHints) > 0 {

--- a/internal/tui/modelpicker_test.go
+++ b/internal/tui/modelpicker_test.go
@@ -54,28 +54,28 @@ func TestModelPickerFilter(t *testing.T) {
 	}
 
 	// substring on model name, case-insensitive
-	p.query = "BET"
+	p.filter.query = "BET"
 	p.applyQuery()
 	if got := p.view(); len(got) != 2 || got[0].model != "beta" {
 		t.Fatalf("filter by model: %+v", got)
 	}
 
 	// substring on provider name
-	p.query = "c"
+	p.filter.query = "c"
 	p.applyQuery()
 	if got := p.view(); len(got) != 1 || got[0].provider != "c" {
 		t.Fatalf("filter by provider: %+v", got)
 	}
 
 	// no match: empty view, not a crash
-	p.query = "zzz"
+	p.filter.query = "zzz"
 	p.applyQuery()
 	if got := p.view(); len(got) != 0 {
 		t.Fatalf("no-match view: %+v", got)
 	}
 
 	// clearing the query restores everything
-	p.query = ""
+	p.filter.query = ""
 	p.applyQuery()
 	if got := len(p.view()); got != 4 {
 		t.Fatalf("cleared query view: %d", got)
@@ -89,14 +89,14 @@ func TestModelPickerFuzzyFilter(t *testing.T) {
 	}}
 
 	// subsequence: "claudopus" skips the "-" and still matches
-	p.query = "claudopus"
+	p.filter.query = "claudopus"
 	p.applyQuery()
 	if got := p.view(); len(got) != 1 || got[0].model != "claude-opus-4" {
 		t.Fatalf("subsequence filter: %+v", got)
 	}
 
 	// provider match ranks alongside model matches
-	p.query = "openai"
+	p.filter.query = "openai"
 	p.applyQuery()
 	if got := p.view(); len(got) != 1 || got[0].model != "gpt-5" {
 		t.Fatalf("provider subsequence filter: %+v", got)

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -84,6 +85,8 @@ type ppanel struct {
 
 	list []string // panelCompact/panelSubagent: "default (…)" + every known model (config then catalog "(new)"); panelTheme: {"auto","light","dark"}
 	midx int      // panelCompact/panelSubagent/panelTheme/panelBrowser/panelMCP: selection
+
+	filter modelFilter // panelCompact/panelSubagent: type-to-filter over list
 
 	note string // panelCompact/panelSubagent: dim footer note (stale catalog hint)
 
@@ -677,57 +680,64 @@ func (m *model) panelKey(msg tea.KeyMsg, pp *ppanel) (tea.Model, tea.Cmd) {
 			}
 		}
 
-	case panelSubagent:
-		switch msg.Type {
-		case tea.KeyEsc, tea.KeyCtrlC:
-			pop()
-		case tea.KeyUp, tea.KeyCtrlP, tea.KeyShiftTab:
-			pp.midx = (pp.midx - 1 + len(pp.list)) % len(pp.list)
-		case tea.KeyDown, tea.KeyCtrlN, tea.KeyTab:
-			pp.midx = (pp.midx + 1) % len(pp.list)
-		case tea.KeyLeft, tea.KeyRight, tea.KeyEnter:
-			// apply immediately so a bad pick reports its error inline while
-			// the panel is still open
-			if pp.midx == 0 {
-				m.subagentModelCommand([]string{"off"})
-				pp.err = ""
+	case panelSubagent, panelCompact:
+		// compact and subagent share the model-list interaction: type-to-filter,
+		// ↑/↓ move over the filtered rows, ←/→/enter apply the highlighted one.
+		view := pp.filter.view(len(pp.list))
+		apply := func() {
+			if len(view) == 0 || pp.midx >= len(view) {
+				return
+			}
+			row := view[pp.midx]
+			name := strings.TrimSuffix(pp.list[row], dimNew)
+			pp.err = ""
+			if row == 0 { // the "default (…)" row
+				if pp.kind == panelCompact {
+					m.compactCommand([]string{"off"})
+				} else {
+					m.subagentModelCommand([]string{"off"})
+				}
+				return
+			}
+			if pp.kind == panelCompact {
+				m.compactCommand([]string{name})
+				if m.compactModel != name {
+					pp.err = "couldn't resolve " + name + " — kept previous"
+				}
 			} else {
-				name := strings.TrimSuffix(pp.list[pp.midx], dimNew)
 				m.subagentModelCommand([]string{name})
-				pp.err = ""
 				if m.cfg.TaskModel != name {
 					pp.err = "couldn't resolve " + name + " — kept previous"
 				}
 			}
-			if msg.Type == tea.KeyEnter && pp.err == "" {
-				pop()
-			}
 		}
-
-	case panelCompact:
 		switch msg.Type {
 		case tea.KeyEsc, tea.KeyCtrlC:
 			pop()
 		case tea.KeyUp, tea.KeyCtrlP, tea.KeyShiftTab:
-			pp.midx = (pp.midx - 1 + len(pp.list)) % len(pp.list)
-		case tea.KeyDown, tea.KeyCtrlN, tea.KeyTab:
-			pp.midx = (pp.midx + 1) % len(pp.list)
-		case tea.KeyLeft, tea.KeyRight, tea.KeyEnter:
-			// apply immediately so a bad pick reports its error inline while
-			// the panel is still open
-			if pp.midx == 0 {
-				m.compactCommand([]string{"off"})
-				pp.err = ""
-			} else {
-				name := strings.TrimSuffix(pp.list[pp.midx], dimNew)
-				m.compactCommand([]string{name})
-				pp.err = ""
-				if m.compactModel != name {
-					pp.err = "couldn't resolve " + name + " — kept previous"
-				}
+			if len(view) > 0 {
+				pp.midx = (pp.midx - 1 + len(view)) % len(view)
 			}
-			if msg.Type == tea.KeyEnter && pp.err == "" {
+		case tea.KeyDown, tea.KeyCtrlN, tea.KeyTab:
+			if len(view) > 0 {
+				pp.midx = (pp.midx + 1) % len(view)
+			}
+		case tea.KeyLeft, tea.KeyRight:
+			apply()
+		case tea.KeyEnter:
+			apply()
+			if pp.err == "" {
 				pop()
+			}
+		case tea.KeyBackspace, tea.KeyDelete:
+			if pp.filter.backspace() {
+				pp.filter.applyModelList(pp.list)
+				pp.midx = 0
+			}
+		case tea.KeyRunes, tea.KeySpace:
+			if pp.filter.typeRunes(msg.Runes) {
+				pp.filter.applyModelList(pp.list)
+				pp.midx = 0
 			}
 		}
 
@@ -1001,10 +1011,19 @@ func (m *model) panelView(pp *ppanel) string {
 		}
 		b.WriteString("\n" + dimStyle.Render("  ↑/↓ select · enter/←/→ apply · esc back"))
 
-	case panelSubagent:
-		for i, name := range pp.list {
+	case panelSubagent, panelCompact:
+		// compact and subagent share the model-list render: a "/" query line,
+		// the filtered rows, then err/note/footer.
+		b.WriteString("  " + botStyle.Render("/") + pp.filter.query + dimStyle.Render("▏") + "\n")
+		view := pp.filter.view(len(pp.list))
+		for i, row := range view {
+			name := pp.list[row]
 			cur := ""
-			if (i == 0 && m.cfg.TaskModel == "") || (i > 0 && name == m.cfg.TaskModel) {
+			current := m.compactModel
+			if pp.kind == panelSubagent {
+				current = m.cfg.TaskModel
+			}
+			if (row == 0 && current == "") || (row > 0 && name == current) {
 				cur = dimStyle.Render("  (current)")
 			}
 			line := name + cur
@@ -1017,29 +1036,8 @@ func (m *model) panelView(pp *ppanel) string {
 				b.WriteString("   " + line + "\n")
 			}
 		}
-		if pp.err != "" {
-			b.WriteString(errStyle.Render("  "+pp.err) + "\n")
-		}
-		if pp.note != "" {
-			b.WriteString(dimStyle.Render("  "+pp.note) + "\n")
-		}
-		b.WriteString("\n" + dimStyle.Render("  ↑/↓ select · enter/←/→ apply · esc back"))
-
-	case panelCompact:
-		for i, name := range pp.list {
-			cur := ""
-			if (i == 0 && m.compactModel == "") || (i > 0 && name == m.compactModel) {
-				cur = dimStyle.Render("  (current)")
-			}
-			line := name + cur
-			if strings.HasSuffix(name, dimNew) {
-				line = dimStyle.Render(line)
-			}
-			if i == pp.midx {
-				b.WriteString(botStyle.Render(" → "+line) + "\n")
-			} else {
-				b.WriteString("   " + line + "\n")
-			}
+		if len(view) == 0 {
+			b.WriteString(dimStyle.Render("  no models match "+strconv.Quote(pp.filter.query)) + "\n")
 		}
 		if pp.err != "" {
 			b.WriteString(errStyle.Render("  "+pp.err) + "\n")
@@ -1047,7 +1045,7 @@ func (m *model) panelView(pp *ppanel) string {
 		if pp.note != "" {
 			b.WriteString(dimStyle.Render("  "+pp.note) + "\n")
 		}
-		b.WriteString("\n" + dimStyle.Render("  ↑/↓ select · enter/←/→ apply · esc back"))
+		b.WriteString("\n" + dimStyle.Render("  type to filter · ↑/↓ select · enter/←/→ apply · esc back"))
 
 	case panelTheme:
 		cur := m.cfg.Theme

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -373,6 +373,78 @@ func TestPaletteCompactPanelDefaultRowRestores(t *testing.T) {
 	}
 }
 
+// Typing in a model panel fuzzy-filters the rows (same behavior as /model):
+// matches narrow as runes arrive, and enter applies the highlighted row.
+func TestPaletteModelPanelFilters(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	if err := config.SaveCatalogs(map[string]config.Catalog{
+		"inference": {FetchedAt: time.Now(), Models: []config.ModelInfoLite{{ID: "deepseek-v4-pro", ContextLength: 1048576}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m := compactCmdModel()
+	m.openPaletteOn("Compaction model")
+	pp := m.palette.top()
+	full := len(pp.list)
+	if full < 2 {
+		t.Fatalf("fixture should list several models, got %v", pp.list)
+	}
+	tm, _ := m.paletteKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("v4-pro")})
+	m = tm.(*model)
+	pp = m.palette.top()
+	view := pp.filter.view(len(pp.list))
+	if len(view) != 1 {
+		var rows []string
+		for _, r := range view {
+			rows = append(rows, pp.list[r])
+		}
+		t.Fatalf("typing should narrow %d rows to the v4-pro match, got %v", full, rows)
+	}
+	if name := pp.list[view[0]]; !strings.HasPrefix(name, "deepseek-v4-pro") {
+		t.Fatalf("the surviving row should be the catalog model, got %q", name)
+	}
+	// clearing the query via backspace restores the full list
+	for len(pp.filter.query) > 0 {
+		tm, _ = m.paletteKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		m = tm.(*model)
+		pp = m.palette.top()
+	}
+	if len(pp.filter.view(len(pp.list))) != full {
+		t.Fatalf("clearing the query should restore all %d rows, got %d", full, len(pp.filter.view(len(pp.list))))
+	}
+	// re-filter and apply the match
+	tm, _ = m.paletteKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("v4-pro")})
+	m = tm.(*model)
+	tm, _ = m.paletteKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = tm.(*model)
+	if m.compactModel != "deepseek-v4-pro" {
+		t.Fatalf("enter should apply the filtered model, got %q", m.compactModel)
+	}
+}
+
+// A query with no matches renders the "no models match" line and apply is a
+// no-op (no crash on an empty view).
+func TestPaletteModelPanelFilterNoMatch(t *testing.T) {
+	m := compactCmdModel()
+	m.openPaletteOn("Compaction model")
+	tm, _ := m.paletteKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("zzz-no-such")})
+	m = tm.(*model)
+	pp := m.palette.top()
+	if len(pp.filter.view(len(pp.list))) != 0 {
+		t.Fatal("a nonsense query should match nothing")
+	}
+	view := m.panelView(pp)
+	if !strings.Contains(view, "no models match") {
+		t.Errorf("the empty-filter view should say so, got %q", view)
+	}
+	// enter on an empty view must not panic or apply anything
+	tm, _ = m.paletteKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m = tm.(*model)
+	if m.compactModel != "" {
+		t.Errorf("an empty view must not change the compaction model, got %q", m.compactModel)
+	}
+}
+
 // The compaction panel lists catalog-advertised models alongside the
 // configured ones (marked (new)), and selecting one applies it.
 func TestPaletteCompactPanelListsCatalogModels(t *testing.T) {


### PR DESCRIPTION
## Problem

ctrl+p › **Compaction model** and **Subagent model** list every config + catalog model (after #89) but had no way to narrow them — `/model` type-to-filters with tiered substring/subsequence ranking, the palette panels didn't. Two selection surfaces, two behaviors.

## Fix

Extract the filter into one small shared `modelFilter` (query + ranked row indexes over a scoring function) and rebase **both** surfaces onto it, so the fuzzy logic lives in exactly one place:

- **`modelPicker.applyQuery`** now drives `modelFilter` over its `modelItem` routes — same user-visible behavior, no more duplicated hit-collection/sort code.
- **`modelFilter.applyModelList`** scores the panels' plain name lists, stripping the `default (…)` wrapper and `(new)` catalog markers so queries match the real name.
- **`panelSubagent` + `panelCompact`** collapse into one shared key handler and one shared render: a `/` query line, fuzzy-filtered rows, the `no models match` empty state, and a `type to filter` footer. (This also deletes the last duplicated apply/navigation block between the two panels.)

Typing, Backspace, and apply (enter/←/→) now behave identically across `/model`, ctrl+p › Compaction model, and ctrl+p › Subagent model.

## Tests

- `TestPaletteModelPanelFilters` — typing narrows rows, Backspace restores, enter applies the filtered model
- `TestPaletteModelPanelFilterNoMatch` — nonsense query renders "no models match" and apply is a safe no-op
- Existing `TestModelPickerFilter`/`FuzzyFilter` updated to the new field and still pass (proving `/model` behavior is unchanged)

Full `go test ./internal/tui/` + `golangci-lint` (0 issues) pass.