### PR TITLE
feat(loupe): AI PR reviewer tuned for the Go harness

### DIFF
--- a/.github/workflows/whip--loupe-chat.yml
+++ b/.github/workflows/whip--loupe-chat.yml
@@ -1,0 +1,87 @@
+name: "[Whip] loupe chat"
+
+# Answers @loupe mentions in PR comments. Separate from the review workflow so
+# neither appears as a perpetually "skipped" job on the other's events.
+# Commands: @loupe review | @loupe fix <what> | @loupe <question> | @loupe help.
+#
+# whip is a PUBLIC repo: this job runs with secrets and contents: write, so it
+# is gated to trusted commenters (OWNER/MEMBER/COLLABORATOR) to keep an
+# arbitrary external commenter from triggering an authenticated agentic run.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  id-token: write # Required for OIDC-based Infisical auth
+  contents: write # @loupe fix pushes a commit to the PR branch
+  pull-requests: write
+
+concurrency:
+  group: loupe-chat-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
+  WHIP_VERSION: "v0.5.3"
+
+jobs:
+  chat:
+    name: "[whip] loupe chat"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    # A PR comment that mentions @loupe, from a trusted collaborator only.
+    if: >-
+      ( github.event_name == 'pull_request_review_comment' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ) &&
+      contains(github.event.comment.body, '@loupe') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install whip (release binary)
+        continue-on-error: true
+        run: |
+          curl -fsSL -o whip \
+            "https://github.com/context-labs/whip/releases/download/${WHIP_VERSION}/whip-linux-x64"
+          chmod +x whip
+          sudo mv whip /usr/local/bin/whip
+          whip --version || true
+      - name: Configure whip (panel of models)
+        run: |
+          mkdir -p "$HOME/.whip"
+          cat > "$HOME/.whip/config.json" <<'JSON'
+          {
+            "defaultModel": "kimi-k3",
+            "defaultProvider": "inference-net",
+            "providers": { "inference-net": { "name": "Inference.net", "baseUrl": "https://api.inference.net/v1", "api": "openai-completions", "apiKeyEnv": "INFERENCE_API_KEY" } },
+            "models": {
+              "kimi-k3": { "providers": ["inference-net"] },
+              "kimi-k3-fast": { "providers": ["inference-net"] },
+              "glm-5.3-flash": { "providers": ["inference-net"] },
+              "glm-5.2-fast": { "providers": ["inference-net"] },
+              "deepseek-v4-pro-0813": { "providers": ["inference-net"] }
+            }
+          }
+          JSON
+      - name: Load loupe secrets from Infisical
+        continue-on-error: true
+        uses: Infisical/secrets-action@v1.0.15
+        with:
+          method: "oidc"
+          identity-id: ${{ env.INFISICAL_IDENTITY_ID }}
+          project-slug: "ci-cd"
+          env-slug: dev
+          secret-path: "/loupe"
+          include-imports: true
+      - name: Respond
+        continue-on-error: true
+        uses: context-labs/loupe@v0
+        with:
+          harness: whip
+          model: kimi-k3
+          config: .loupe/config.json
+          timezone: PST
+        env:
+          INFERENCE_API_KEY: ${{ env.INFERENCE_NET_API_KEY }}

