### PR TITLE
llm: discard tool calls with malformed JSON arguments

### DIFF
--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -45,7 +45,11 @@ func parallelServer(t *testing.T) *httptest.Server {
 		w.Header().Set("Content-Type", "text/event-stream")
 		if call == 1 {
 			for i, id := range []string{"a", "b", "c"} {
-				args := fmt.Sprintf(`{\"s\":%q}`, id)
+				// arguments must be a JSON object: the streaming client
+				// (internal/llm) discards tool calls whose args aren't valid
+				// JSON before they reach the tool layer, so the raw value has
+				// to be {"s":"a"}, not the backslash-escaped {\"s\":\"a\"}.
+				args := fmt.Sprintf(`{"s":%q}`, id)
 				fmt.Fprintf(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":%d,"id":%q,"type":"function","function":{"name":"slow","arguments":%q}}]}}]}`+"\n\n", i, id, args)
 			}
 			fmt.Fprint(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n")

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -770,8 +770,33 @@ func (c *Client) streamOnce(ctx context.Context, body []byte, onText, onThink fu
 		calls = nil
 		msg.Content += "\n[response truncated by max_tokens; tool calls discarded]"
 	}
+	// Discard tool calls whose accumulated function.arguments never closed
+	// into a JSON object — a provider that emitted malformed arguments, or a
+	// stream that ended mid-call (a proxy closed the connection, no
+	// finish_reason). Strict providers validate incoming history and reject
+	// the whole request before the first token when an assistant tool_call
+	// carries malformed arguments, so persisting the call poisons the next
+	// turn. Drop just the malformed calls so valid siblings still execute,
+	// and note what was dropped — mirrors the max_tokens guard above.
+	kept := make([]ToolCall, 0, len(calls))
+	for _, tc := range calls {
+		if tc.Function.Arguments != "" && !validToolCallArgs(tc.Function.Arguments) {
+			msg.Content += fmt.Sprintf("\n[tool call %q discarded: arguments are invalid JSON]", tc.Function.Name)
+			continue
+		}
+		kept = append(kept, tc)
+	}
+	calls = kept
 	msg.ToolCalls = calls
 	return msg, usage, nil
+}
+
+// validToolCallArgs reports whether s is a JSON object — the shape providers
+// require for function.arguments. Empty arguments are treated as valid (a
+// no-argument call) and left for the tool layer to handle.
+func validToolCallArgs(s string) bool {
+	var obj map[string]any
+	return json.Unmarshal([]byte(s), &obj) == nil
 }
 
 // Complete sends a non-streaming chat request and returns the assistant text

--- a/internal/llm/openai_args_test.go
+++ b/internal/llm/openai_args_test.go
@@ -1,0 +1,128 @@
+package llm
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Some providers stream a tool call whose accumulated function.arguments
+// never closes into valid JSON — a provider emission bug, or a stream that
+// ended mid-call. whip persists the assistant message with its tool_calls
+// into history and replays them on the next turn, where strict providers
+// validate incoming history and reject the whole request before the first
+// token when an assistant tool_call carries malformed arguments.
+//
+// The malformed call must be dropped before it reaches history, the same way
+// a max_tokens-truncated call is — see TestStreamLengthDiscardsToolCalls.
+func TestStreamDiscardsToolCallWithInvalidJSONArgs(t *testing.T) {
+	// arguments = `{"path":"/tmp/x"` — an object that never closed its brace
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"w1","type":"function","function":{"name":"write","arguments":"{\"path\":\"/tmp/x\""}}]}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+	defer srv.Close()
+
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.ToolCalls) != 0 {
+		t.Fatalf("tool call with invalid JSON arguments must be discarded before history, got %+v", msg.ToolCalls)
+	}
+	if !strings.Contains(msg.Content, "invalid JSON") {
+		t.Fatalf("expected a discard note in content, got %q", msg.Content)
+	}
+}
+
+// A stream that ends mid-tool-call with no finish_reason and no [DONE] (the
+// server or a proxy closed the connection) leaves the accumulated arguments
+// incomplete. Same root cause as invalid-args emission, same rejection on
+// replay: the half-built call must not be persisted.
+func TestStreamDiscardsIncompleteArgsOnDroppedStream(t *testing.T) {
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"w1","type":"function","function":{"name":"write","arguments":"{\"path\":\"/tmp/x\""}}]}}]}`,
+		// no finish_reason, no [DONE] — the server just stops sending
+	)
+	defer srv.Close()
+
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.ToolCalls) != 0 {
+		t.Fatalf("incomplete tool call from a dropped stream must be discarded, got %+v", msg.ToolCalls)
+	}
+}
+
+// A tool call whose arguments stream into valid JSON must still be kept —
+// the guard targets malformed arguments, not tool calls in general.
+func TestStreamKeepsToolCallWithValidJSONArgs(t *testing.T) {
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"w1","type":"function","function":{"name":"write","arguments":"{\"path\":\"/tmp/x\""}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\"content\":\"hi\"}"}}]}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+	defer srv.Close()
+
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("valid tool call must be kept, got %+v", msg.ToolCalls)
+	}
+	tc := msg.ToolCalls[0]
+	if tc.Function.Arguments != `{"path":"/tmp/x","content":"hi"}` {
+		t.Fatalf("arguments assembly changed: %q", tc.Function.Arguments)
+	}
+}
+
+// A malformed call alongside a valid one: the valid sibling must still
+// execute. Dropping only the bad call (not the whole turn) keeps the turn
+// productive and leaves no orphan in history.
+func TestStreamDropsOnlyMalformedKeepsValidSibling(t *testing.T) {
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"good","type":"function","function":{"name":"read","arguments":"{\"path\":\"/a\"}"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"bad","type":"function","function":{"name":"write","arguments":"{\"path\":\"/b\""}}]}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+	defer srv.Close()
+
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("only the malformed call should be dropped, got %+v", msg.ToolCalls)
+	}
+	tc := msg.ToolCalls[0]
+	if tc.ID != "good" || tc.Function.Name != "read" || tc.Function.Arguments != `{"path":"/a"}` {
+		t.Fatalf("valid sibling changed: %+v", tc)
+	}
+	if !strings.Contains(msg.Content, "write") || !strings.Contains(msg.Content, "invalid JSON") {
+		t.Fatalf("discard note should name the dropped call, got %q", msg.Content)
+	}
+}
+
+// A no-argument call (empty arguments) is a legitimate call shape, not a
+// malformed one — it must be kept for the tool layer to handle.
+func TestStreamKeepsToolCallWithEmptyArgs(t *testing.T) {
+	srv := sseServer(t,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"status"}}]}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	)
+	defer srv.Close()
+
+	msg, _, err := New(srv.URL, "test-key").Stream(context.Background(), Request{Model: "m"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.ToolCalls) != 1 || msg.ToolCalls[0].ID != "c1" {
+		t.Fatalf("no-arg call must be kept, got %+v", msg.ToolCalls)
+	}
+}


### PR DESCRIPTION
## Problem

When a provider streams a tool call whose accumulated `function.arguments` never closes into valid JSON — a provider emission bug, or a stream that ended mid-call (a proxy closed the connection with no `finish_reason`) — whip persists the assistant message with that `tool_call` into the conversation history. On the next turn the history is replayed, and strict providers validate incoming history and reject the whole request before the first token:

```
400 tool_calls[].function.arguments for function 'write' must be a JSON object string (or an object), got invalid JSON
```

The poisoned call then blocks every subsequent turn until the user rewinds past it.

## Root cause

`streamOnce` only guarded against incomplete arguments on `finish_reason: "length"` (max_tokens truncation):

```go
if finish == "length" && len(calls) > 0 {
    calls = nil
    msg.Content += "\n[response truncated by max_tokens; tool calls discarded]"
}
```

Malformed arguments from any other path — a provider that emitted non-JSON, or a stream that dropped with no `finish_reason` at all — slipped through and were kept in `msg.ToolCalls`, which the agent loop then appends to `Messages` verbatim and replays next turn.

## Fix

After accumulation, drop tool calls whose non-empty `function.arguments` isn't a JSON object, keeping valid siblings so a single bad call doesn't void the whole turn. A note is appended to the assistant content naming the dropped call — mirroring the existing max_tokens guard. Empty arguments are left alone (a legitimate no-argument call shape) and handled by the tool layer.

The malformed call never reaches history, so it can't poison the next request.

## Tests

New file `internal/llm/openai_args_test.go`:

- `TestStreamDiscardsToolCallWithInvalidJSONArgs` — unclosed-object args discarded, with a discard note in content
- `TestStreamDiscardsIncompleteArgsOnDroppedStream` — a stream that ends mid-call (no `finish_reason`, no `[DONE]`) discards the half-built call
- `TestStreamKeepsToolCallWithValidJSONArgs` — valid args arriving across two deltas are still assembled and kept
- `TestStreamDropsOnlyMalformedKeepsValidSibling` — one malformed + one valid call in the same turn: only the bad one is dropped, the sibling executes
- `TestStreamKeepsToolCallWithEmptyArgs` — a no-argument call is not treated as malformed

## Drive-by

`internal/agent/parallel_test.go`'s SSE fixture emitted backslash-escaped arguments (`{\"s\":\"a\"}`) — not valid JSON, only passing because `slowTool` ignores its args. The new guard now correctly drops such calls, so the fixture is fixed to emit the real JSON object (`{"s":"a"}`) it clearly intended.
