### PR TITLE
feat(agent): nudge the model toward subagents (system prompt + context pressure)

### DIFF
--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -49,7 +49,7 @@ Available tools:
 - bash: Execute bash commands (ls, grep, find, etc.)
 - edit: Make precise file edits with exact text replacement
 - write: Create or overwrite files
-- task: Delegate a self-contained task to a subagent with fresh context
+- subagent: Delegate a self-contained task to a subagent with fresh context
 
 Guidelines:
 - Use bash for file operations like ls, rg, find
@@ -59,6 +59,7 @@ Guidelines:
 - When the user tags a file with @, a note lists the tagged paths — inspect them with your tools as needed
 - Be concise in your responses
 - Show file paths clearly when working with files
+- Delegate proactively: exploration, codebase questions, and search that pull in more than a couple of files belong in a subagent, not inline — its context absorbs the bulk and only the distilled report returns to you. Launch independent investigations as parallel subagent calls in one message (background:true for fire-and-forget work you check on later). Don't delegate a lookup you already know the file for — read it directly.
 
 Operating rules:
 - The tool set changes turn to turn: MCP servers connect and drop, skills come and go. Never assume a tool exists because it did earlier — check the current set before calling it.

--- a/docs/features.md
+++ b/docs/features.md
@@ -147,6 +147,36 @@ catalog (hidden when the model has no advertised price). The result note
 renders even with no session store; the `raw history preserved` suffix appears
 only once the event is actually recorded.
 
+### Delegation nudges (proactive + context-pressure)
+
+Two mechanisms steer the model toward the `subagent` tool, modeled on how
+opencode and Claude Code drive delegation (their `task.txt` / sub-agent docs —
+delegation frequency is a prompt-engineering problem, not a capability one).
+
+- **Proactive guidance** lives in the base system prompt
+  (`cmd/whip/main.go` `systemPrompt`): a Guidelines line tells the model to
+  route multi-file exploration, codebase questions, and independent parallel
+  work to subagents (whose context absorbs the bulk and returns only the
+  distilled report), and to fire independent investigations as parallel
+  subagent calls in one message — while not delegating a lookup it already
+  knows the file for.
+- **Context-pressure nudge**: once the estimated token count crosses 35% of
+  the advertised context window (`nudgeThreshold`, below the 50% compaction
+  threshold so delegation can still *prevent* the fold), `Turn` appends an
+  ephemeral trailing system message each round (`contextPressureNudge`,
+  `internal/agent/agent.go`) telling the model current usage and to hand the
+  next big investigation to a subagent before doing more inline bulk reading.
+  Like the todo block, the nudge is re-derived per round and never persisted
+  to `a.Messages`, so it can't fossilize in the transcript after compaction
+  shrinks usage back down. It no-ops when the provider advertises no context
+  limit. The message pushes what the model controls (delegation), not a
+  compaction warning (which it doesn't control).
+
+Tests: `TestContextPressureNudge` (off without a limit, quiet below the
+threshold, fires above it naming subagent delegation),
+`TestContextPressureNudgeIsEphemeralPerRound` (rides the streamed request,
+never persisted into `a.Messages`).
+
 ### Provider prompt-prefix caching
 
 To cut time-to-first-token on the many sequential turns of an agent loop,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -432,6 +432,12 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 			msgs = append(append([]llm.Message(nil), a.Messages...),
 				llm.Message{Role: "system", Content: block})
 		}
+		if nudge := a.contextPressureNudge(); nudge != "" {
+			// Same ephemeral-append pattern as todoBlock: re-derived each round,
+			// never persisted, so it appears exactly while pressure is high.
+			msgs = append(append([]llm.Message(nil), msgs...),
+				llm.Message{Role: "system", Content: nudge})
+		}
 		// Surface transient-request retries through the event hook so the UI
 		// shows "retrying" instead of looking hung. Set/restored per call: the
 		// client may outlive this turn's Events.
@@ -651,6 +657,31 @@ func (a *Agent) threshold() float64 {
 		return a.CompactThreshold
 	}
 	return defaultCompactThreshold
+}
+
+// nudgeThreshold is the fraction of ContextLimit at which Turn starts
+// reminding the model to delegate bulk work to subagents instead of pulling
+// it into the main context. It sits below the compaction threshold so the
+// nudge lands while delegation can still prevent the fold, not after it.
+// 35% is early enough to matter, late enough not to nag on short turns.
+const nudgeThreshold = 0.35
+
+// contextPressureNudge returns the ephemeral "delegate before you bloat"
+// reminder, or "" when context pressure is low (or the provider advertised
+// no limit). Turn appends it as a trailing system message each round it
+// applies — never persisted, so it can't fossilize in the transcript after
+// compaction shrinks things back down. The message is deliberately not a
+// compaction warning: the model doesn't control when compaction fires, only
+// how much it hoards — so it pushes the behavior the model *does* control.
+func (a *Agent) contextPressureNudge() string {
+	if a.ContextLimit == 0 {
+		return ""
+	}
+	pct := 100 * EstimateTokens(a.Messages) / a.ContextLimit
+	if pct < int(nudgeThreshold*100) {
+		return ""
+	}
+	return fmt.Sprintf("Context usage is at ~%d%% of the window and old turns will be folded into a summary at %.0f%%. Before doing more bulk reading or exploration inline, delegate it to a subagent — its context absorbs the file contents and search results, and only the distilled report lands here. Finish the current step, then hand the next big investigation off (parallel subagent calls in one message for independent questions; background:true for work you don't need to block on).", pct, a.threshold()*100)
 }
 
 // maybeCompact folds old turns into a summary once the estimated token count

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -589,6 +589,73 @@ func TestCompactThresholdExplicitOverride(t *testing.T) {
 	}
 }
 