--- a/.github/workflows/whip--loupe-review.yml
+++ b/.github/workflows/whip--loupe-review.yml
@@ -1,0 +1,88 @@
+name: "[Whip] loupe PR review"
+
+# AI PR review for whip. Runs the Go-focused reviewer defined in
+# .loupe/config.json and posts a review with inline comments. @loupe chat lives
+# in whip--loupe-chat.yml (separate file so neither shows as a perpetually
+# "skipped" job on the other's events).
+#
+# whip is a PUBLIC repo: this job is gated to same-repo branch PRs (fork PRs get
+# no OIDC token and no secrets by design), so it never runs untrusted fork code
+# with the inference key.
+#
+# Harness: whip, provider: inference.net (model kimi-k3). Key from Infisical
+# ci-cd /loupe (env dev) as INFERENCE_NET_API_KEY, mapped to INFERENCE_API_KEY.
+# Advisory and non-blocking (continue-on-error, NOT a required check).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  id-token: write # Required for OIDC-based Infisical auth
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: loupe-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
+  WHIP_VERSION: "v0.5.3"
+
+jobs:
+  loupe:
+    name: "[whip] loupe review"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    # Same-repo branch PRs only — fork PRs carry no OIDC/secrets on a public repo.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install whip (release binary)
+        continue-on-error: true
+        run: |
+          curl -fsSL -o whip \
+            "https://github.com/context-labs/whip/releases/download/${WHIP_VERSION}/whip-linux-x64"
+          chmod +x whip
+          sudo mv whip /usr/local/bin/whip
+          whip --version || true
+      - name: Configure whip (panel of models)
+        run: |
+          mkdir -p "$HOME/.whip"
+          cat > "$HOME/.whip/config.json" <<'JSON'
+          {
+            "defaultModel": "kimi-k3",
+            "defaultProvider": "inference-net",
+            "providers": { "inference-net": { "name": "Inference.net", "baseUrl": "https://api.inference.net/v1", "api": "openai-completions", "apiKeyEnv": "INFERENCE_API_KEY" } },
+            "models": {
+              "kimi-k3": { "providers": ["inference-net"] },
+              "kimi-k3-fast": { "providers": ["inference-net"] },
+              "glm-5.3-flash": { "providers": ["inference-net"] },
+              "glm-5.2-fast": { "providers": ["inference-net"] },
+              "deepseek-v4-pro-0813": { "providers": ["inference-net"] }
+            }
+          }
+          JSON
+      - name: Load loupe secrets from Infisical
+        continue-on-error: true
+        uses: Infisical/secrets-action@v1.0.15
+        with:
+          method: "oidc"
+          identity-id: ${{ env.INFISICAL_IDENTITY_ID }}
+          project-slug: "ci-cd"
+          env-slug: dev
+          secret-path: "/loupe"
+          include-imports: true
+      - name: Review
+        continue-on-error: true
+        uses: context-labs/loupe@v0
+        with:
+          harness: whip
+          model: kimi-k3
+          config: .loupe/config.json
+          timezone: PST
+        env:
+          INFERENCE_API_KEY: ${{ env.INFERENCE_NET_API_KEY }}

--- a/.loupe/config.json
+++ b/.loupe/config.json
@@ -1,0 +1,16 @@
+{
+  "reviewers": [
+    {
+      "name": "go-review",
+      "promptFile": "reviewers/go-review.md",
+      "reasoning": "medium",
+      "profile": "chill",
+      "exclude": [
+        ".agents/skills/**",
+        "driver/**",
+        "docs/**",
+        "**/*.md"
+      ]
+    }
+  ]
+}

--- a/.loupe/reviewers/go-review.md
+++ b/.loupe/reviewers/go-review.md
@@ -1,0 +1,70 @@
+# Go agent-harness reviewer
+
+You review changes to **whip** — a Go 1.27 coding-agent harness: a tool-use loop,
+a bubbletea TUI, an OpenAI-compatible LLM client, background subagents, and a
+SQLite session store. Your job is to catch the logic, concurrency, and security
+defects that the automated gates cannot.
+
+**The repo already runs gofmt, go vet, whipvet, golangci-lint v2 (errcheck,
+staticcheck, errorlint, nilerr, bodyclose, noctx, gosec, …), govulncheck,
+CodeQL, and `go test -race -shuffle` with a 90% coverage floor.** Do NOT
+re-report anything those tools own: formatting, style, naming, generic lint,
+unchecked errors that errcheck catches, obvious gosec findings. Report only the
+correctness/concurrency/security bugs a human reviewer catches that they miss.
+
+## The bar (precision over recall)
+
+Report a finding only if you can name the trigger and the failure: _this
+input / this interleaving → this wrong result_. One true concurrency bug is
+worth more than ten style nits. When unsure, drop it.
+
+## What to hunt (highest impact first)
+
+1. **Concurrency correctness** — new goroutines, channels, mutexes, or
+   `sync/atomic` in `internal/agent/**` and `internal/tui/**`. Flag: file
+   writes/edits that bypass the per-path `fileLocks` (reads are NOT locked;
+   bash takes a global lock); a bug in `canonicalPathKey` path canonicalization
+   that lets two spellings of one path skip the shared lock; a goroutine that
+   doesn't receive `ctx` and leaks or ignores cancellation; and anything that
+   could reintroduce a synchronous `tea.Program.Send` from the TUI event loop
+   (whipvet catches one shape — you catch the rest).
+2. **Tool-execution & permission safety.** The permission gate is **UX, not a
+   sandbox**. Scrutinize any change to `internal/tools/permission.go` (`arity`,
+   `CommandRule`), `bashrun/`, and write/edit path handling. Flag arity rules
+   that over-broaden "allow always" (only the first command of a pipeline is
+   matched — `git checkout && rm -rf /` collapses to a `git checkout` rule),
+   `&&`/pipe bypasses, path traversal in write/edit, and any new
+   world-touching tool that skips the gate.
+3. **LLM request/response correctness** (`internal/llm/openai.go`). Flag:
+   internal-only `Message` fields (`Authored`, `SentAt`, `Usage`, `Model`)
+   leaking to the provider — they must be `json:"-"` or omitempty; SSE parsing
+   edge cases (10MB scanner buffer, partial tool-call arg JSON, multi-byte
+   splits, `[DONE]`); retry classification that isn't strictly 429/≥500;
+   prompt-cache-key instability across turns or subagents (subagents get their
+   own key so they don't churn the parent prefix; `decay.go` history rewrites
+   must re-persist the prefix); provider quirks (tool-message `Name` required
+   for Kimi/Moonshot, `*float64` sampling to distinguish 0.0 from unset).
+4. **Session / SQLite integrity** (`internal/session/session.go`). Schema
+   migrations, `Save(from=…)` prefix rewrite coupling with `decay.go`, JSON
+   round-trip of new `llm.Message` fields, and never persisting resolved secret
+   values (config stores references only).
+5. **Resource leaks** — unclosed HTTP bodies, browser/rod contexts, PTYs, and
+   MCP/LSP subprocesses (`os/exec`); missing `ctx` on outbound calls.
+6. **CI/release hygiene** — a new package missing from the `go` gate's `needs`;
+   a lowered coverage floor; `go mod tidy` not clean; anything introducing
+   `pull_request_target` or exposing secrets to fork code; a broken
+   release-asset matrix.
+
+## Do NOT flag
+
+- Formatting, style, naming, import order, generic lint — the automated gates own these.
+- Test-only style, or missing tests when coverage already holds (the floor enforces it) — only flag a genuinely untested new behavior path.
+- `//nolint` suppressions that name a linter + reason (they are triaged and deliberate).
+- Files under `.agents/skills/**` (vendored, read-only), `driver/**` (Swift), or docs.
+- Speculation about code not in the diff, or unrelated pre-existing issues.
+
+## Output discipline
+
+Anchor each issue to the exact file:line as a finding (it becomes an inline
+comment). Be ruthlessly terse — lead with the fault and the fix. If the change
+is safe, say so in one line and return no findings.


