### PR TITLE
feat(tui): "sidebar" config to hide opencode sidebar at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,6 +173,7 @@ type Config struct {
 	TaskProvider    string `json:"taskProvider,omitempty"`    // provider for the subagent model; "" = the model's default routing
 	Theme           string `json:"theme,omitempty"`           // "light", "dark", or "" (auto-detect at startup)
 	UIMode          string `json:"uiMode,omitempty"`          // "" (default whip look) or "opencode" (reproduces opencode's TUI palette/glyphs/logo)
+	Sidebar         *bool  `json:"sidebar,omitempty"`         // opencode-mode sidebar; nil = shown when the terminal is ≥120 cols, false = hidden at startup (ctrl+x b still toggles)
 	Mouse           *bool  `json:"mouse,omitempty"`           // false disables capture so native terminal selection works
 	Thinking        *bool  `json:"thinking,omitempty"`        // nil defaults to on; false hides reasoning tokens (ctrl+o)
 	CollapsePaste   *bool  `json:"collapsePaste,omitempty"`   // nil/false: pastes land verbatim; true collapses ≥3-line pastes into a [Pasted ~N lines] placeholder

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -363,10 +363,15 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 	if cfg.Thinking != nil {
 		showThinking = *cfg.Thinking
 	}
+	sidebarHide := false // default shown (when the terminal is wide enough); "sidebar": false opts out at startup
+	if cfg.Sidebar != nil {
+		sidebarHide = !*cfg.Sidebar
+	}
 	m := &model{
 		cfg: cfg, agent: ag, modelName: mn, provName: pn, sysPrompt: sysPrompt,
 		input: ti, spin: spinner.New(spinner.WithSpinner(spinner.Dot)), follow: true, saved: 1, hoverIdx: -1,
 		catalogs: config.LoadCatalogs(), mouseOn: mouseOn, now: time.Now, showThinking: showThinking,
+		sidebarHide: sidebarHide,
 		compactModel: cfg.CompactModel, compactProv: cfg.CompactProvider,
 		skillScan: func() []skills.Skill { return skills.Scan(skills.DefaultDirs()...) },
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -371,7 +371,7 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 		cfg: cfg, agent: ag, modelName: mn, provName: pn, sysPrompt: sysPrompt,
 		input: ti, spin: spinner.New(spinner.WithSpinner(spinner.Dot)), follow: true, saved: 1, hoverIdx: -1,
 		catalogs: config.LoadCatalogs(), mouseOn: mouseOn, now: time.Now, showThinking: showThinking,
-		sidebarHide: sidebarHide,
+		sidebarHide:  sidebarHide,
 		compactModel: cfg.CompactModel, compactProv: cfg.CompactProvider,
 		skillScan: func() []skills.Skill { return skills.Scan(skills.DefaultDirs()...) },
 	}


### PR DESCRIPTION
## What

Adds a `"sidebar"` config option that starts the opencode-mode right sidebar hidden, targeting the `feat/opencode-ui-mode` branch (PR #68).

```jsonc
{
  "uiMode": "opencode",
  "sidebar": false,   // start with the sidebar hidden
}
```

## Behavior

- `nil` / absent → current behavior unchanged (sidebar shown when terminal ≥120 cols)
- `"sidebar": false` → hidden at startup
- `ctrl+x b` still toggles live either way — config only sets the **initial** state

## How

- `internal/config/config.go` — `Sidebar *bool` field (`*bool` so absent ≠ explicit true/false)
- `internal/tui/tui.go` — read `cfg.Sidebar` into `model.sidebarHide` at startup

## Test plan

- `go build` + `go vet` clean on `internal/config` + `internal/tui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)