### PR TITLE
feat(loupe): config-driven setup (harness/model/panel in .loupe.json)

### DIFF
--- a/.github/workflows/whip--loupe-chat.yml
+++ b/.github/workflows/whip--loupe-chat.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
-  WHIP_VERSION: "v0.5.3"
+  WHIP_VERSION: "v0.5.4"
 
 jobs:
   chat:
@@ -48,23 +48,6 @@ jobs:
           chmod +x whip
           sudo mv whip /usr/local/bin/whip
           whip --version || true
-      - name: Configure whip (panel of models)
-        run: |
-          mkdir -p "$HOME/.whip"
-          cat > "$HOME/.whip/config.json" <<'JSON'
-          {
-            "defaultModel": "kimi-k3",
-            "defaultProvider": "inference-net",
-            "providers": { "inference-net": { "name": "Inference.net", "baseUrl": "https://api.inference.net/v1", "api": "openai-completions", "apiKeyEnv": "INFERENCE_API_KEY" } },
-            "models": {
-              "kimi-k3": { "providers": ["inference-net"] },
-              "kimi-k3-fast": { "providers": ["inference-net"] },
-              "glm-5.3-flash": { "providers": ["inference-net"] },
-              "glm-5.2-fast": { "providers": ["inference-net"] },
-              "deepseek-v4-pro-0813": { "providers": ["inference-net"] }
-            }
-          }
-          JSON
       - name: Load loupe secrets from Infisical
         continue-on-error: true
         uses: Infisical/secrets-action@v1.0.15
@@ -79,9 +62,6 @@ jobs:
         continue-on-error: true
         uses: context-labs/loupe@v0
         with:
-          harness: whip
-          model: kimi-k3
           config: .loupe/config.json
-          timezone: PST
         env:
           INFERENCE_API_KEY: ${{ env.INFERENCE_NET_API_KEY }}

--- a/.github/workflows/whip--loupe-review.yml
+++ b/.github/workflows/whip--loupe-review.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
-  WHIP_VERSION: "v0.5.3"
+  WHIP_VERSION: "v0.5.4"
 
 jobs:
   loupe:
@@ -49,23 +49,6 @@ jobs:
           chmod +x whip
           sudo mv whip /usr/local/bin/whip
           whip --version || true
-      - name: Configure whip (panel of models)
-        run: |
-          mkdir -p "$HOME/.whip"
-          cat > "$HOME/.whip/config.json" <<'JSON'
-          {
-            "defaultModel": "kimi-k3",
-            "defaultProvider": "inference-net",
-            "providers": { "inference-net": { "name": "Inference.net", "baseUrl": "https://api.inference.net/v1", "api": "openai-completions", "apiKeyEnv": "INFERENCE_API_KEY" } },
-            "models": {
-              "kimi-k3": { "providers": ["inference-net"] },
-              "kimi-k3-fast": { "providers": ["inference-net"] },
-              "glm-5.3-flash": { "providers": ["inference-net"] },
-              "glm-5.2-fast": { "providers": ["inference-net"] },
-              "deepseek-v4-pro-0813": { "providers": ["inference-net"] }
-            }
-          }
-          JSON
       - name: Load loupe secrets from Infisical
         continue-on-error: true
         uses: Infisical/secrets-action@v1.0.15
@@ -80,9 +63,6 @@ jobs:
         continue-on-error: true
         uses: context-labs/loupe@v0
         with:
-          harness: whip
-          model: kimi-k3
           config: .loupe/config.json
-          timezone: PST
         env:
           INFERENCE_API_KEY: ${{ env.INFERENCE_NET_API_KEY }}

--- a/.loupe/config.json
+++ b/.loupe/config.json
@@ -1,4 +1,23 @@
 {
+  "harness": "whip",
+  "model": "kimi-k3",
+  "timezone": "PST",
+  "whip": {
+    "provider": {
+      "name": "inference-net",
+      "label": "Inference.net",
+      "baseUrl": "https://api.inference.net/v1",
+      "apiKeyEnv": "INFERENCE_API_KEY"
+    },
+    "defaultModel": "kimi-k3",
+    "models": [
+      "kimi-k3",
+      "kimi-k3-fast",
+      "glm-5.3-flash",
+      "glm-5.2-fast",
+      "deepseek-v4-pro-0813"
+    ]
+  },
   "reviewers": [
     {
       "name": "go-review",


### PR DESCRIPTION
Config-driven loupe: moves harness/model/timezone/dir and the whip provider + model panel into `.loupe.json`. loupe (@v0) materializes the whip config into a throwaway `WHIP_HOME` at review time, so the workflows drop the hand-written **Configure whip** step and the duplicated inputs — they now only provision (checkout, whip install, Infisical) and wire the secret. `WHIP_VERSION` → **v0.5.4** (per-subagent effort). Every step stays `continue-on-error` (advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)