### PR TITLE
fix(tui): complete $skills/@files after ctrl+j newline or multi-line paste

### DIFF
--- a/internal/tui/complete.go
+++ b/internal/tui/complete.go
@@ -37,12 +37,14 @@ var execNow = map[string]bool{
 
 // completions splits val into an untouched head and candidates for its last
 // token: slash commands, /model or /effort arguments, $skills, or filesystem
-// paths. nil efforts uses the default /effort candidates.
+// paths. A newline (ctrl+j or pasted text) also starts a fresh token, so
+// $skills and @files complete on later lines too. nil efforts uses the
+// default /effort candidates.
 func completions(val string, models, providers, skillCands, efforts []cand) (head string, cands []cand) {
 	if efforts == nil {
 		efforts = effortCands
 	}
-	i := strings.LastIndexByte(val, ' ')
+	i := strings.LastIndexAny(val, " \n")
 	head, token := val[:i+1], val[i+1:]
 	fields := strings.Fields(head)
 	switch {

--- a/internal/tui/mentions_test.go
+++ b/internal/tui/mentions_test.go
@@ -80,6 +80,36 @@ func TestSkillCompletion(t *testing.T) {
 	}
 }
 
+// Regression: after a ctrl+j newline (or a pasted multi-line block) the last
+// token starts on a later line; a space-only split never saw the $ prefix, so
+// skill completion silently died.
+func TestSkillCompletionAfterNewline(t *testing.T) {
+	sk := []cand{{"$go-style", "style rules"}, {"$go-testing", "test rules"}, {"$other", ""}}
+	for _, val := range []string{
+		"first line\n$go-",            // ctrl+j then start the token
+		"first line\napply $go-",      // ctrl+j then words then the token
+		"pasted\nmulti\nline\nuse $g", // pasted block ending in a $ token
+	} {
+		head, cs := completions(val, nil, nil, sk, nil)
+		if len(cs) == 0 || !strings.HasPrefix(cs[0].Text, "$go-") {
+			t.Fatalf("$ completion after newline: %q -> %v", val, texts(cs))
+		}
+		if !strings.HasSuffix(head, "$") && !strings.HasSuffix(head, " ") && !strings.HasSuffix(head, "\n") {
+			t.Fatalf("head should keep everything before the token: %q -> head %q", val, head)
+		}
+	}
+}
+
+// Same regression for @file completion on a later line.
+func TestAtMentionCompletionAfterNewline(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "alpha.txt"), nil, 0o644)
+	_, cs := completions("first line\nfix @"+dir+"/al", nil, nil, nil, nil)
+	if len(cs) != 1 || cs[0].Text != "@"+filepath.Join(dir, "alpha.txt") {
+		t.Fatalf("@ completion after newline: %v", texts(cs))
+	}
+}
+
 func TestPrepareTurnReloadsSkillsEveryTurn(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3058,7 +3058,7 @@ func (m *model) refreshMenu() {
 		return // previewing a frozen candidate; nothing to re-filter
 	}
 	val := m.input.Value()
-	token := val[strings.LastIndexByte(val, ' ')+1:]
+	token := val[strings.LastIndexAny(val, " \n")+1:]
 	if strings.HasPrefix(val, "/") || strings.HasPrefix(token, "@") || strings.HasPrefix(token, "$") {
 		head, cands := completions(val, m.modelCands(), m.providerCands(), m.skillCands(), effortCandsFor(m.effortsFor()))
 		if len(cands) > 0 {


### PR DESCRIPTION
## Problem

Invoking a skill with `$` stopped working once the input contained a newline — from ctrl+j or a pasted multi-line block. The completion split the input into head/token with `strings.LastIndexByte(val, ' ')`, so with `first line\n$go-` the "last token" was `line\n$go-`, which never matched the `$`-prefix branch. Skill completion silently died anywhere but the first line; the same bug hit `@file` completion.

## Fix

Split on `strings.LastIndexAny(val, " \n")` instead, in both places that do the token split:

- `completions()` (internal/tui/complete.go) — the candidate source for `$skills`, `@files`, and tab cycling
- `refreshMenu()` (internal/tui/tui.go) — the live-dropdown gate that decides whether to keep re-filtering

Note: expansion at submit time (`expandSkills`) was unaffected — it already scans whitespace-separated fields.

## Tests

- `TestSkillCompletionAfterNewline` — ctrl+j then `$`, ctrl+j then words then `$`, and a pasted multi-line block ending in a `$` token
- `TestAtMentionCompletionAfterNewline` — same regression for `@file`

`go test ./internal/tui/`, `go vet`, and `go build ./...` all pass.