### PR TITLE
fix(skills): parse YAML block scalars in SKILL.md frontmatter

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -92,8 +92,12 @@ func ScanDetailed(dirs ...string) ([]Skill, []ScanProblem) {
 	return out, problems
 }
 
-// parse reads name/description from the YAML frontmatter.
-// ponytail: single-line values only; a real YAML parser when a skill needs one
+// parse reads name/description from the YAML frontmatter. Values may be
+// single-line scalars or YAML block scalars (>/| with -/+ chomping) — the
+// folded style is how claude-code's skill tooling writes long descriptions,
+// and treating the indicator as the value renders "description: >-" in the
+// catalog, hiding the skill from model-triggering entirely.
+// ponytail: still not a real YAML parser; nested maps/sequences are ignored.
 func parse(path string) (Skill, error) {
 	f, err := os.Open(path) //nolint:gosec // G304: reading caller-discovered skill files is the function's contract
 	if err != nil {
@@ -111,15 +115,144 @@ func parse(path string) (Skill, error) {
 		if strings.TrimSpace(line) == "---" {
 			break
 		}
-		if v, ok := strings.CutPrefix(line, "name:"); ok {
-			s.Name = unquote(v)
-		} else if v, ok := strings.CutPrefix(line, "description:"); ok {
-			s.Description = unquote(v)
-		} else if v, ok := strings.CutPrefix(line, "disable-model-invocation:"); ok {
+		key, v, ok := cutKey(line)
+		if !ok {
+			continue
+		}
+		if isBlockScalarIndicator(v) {
+			// Block scalars are already plain values: no unquoting, and no
+			// TrimSpace — chomping indicators own the trailing newlines.
+			v = readBlockScalar(sc, v, indentOf(line))
+		} else {
+			v = unquote(v)
+		}
+		switch key {
+		case "name":
+			s.Name = v
+		case "description":
+			s.Description = v
+		case "disable-model-invocation":
 			s.DisableModelInvocation = strings.TrimSpace(v) == "true"
 		}
 	}
 	return s, sc.Err()
+}
+
+// cutKey splits a top-level frontmatter line into key and raw value. Only
+// unindented keys are recognized — an indented line belongs to a block scalar
+// or a nested mapping we don't model, and must not shadow a real key.
+func cutKey(line string) (key, value string, ok bool) {
+	if line == "" || line[0] == ' ' || line[0] == '\t' {
+		return "", "", false
+	}
+	k, v, found := strings.Cut(line, ":")
+	if !found {
+		return "", "", false
+	}
+	return k, v, true
+}
+
+func indentOf(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
+}
+
+// isBlockScalarIndicator reports whether a raw frontmatter value is a YAML
+// block-scalar header: > (folded) or | (literal), optionally with a -/+
+// chomping or digit indentation indicator (e.g. ">-", "|+", ">2").
+func isBlockScalarIndicator(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" || (v[0] != '>' && v[0] != '|') {
+		return false
+	}
+	for _, r := range v[1:] {
+		if r != '-' && r != '+' && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+// readBlockScalar consumes the indented lines following a block-scalar header
+// and folds them per the indicator: literal (|) keeps newlines, folded (>)
+// joins lines with spaces. Chomping: default clips to a single trailing
+// newline (folded into nothing at the edges), "-" strips it, "+" keeps it.
+// This is the common-case subset — indentation indicators are honored as
+// "more indented than the key", which is how skill files are actually written.
+func readBlockScalar(sc *bufio.Scanner, header string, keyIndent int) string {
+	indicator := strings.TrimSpace(header)
+	literal := indicator[0] == '|'
+	chomp := byte(0)
+	for _, r := range indicator[1:] {
+		if r == '-' || r == '+' {
+			chomp = byte(r)
+		}
+	}
+
+	var lines []string
+	// Determine indentation from the first content line, then take every
+	// following line at least that indented (blank lines carry through).
+	bodyIndent := -1
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			// Closing frontmatter delimiter consumed along with the scalar;
+			// parse's loop will just hit EOF. Skill files keep descriptions
+			// early in the frontmatter, so this stays theoretical.
+			break
+		}
+		ind := indentOf(line)
+		if trimmed != "" {
+			if ind <= keyIndent {
+				break
+			}
+			if bodyIndent == -1 {
+				bodyIndent = ind
+			}
+		}
+		lines = append(lines, line)
+	}
+	// Unread the terminator? bufio.Scanner can't push back — but the only
+	// terminators are the frontmatter close (loop is done anyway) or a
+	// sibling key. A sibling key after a block scalar IS valid YAML, so
+	// note the limitation rather than pretend: keys following a block
+	// scalar on a later line are lost. No known SKILL.md does this — the
+	// block scalar is always the last field of its file section — and a
+	// real YAML parser remains the answer if that changes.
+	_ = keyIndent
+
+	// Strip the common body indentation.
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			lines[i] = ""
+			continue
+		}
+		if bodyIndent > 0 && len(line) >= bodyIndent {
+			lines[i] = line[bodyIndent:]
+		}
+	}
+	// Leading blank lines belong to the wrapper, not the value.
+	for len(lines) > 0 && lines[0] == "" {
+		lines = lines[1:]
+	}
+	// Trailing blanks matter only for keep ("+") chomping: the delimiter line
+	// already contributed one newline, so any beyond the first are real.
+	trailing := 0
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+		trailing++
+	}
+
+	var v string
+	if literal {
+		v = strings.Join(lines, "\n")
+	} else {
+		v = strings.Join(lines, " ")
+	}
+	if chomp == '+' && len(lines) > 0 {
+		v += "\n" + strings.Repeat("\n", trailing)
+	}
+	return v
 }
 
 func unquote(v string) string {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -82,3 +82,48 @@ func TestScanAndPromptBlock(t *testing.T) {
 		t.Fatalf("spec-legal description must not be truncated")
 	}
 }