+func TestContextPressureNudge(t *testing.T) {
+	// no advertised limit: nudge disabled regardless of size
+	ag := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag.Messages = append(ag.Messages, llm.Message{Role: "user", Content: strings.Repeat("x", 4000)})
+	if n := ag.contextPressureNudge(); n != "" {
+		t.Fatalf("no context limit should mean no nudge, got %q", n)
+	}
+
+	// below the 35% nudge threshold: quiet
+	ag2 := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag2.ContextLimit = 10000 // 35% = 3500 estimated tokens
+	ag2.Messages = append(ag2.Messages, llm.Message{Role: "user", Content: strings.Repeat("x", 1200)})
+	if n := ag2.contextPressureNudge(); n != "" {
+		t.Fatalf("below nudge threshold should stay quiet, got %q", n)
+	}
+
+	// above the threshold: nudge fires and names subagent delegation
+	ag3 := New(llm.New("http://unused", "k"), "m", 100, "sys")
+	ag3.ContextLimit = 1000 // 35% = 350 estimated tokens
+	ag3.Messages = append(ag3.Messages, llm.Message{Role: "user", Content: strings.Repeat("x", 1800)})
+	n := ag3.contextPressureNudge()
+	if n == "" {
+		t.Fatal("expected a nudge above the threshold")
+	}
+	if !strings.Contains(n, "subagent") {
+		t.Fatalf("nudge should push subagent delegation, got %q", n)
+	}
+	if !strings.Contains(n, "%") {
+		t.Fatalf("nudge should report current usage, got %q", n)
+	}
+}
+
+func TestContextPressureNudgeIsEphemeralPerRound(t *testing.T) {
+	// the nudge rides each streamed request as a trailing system message but is
+	// never appended to a.Messages — resume and compaction see a clean history
+	var sawNudge atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		for _, m := range req.Messages {
+			if m.Role == "system" && strings.Contains(m.Content, "delegate it to a subagent") {
+				sawNudge.Store(true)
+			}
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"done"}}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.ContextLimit = 1000
+	// seed history over the 35% nudge threshold but under the 50% compact one
+	ag.Messages = append(ag.Messages, llm.Message{Role: "user", Content: strings.Repeat("x", 1500)})
+	if _, err := ag.Turn(context.Background(), "hi", Events{}); err != nil {
+		t.Fatal(err)
+	}
+	if !sawNudge.Load() {
+		t.Fatal("the request should have carried the delegation nudge")
+	}
+	for _, m := range ag.Messages {
+		if strings.Contains(m.TextContent(), "delegate it to a subagent") {
+			t.Fatal("nudge must not be persisted into the conversation")
+		}
+	}
+}
+
 func TestNoProactiveCompactBelowThresholdOrWithoutLimit(t *testing.T) {
 	srv := textServer(t, func(n int, req llm.Request) string { return "done" })
 	defer srv.Close()


### PR DESCRIPTION
## Why

Research into how other harnesses (opencode, Claude Code) get the main agent to actually *use* subagents found it's a **prompt-engineering problem, not a capability one**. whip already has strong subagent plumbing (foreground fan-out, background tasks, worktrees, model routing) but almost nothing telling the model *when* to reach for it. This adds two of the levers from that research.

## What

**#2 — proactive-delegation guidance** (`cmd/whip/main.go` `systemPrompt`)
- New Guidelines line: route multi-file exploration / codebase questions / independent parallel work to subagents (their context absorbs the bulk, only the distilled report returns), fire independent investigations as parallel subagent calls in one message, don't delegate a known-file lookup.
- Drive-by fix: the tools list still named the tool `task:` — it's `subagent` now.

**#4 — context-pressure delegation nudge** (`internal/agent/agent.go`)
- Once estimated usage crosses 35% of the advertised context window (`nudgeThreshold`, deliberately below the 50% compaction threshold so delegation can still *prevent* the fold), `Turn` appends an ephemeral trailing system message each round urging the model to hand the next big investigation to a subagent before doing more inline bulk reading.
- Same ephemeral-append pattern as `todoBlock`: re-derived per round, never persisted to `a.Messages`, so it can't fossilize after compaction. No-ops when the provider advertises no limit.
- The message pushes what the model controls (delegation), not a compaction warning (which it doesn't).

## Tests
- `TestContextPressureNudge` — off without a limit, quiet below the threshold, fires above it naming subagent delegation.
- `TestContextPressureNudgeIsEphemeralPerRound` — nudge rides the streamed request but is never persisted into `a.Messages`.
- `go test -race ./internal/agent ./cmd/whip` clean; `gofmt -s` + `go vet` clean.

Note: `task check`'s `internal/browser` tests fail on this machine because they need a live Chrome with remote debugging — same failure reproduces on the base commit `ea7f6c8`, so it's pre-existing/environmental, not from this diff.

## Docs
`docs/features.md` gains a "Delegation nudges" section. No roadmap checkbox applies (the checked subagent items are shipped; the unchecked ones — `@agent` mentions, custom agent definitions — are separate levers #5/#3 from the research).