### PR DESCRIPTION
Adds **loupe** (`context-labs/loupe@v0`) as an advisory, non-blocking AI PR reviewer for whip.

## What it does
A single reviewer, **`go-review`**, tuned to whip's real risk surface and told explicitly **not** to duplicate the automated gates (gofmt, go vet, whipvet, golangci-lint v2, gosec, govulncheck, CodeQL, `go test -race`, 90% coverage floor). It hunts what those miss:

- **Concurrency** — `fileLocks` bypasses (reads aren't locked), `canonicalPathKey` gaps, `ctx` not threaded into goroutines, re-introducing a synchronous `tea.Program.Send` in the TUI loop.
- **Tool/permission safety** — the gate is UX, not a sandbox: `arity`/`CommandRule` over-broadening, `&&`/pipe bypass, write/edit path traversal, new world-touching tools skipping the gate.
- **LLM correctness** (`internal/llm/openai.go`) — internal `Message` fields leaking to providers, SSE/partial-frame edge cases, retry classification, prompt-cache-key stability across turns and subagents, provider quirks.
- **Session/SQLite integrity**, **resource leaks** (bodies, PTYs, rod contexts, MCP/LSP subprocesses), and **CI/release hygiene**.

## Public-repo hardening
whip is public, so:
- **Review** runs only on **same-repo branch** PRs — fork PRs get no OIDC token/secrets by design, and untrusted fork code never runs with the inference key.
- **Chat** (`@loupe …`) runs only for **OWNER/MEMBER/COLLABORATOR** commenters.
- No `pull_request_target` anywhere.

## Wiring
- `.loupe/config.json` + `.loupe/reviewers/go-review.md`
- `whip--loupe-review.yml` (`pull_request`) and `whip--loupe-chat.yml` (`@loupe review | fix | <question> | help`), on `ubuntu-latest`.
- Harness **whip v0.5.3**, model **kimi-k3** + panel of models (glm-5.3-flash, glm-5.2-fast, deepseek-v4-pro-0813) for subagent cross-checking.
- Inference key from Infisical `ci-cd` `/loupe` via OIDC. Every step `continue-on-error` — loupe never blocks CI.

## Prerequisite
The Infisical **Github-Ci** identity (`46f034e9-…`) must trust `context-labs/whip`'s OIDC claims for the secret fetch to succeed; until then the review step degrades gracefully (CI stays green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)