### PR TITLE
feat(agent): per-subagent reasoning effort on the task tool

### DIFF
--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -23,12 +23,16 @@ type SubModel struct {
 	Model        string // model id sent to the API
 	ContextLimit int    // provider-advertised context window (0 = unknown)
 	MaxTokens    int    // output cap (0 = inherit the parent's)
+	Effort       string // reasoning-effort override ("" = inherit the parent's)
 }
 
 // newSub builds a fresh subagent. Route precedence: the explicit override o
 // (a per-task model pick) → the agent's TaskDefault (config taskModel) → the
 // parent's own client and model.
 func (a *Agent) newSub(o SubModel) *Agent {
+	// Capture the requested effort before o is replaced by a default route —
+	// a per-task effort can be set with or without a model override.
+	effort := o.Effort
 	if o.Client == nil {
 		o = a.TaskDefault
 	}
@@ -45,7 +49,12 @@ func (a *Agent) newSub(o SubModel) *Agent {
 	c := *o.Client
 	o.Client = &c
 	sub := New(o.Client, o.Model, o.MaxTokens, subagentPrompt())
-	sub.Effort = a.Effort
+	// A per-task effort override wins; otherwise inherit the parent's effort.
+	if effort != "" {
+		sub.Effort = effort
+	} else {
+		sub.Effort = a.Effort
+	}
 	sub.ContextLimit = o.ContextLimit
 	sub.Tools = tools.All()
 	return sub
@@ -73,8 +82,8 @@ func (a *Agent) resolveSub(model, provider string) (SubModel, error) {
 func taskTool(parent *Agent) tools.Tool {
 	return tools.Tool{
 		Def: llm.NewTool("subagent",
-			"Launch a subagent to handle a self-contained task with its own fresh context. It has the same tools as you (bash, read, write, edit) and returns only its final report. Use it for context-heavy exploration or work that can be described completely up front. To investigate several things in parallel, emit MULTIPLE subagent calls in one message — they run concurrently and all reports come back together in one turn. background=true is for fire-and-forget tasks you check on later: it runs concurrently while you keep working and the report arrives automatically as a message when it finishes (do NOT poll; subagent_steer can send mid-course corrections). Subagents run on a cheap fast model by default; set model only when the task needs a specific/stronger one.",
-			`{"type":"object","properties":{"description":{"type":"string","description":"Short 3-8 word summary of the task"},"prompt":{"type":"string","description":"Complete instructions for the subagent; it cannot ask follow-up questions"},"background":{"type":"boolean","description":"Run concurrently and get notified on completion (default false = block until done)"},"model":{"type":"string","description":"Optional model to run the subagent on (a configured model name or catalog id); omit for the default"},"provider":{"type":"string","description":"Optional provider for the model override; omit for its default routing"},"worktree":{"type":"boolean","description":"Run the subagent in its own git worktree so its file edits stay isolated from yours and from other subagents (default: the session's worktreeSubagents setting). Use true for parallel EDITING subagents; leave false for read-only/exploration tasks (worktree is wasted) or when the subagent needs the parent's uncommitted changes."}},"required":["prompt"]}`),
+			"Launch a subagent to handle a self-contained task with its own fresh context. It has the same tools as you (bash, read, write, edit) and returns only its final report. Use it for context-heavy exploration or work that can be described completely up front. To investigate several things in parallel, emit MULTIPLE subagent calls in one message — they run concurrently and all reports come back together in one turn. background=true is for fire-and-forget tasks you check on later: it runs concurrently while you keep working and the report arrives automatically as a message when it finishes (do NOT poll; subagent_steer can send mid-course corrections). Subagents run on a cheap fast model by default; set model (and optionally effort) only when the task needs a specific or stronger reasoning pass.",
+			`{"type":"object","properties":{"description":{"type":"string","description":"Short 3-8 word summary of the task"},"prompt":{"type":"string","description":"Complete instructions for the subagent; it cannot ask follow-up questions"},"background":{"type":"boolean","description":"Run concurrently and get notified on completion (default false = block until done)"},"model":{"type":"string","description":"Optional model to run the subagent on (a configured model name or catalog id); omit for the default"},"provider":{"type":"string","description":"Optional provider for the model override; omit for its default routing"},"effort":{"type":"string","description":"Optional reasoning effort for THIS subagent (e.g. \"low\", \"medium\", \"high\", \"xhigh\"); omit to inherit yours. Raise it for a deep-reasoning verification pass on a stronger model."},"worktree":{"type":"boolean","description":"Run the subagent in its own git worktree so its file edits stay isolated from yours and from other subagents (default: the session's worktreeSubagents setting). Use true for parallel EDITING subagents; leave false for read-only/exploration tasks (worktree is wasted) or when the subagent needs the parent's uncommitted changes."}},"required":["prompt"]}`),
 		Run: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var a struct {
 				Description string `json:"description"`
@@ -82,6 +91,7 @@ func taskTool(parent *Agent) tools.Tool {
 				Background  bool   `json:"background"`
 				Model       string `json:"model"`
 				Provider    string `json:"provider"`
+				Effort      string `json:"effort"`
 				Worktree    *bool  `json:"worktree"`
 			}
 			if err := json.Unmarshal(args, &a); err != nil {
@@ -96,6 +106,9 @@ func taskTool(parent *Agent) tools.Tool {
 				//nolint:nilerr // tool contract: failures are tool output the model reads, never loop aborts
 				return "Error: model override: " + err.Error(), nil
 			}
+			// A per-task effort rides on the resolved route (works with or
+			// without a model override; newSub preserves it across defaulting).
+			o.Effort = a.Effort
 
 			// Resolve worktree isolation: per-call override wins, else the
 			// session default. Only meaningful for background subagents (a

--- a/internal/agent/submodel_test.go
+++ b/internal/agent/submodel_test.go
@@ -39,6 +39,56 @@ func modelRecorder(t *testing.T, reply string) (*httptest.Server, func() []strin
 	}
 }
 
+// effortRecorder is a text server that records the reasoning_effort of every
+// request, so routing tests can assert which effort a subagent ran at.
+func effortRecorder(t *testing.T, reply string) (*httptest.Server, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var efforts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		mu.Lock()
+		efforts = append(efforts, req.ReasoningEffort)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		b, _ := json.Marshal(reply)
+		fmt.Fprintf(w, `data: {"choices":[{"delta":{"content":%s},"finish_reason":"stop"}]}`+"\n\n", b)
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), efforts...)
+	}
+}
+
+// A task-call effort override sets the subagent's reasoning effort independently
+// of the parent's; omitting it inherits the parent's effort.
+func TestTaskEffortOverride(t *testing.T) {
+	srv, efforts := effortRecorder(t, "ok")
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "parent-model", 100, "sys")
+	ag.Effort = "low"
+
+	// Explicit effort on the task call wins over the parent's.
+	out, err := findTool(t, ag, "subagent").Run(context.Background(),
+		json.RawMessage(`{"prompt":"go","effort":"xhigh"}`))
+	if err != nil || out != "ok" {
+		t.Fatalf("task run: %q, %v", out, err)
+	}
+	// No effort given: the subagent inherits the parent's "low".
+	if _, err := findTool(t, ag, "subagent").Run(context.Background(),
+		json.RawMessage(`{"prompt":"go"}`)); err != nil {
+		t.Fatal(err)
+	}
+	got := efforts()
+	if len(got) != 2 || got[0] != "xhigh" || got[1] != "low" {
+		t.Fatalf("subagent efforts should be [xhigh, low], saw %v", got)
+	}
+}
+
 // findTool digs a named tool out of an agent's built-in set.
 func findTool(t *testing.T, a *Agent, name string) tools.Tool {
 	t.Helper()


### PR DESCRIPTION
## Why
Subagents inherited the parent session's reasoning effort (`sub.Effort = a.Effort`) with no way to run one at a different level, and the `subagent` task tool exposed only `model`/`provider`. So you couldn't, say, keep the driver on `low` but dispatch a deep verification subagent at `xhigh`.

## What
- `SubModel` gains an `Effort` field.
- `newSub` applies a per-task effort override and otherwise inherits the parent's — captured before default-routing, so it works **with or without** a model override, and for both **foreground and background** subagents (both route through `newSub`).
- The `subagent` tool schema gains an optional `effort` arg; the value rides on the resolved `SubModel`. `reasoning_effort` is free-form passthrough to the provider, so any level the provider accepts (`low`/`medium`/`high`/`xhigh`/…) works.
- Test asserts an explicit `effort` wins and an omitted one inherits the parent's.

## Use case
Lets an orchestrator (e.g. loupe's PR reviewer) instruct whip: *"spawn a `gpt-5.6-luna` verification subagent at `xhigh` to pressure-test this suspected bug"* while the main model stays cheap/low.

Verified locally: `go build ./...`, `go vet ./internal/agent/`, `go test ./internal/agent/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)