+
+// claude-code's skill tooling writes long descriptions as YAML folded block
+// scalars (description: >- followed by indented lines). Before block-scalar
+// support, the catalog rendered the indicator itself as the description —
+// the skill loaded but the model saw ">-", so nothing ever triggered it.
+func TestBlockScalarDescriptions(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "folded-strip",
+		"---\nname: folded-strip\ndescription: >-\n  Explicit-invocation working loop — never\n  auto-triggers; when invoked it replaces the\n  default routing for that task.\n---\nbody")
+	writeSkill(t, dir, "folded-clip",
+		"---\nname: folded-clip\ndescription: >\n  first line\n  second line\n---\n")
+	writeSkill(t, dir, "literal-keep",
+		"---\nname: literal-keep\ndescription: |+\n  line one\n  line two\n---\n")
+	writeSkill(t, dir, "block-last",
+		"---\ndescription: >-\n  nothing follows\n  this block\n---\n")
+	writeSkill(t, dir, "after-block",
+		"---\ndescription: >-\n  folded text here\ndisable-model-invocation: true\n---\n")
+
+	byName := map[string]Skill{}
+	for _, s := range Scan(dir) {
+		byName[s.Name] = s
+	}
+
+	want := map[string]string{
+		"folded-strip": "Explicit-invocation working loop — never auto-triggers; when invoked it replaces the default routing for that task.",
+		"folded-clip":  "first line second line",
+		"literal-keep": "line one\nline two\n",
+		"block-last":   "nothing follows this block",
+	}
+	for name, desc := range want {
+		s, ok := byName[name]
+		if !ok {
+			t.Fatalf("skill %q not scanned: %+v", name, byName)
+		}
+		if s.Description != desc {
+			t.Errorf("%s description = %q, want %q", name, s.Description, desc)
+		}
+	}
+
+	// A key following a block scalar is out of scope for the hand parser;
+	// pinned so a future real-YAML swap knows the contract changed.
+	if _, ok := byName["after-block"]; !ok {
+		t.Fatalf("after-block not scanned: %+v", byName)
+	}
+}


### PR DESCRIPTION
## Problem

Skills whose frontmatter uses a YAML folded/literal block scalar for the description:

```yaml
---
name: dev-loop
description: >-
  Explicit-invocation working loop (/dev-loop or "use dev-loop") — never
  auto-triggers; when invoked it replaces the default workflow-skill routing
  ...
---
```

loaded with the **literal string `>-`** as their description. The skill appeared in `<available_skills>`, but the model saw:

```xml
<description>&gt;-</description>
```

…so nothing could ever trigger it. This is exactly how claude-code's skill tooling emits long descriptions, so any skill corpus shared with claude-code (e.g. a monorepo's `.agents/skills/`) silently loses every multi-line-description skill. Nine skills in one real repo were degraded this way.

## Fix

`parse` now recognizes block-scalar indicators (`>`, `|`, with `-`/`+` chomping and digit indentation indicators) on top-level frontmatter keys and folds/unfolds the body accordingly:

- folded (`>`) blocks join lines with spaces; literal (`|`) blocks keep newlines
- block values bypass `unquote` so chomping-owned trailing newlines survive
- indented lines no longer risk being misparsed as keys (`cutKey` requires column 0)

Still deliberately **not** a full YAML dependency: nested maps/sequences stay ignored, and a sibling key on the line *following* a block scalar is a documented limitation (no known SKILL.md does this — the block scalar is always its section's last field). Pinned in the test so a future real-YAML swap knows the contract changed.

## Verification

- `TestBlockScalarDescriptions` — regression coverage using the failing frontmatter shape (`>-`, `>`, `|+`, block as last field, block followed by another key)
- Full `internal/skills` suite passes; the two failing tests elsewhere in the repo (`TestPortProbeSquatterTriggersFallback`, `TestStartupReport*`) fail identically on clean `main` — environment-dependent, untouched by this change
- End-to-end against a real monorepo `.agents/skills/`: all nine previously-degraded skills (`dev-loop`, `changelog`, `grafana-query`, `github-query`, `incident-io`, `cloudflare`, `adversarial-code-review`, `fixing-a-bug`, `grafana-inference-platform`) now scan with their full descriptions, zero scan problems