### PR TITLE
fix(llm): handle sparse streamed tool-call indexes

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -697,7 +697,8 @@ func (c *Client) streamOnce(ctx context.Context, body []byte, onText, onThink fu
 
 	msg := Message{Role: "assistant"}
 	var usage Usage      // from the terminal chunk (include_usage); zero if omitted
-	var calls []ToolCall // indexed by stream tool_call index
+	var calls []ToolCall // arrival order; providers may use sparse stream indexes
+	callPositions := make(map[int]int)
 	finish := ""
 	sc := bufio.NewScanner(resp.Body)
 	sc.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -742,10 +743,13 @@ func (c *Client) streamOnce(ctx context.Context, body []byte, onText, onThink fu
 			}
 		}
 		for _, tc := range d.ToolCalls {
-			for len(calls) <= tc.Index {
+			pos, ok := callPositions[tc.Index]
+			if !ok {
+				pos = len(calls)
+				callPositions[tc.Index] = pos
 				calls = append(calls, ToolCall{Type: "function"})
 			}
-			cur := &calls[tc.Index]
+			cur := &calls[pos]
 			if tc.ID != "" {
 				cur.ID = tc.ID
 			}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -129,6 +129,26 @@ func TestStreamTextAndToolCalls(t *testing.T) {
 	}
 }
 
+func TestStreamSparseToolCallIndexDoesNotCreateEmptyCall(t *testing.T) {
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"c1","type":"function","function":{"name":"Plan","arguments":"{\"todos\":[]}"}}]}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+	defer srv.Close()
+
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("sparse stream index created phantom tool calls: %+v", msg.ToolCalls)
+	}
+	if got := msg.ToolCalls[0]; got.ID != "c1" || got.Function.Name != "Plan" {
+		t.Fatalf("tool call: %+v", got)
+	}
+}
+
 // onToolCall fires for each streaming tool-call delta once the call has an
 // id, with the id/name/args snapshot at that point — so the UI can render a
 // pending row before execution. A nil onToolCall must not panic.


### PR DESCRIPTION
## Summary

- preserve streamed tool calls when providers use sparse indexes
- avoid creating placeholder tool calls with empty IDs or names
- add regression coverage for a stream whose first tool-call index is nonzero

## Testing

- `go test ./...`

## Provenance

- **Requested by:** Abe (Slack `U06UKTLR2KH`)
- **Source:** [Slack conversation](https://inference-net.slack.com/archives/C0AGS9D50JZ/p1788463689779379?thread_ts=1788462233.951189&cid=C0AGS9D50JZ)
- **Quant turn:** `9085906d`
