### PR TITLE
perf: context/token cost reduction — real-usage compaction, image accounting, doom-loop guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # copy at internal/computer/bin/, which stays ignored too — the placeholder
 # is force-added instead).
 driver/.build/
+internal/tui/whip-transcript-*.md

--- a/docs/context-cost-handoff.md
+++ b/docs/context-cost-handoff.md
@@ -4,7 +4,7 @@
 need — the evidence, the design, what shipped, what's left, and how to verify.
 
 **Repo:** `github.com/context-labs/whip` · **Branch:** `perf/context-cost-management`
-· **PR:** #113 (open, CI green at HEAD `f3ba3a8`) · **Plan doc:** `docs/context-cost-plan.md`
+· **PR:** #113 (open, CI green) · **Plan doc:** `docs/context-cost-plan.md`
 
 ---
 
@@ -52,12 +52,17 @@ bfab024 feat(llm): pixel-true image token estimates + ingest normalization
 a85be57 feat(agent): real-usage compaction trigger, budgeted tail, doom-loop guard, single-count usage
 e57ad57 feat(tui): normalize pasted and @-mentioned images at ingest
 f3ba3a8 lint: goimports grouping in images.go, drop predeclared 'real', remove unused encodePNG
+fb61707 docs: handoff doc for the context-cost work
+(HEAD)  fix(agent): lastPrompt only from own requests + reset on fold; refused calls fire tool events; cleanup
 ```
 
 ### Item 1 — real-usage compaction trigger
 `internal/agent/agent.go`
 - `Agent.lastPrompt` (new field) records the provider-reported `prompt_tokens`
-  of the most recent request, updated in `AddUsage`.
+  of the agent's most recent **own** conversation request, set via
+  `notePrompt` in the turn loop (not in `AddUsage`, which also receives
+  foreground-subagent and summary-call usage). `compact` resets it to 0 so
+  the estimate fallback drives the trigger until the next real request.
 - `maybeCompact` fires when `lastPrompt ≥ threshold × ContextLimit`; the
   chars/4 estimate is the fallback only when the provider returns no usage.
 - **Also closed the single-round-turn gap:** a final response whose usage
@@ -112,6 +117,8 @@ f3ba3a8 lint: goimports grouping in images.go, drop predeclared 'real', remove u
   is exempt (repetition is its designed use).
 - Marked in **issue order before the worker goroutines spawn**, so the
   parallel `runTools` batch can't scramble ordering.
+- A refused call still fires `OnToolStart`/`OnToolEnd` so the TUI's queued
+  row (opened on `OnToolCall`) closes instead of sticking at "⋯".
 
 ### Item 7 — usage single-count
 `internal/agent/background.go` (`launchBackground`), `internal/agent/subagent.go`
@@ -134,6 +141,17 @@ f3ba3a8 lint: goimports grouping in images.go, drop predeclared 'real', remove u
    before round-2 `maybeCompact`, so the just-landed usage never triggered a
    fold. Closed (see item 1), with the `a.compacted` guard preventing a
    re-fold of a fresh fold.
+
+3. **`lastPrompt` poisoning (review pass).** Setting it inside `AddUsage`
+   let a foreground subagent's or the compaction summary call's
+   `prompt_tokens` overwrite the parent's real context size, and the
+   pre-fold value lingered after a fold so the next round could re-fold the
+   fresh summary. Fixed: `notePrompt` from the turn loop only, reset in
+   `compact`. Covered by `TestLastPromptIgnoresFannedInUsage` and an
+   assertion in `TestMaybeCompactUsesRealUsage`.
+4. **Refused doom-loop calls left a stuck TUI row.** The refusal short-cut
+   skipped `OnToolStart`/`OnToolEnd`. Fixed; asserted in
+   `TestDoomLoopRefusalSkipsExecution`.
 
 ## Pre-existing failures (NOT this branch)
 
@@ -158,10 +176,11 @@ go test ./internal/agent/ ./internal/llm/ -count=1   # fresh, not cached
 ```
 
 **CI:** PR #113 → 12/12 checks pass (lint, test, codeql ×2, driver,
-govulncheck, `go`, build ×4 platforms) at HEAD `f3ba3a8`.
+govulncheck, `go`, build ×4 platforms).
 
 **New tests by item:**
-- 1: `TestMaybeCompactUsesRealUsage`, `TestMaybeCompactEstimateFallback`
+- 1: `TestMaybeCompactUsesRealUsage`, `TestMaybeCompactEstimateFallback`,
+  `TestLastPromptIgnoresFannedInUsage`
 - 2: `TestImageTokensPixelFormula`, `TestImagePartRecordsDimensions`,
   `TestContentPartDimsPersistedAndStripped`, `TestPartTokensLazyDecode`,
   `TestDecodeImageSize`
@@ -206,4 +225,4 @@ spill-to-disk is untouched.
   reconstruction used Python + `sqlite3` against the `messages` table (each
   assistant row carries a `usage` JSON blob).
 - Branch is clean and rebased-safe: `git log --oneline origin/main..HEAD`
-  shows the 5 commits; nothing else diverges from `main` except these.
+  shows the commit stack; nothing else diverges from `main` except these.

--- a/docs/context-cost-handoff.md
+++ b/docs/context-cost-handoff.md
@@ -82,8 +82,11 @@ fb61707 docs: handoff doc for the context-cost work
 - `EstimateTokens` (agent.go) now uses `llm.PartTokens` per part.
 
 ### Item 3 — image normalization at ingest
-`internal/llm/normalize.go`; wired in `internal/tui/paste.go`
-(`saveClipboardImage`) and `internal/tui/mentions.go` (`imageParts`).
+`internal/llm/normalize.go`; wired at every image ingest: `internal/tui/paste.go`
+(`saveClipboardImage`), `internal/tui/mentions.go` (`imageParts`), the browser
+`ScreenshotSink` closure (`tui.go`), and ACP client image blocks
+(`internal/acp/translate.go`). The passthrough decision is header-only
+(`DecodeImageSize`); pixels decode only when a re-encode is needed.
 - `NormalizeImage`: pass-through if already ≤2000×2000 and ≤5MiB; else decode
   → `x/image/draw` scale to fit → JPEG q80→40 ladder until ≤5MiB → shrink
   ×0.75 per round (≤32 rounds). Corrupt input passes through unchanged.
@@ -107,7 +110,10 @@ fb61707 docs: handoff doc for the context-cost work
   a text placeholder naming dims + the spilled file path (`spillImage` writes
   the base64 payload to `$TMPDIR/whip-img-<pid>/`, mirroring bash's spill).
   The model can re-attach via `@<path>` if it genuinely needs the pixels.
-  Text parts of the message stay inline.
+  Text parts of the message stay inline. `msgTokens` (hot-window budget)
+  counts image parts via `llm.PartTokens`, so image-only screenshot turns
+  spend the budget and age out. The ACP bridge wires `OnDecay` to re-save
+  from message 1 (like the TUI) so decayed rows don't resurrect on resume.
 
 ### Item 6 — doom-loop guard
 `internal/agent/agent.go` (`markDoomLoops`, `doomLoopRefusal`)

--- a/docs/context-cost-handoff.md
+++ b/docs/context-cost-handoff.md
@@ -203,7 +203,10 @@ govulncheck, `go`, build ×4 platforms).
 - 6: `TestDoomLoopGuard`, `TestDoomLoopRefusalText`,
   `TestDoomLoopRefusalSkipsExecution`
 - 7: `TestBackgroundTaskUsageNotDoubleCounted`, `TestSubUsageForwardsThroughNestedSubs`,
-  session `TestRecordCompactionCarriesModelAndUsage` + sub_usage round-trip in the usage test
+  `TestSubCompactionUsageReachesParentLedger`, foreground split in `TestTaskToolSpawnsSubagent`;
+  session `TestRecordCompactionCarriesModelAndUsage` + sub_usage round-trip; TUI
+  `TestSessionCostUsesFetchedPricing` (per-model sub pricing, unpriceable hides),
+  `TestResumeRestoresUsage` (ledger persist/resume), `TestTaskRowCarriesSubUsage`
 - Updated for the budgeted tail: `TestCompactKeepsToolCallPair`,
   `TestCompactionEventsCarryModelAndUsage`
 

--- a/docs/context-cost-handoff.md
+++ b/docs/context-cost-handoff.md
@@ -1,0 +1,209 @@
+# Handoff: whip context/token cost reduction
+
+**Audience:** another AI (or engineer) picking this up cold. Everything you
+need — the evidence, the design, what shipped, what's left, and how to verify.
+
+**Repo:** `github.com/context-labs/whip` · **Branch:** `perf/context-cost-management`
+· **PR:** #113 (open, CI green at HEAD `f3ba3a8`) · **Plan doc:** `docs/context-cost-plan.md`
+
+---
+
+## 1. Why this exists — the incident
+
+Session `7ec5ba63` (whip's own SQLite session store, `~/.whip/sessions.db`)
+ran kimi-k3 for 48h building a dashboard. Provider-truth spend:
+
+- **2,096 API calls** (731 main-loop + 1,365 subagent)
+- **283M input tokens served** (264M cached, 19M fresh), **~1.5M output**
+- **≈ $210** at inference-net kimi-k3 rates ($3.95/M in, $0.40/M cache-read,
+  $19.8/M out). The whip UI **reported ~$413** — inflated by double-counting.
+
+The user had `compactPct: 30` set (compact at 30% of the 1M context window),
+yet **only two compactions fired in 48 hours** while per-request prompt tokens
+climbed to 392k.
+
+### Root causes (each verified against the session DB, not guessed)
+
+| # | Root cause | Evidence |
+|---|-----------|----------|
+| 1 | Compaction trigger ran on `EstimateTokens` (chars/4 + flat 1200/image), which peaked at **296k/1M (28%)** while the provider billed **392k (37%)** | Replayed session through whip's own estimator: never crossed the 30% threshold (314k), so `maybeCompact` correctly no-opped on broken inputs |
+| 2 | Images counted at flat 1200 tokens regardless of size | 4 real screenshots cost **4.1k–11.4k** tokens each (28px-patch vision model); whip counted 1.2k — **~7× undercount** |
+| 3 | No image normalization at ingest | A **3410×2646** clipboard PNG went in verbatim; ~7.1M input tokens was re-sending old screenshots every request |
+| 4 | Compaction tail = `compactKeepBack = 6` **messages** (not tokens); summary capped at **1024** output tokens with 500-char tool-result truncation | Six messages can be six 50KB tool dumps; 1024 clips a 2-day fold into near-uselessness |
+| 5 | No doom-loop guard | One stuck subagent (`rewrite-flight-parser-structurally-4`) made **789 calls**, including **516× identical `sleep 280; git status`** (a **235-in-a-row** streak) — **85M tokens (~$35)** polling git |
+| 6 | Usage double-counted | Subagent spend fanned into parent counters via `AddUsage` **and** persisted on task sessions → session row read **550M vs 283M** provider-truth (~2×); arithmetic fits `main + 3×subs ≈ 561M` |
+
+Reference implementation consulted: **opencode** (`/home/abe/code/coding-harnesses/opencode`).
+Key contrast: opencode triggers compaction off **provider-reported `usage`**
+(`session/overflow.ts`, `session/processor.ts:435-484`), never the estimate;
+caps images at 2000×2000/JPEG q80→40/≤5MiB (`image/image.ts`); token-budgets
+its compaction tail (`compaction.ts:115-120`); and blocks the 3rd identical
+tool call (`processor.ts:356-380`).
+
+---
+
+## 2. What shipped (all 7 items, on the branch)
+
+Commit stack (oldest→newest):
+
+```
+ebd7516 docs: plan for context/token cost reduction
+bfab024 feat(llm): pixel-true image token estimates + ingest normalization
+a85be57 feat(agent): real-usage compaction trigger, budgeted tail, doom-loop guard, single-count usage
+e57ad57 feat(tui): normalize pasted and @-mentioned images at ingest
+f3ba3a8 lint: goimports grouping in images.go, drop predeclared 'real', remove unused encodePNG
+```
+
+### Item 1 — real-usage compaction trigger
+`internal/agent/agent.go`
+- `Agent.lastPrompt` (new field) records the provider-reported `prompt_tokens`
+  of the most recent request, updated in `AddUsage`.
+- `maybeCompact` fires when `lastPrompt ≥ threshold × ContextLimit`; the
+  chars/4 estimate is the fallback only when the provider returns no usage.
+- **Also closed the single-round-turn gap:** a final response whose usage
+  crosses the threshold now compacts *before* the turn returns (skipped if the
+  turn already compacted, so it never re-folds a fresh fold). Proactive
+  compaction sets `a.compacted = true` to suppress the double-fold.
+
+### Item 2 — pixel-based image estimates
+`internal/llm/images.go`, `internal/llm/openai.go`
+- `ContentPart` gains `W`/`H` (persisted in session JSON; stripped from the
+  provider wire by a **fixed deep-copying `stripAuthored`** — see "bug found").
+- `ImageTokens(w,h)` = `⌈w/28⌉·⌈h/28⌉`, floor 85, fallback 1200 for
+  undecodable parts. `DecodeImageSize` reads headers via `image.DecodeConfig`
+  (blank imports: png/jpeg/gif/webp/bmp). `PartTokens` routes image parts to
+  the pixel estimate, lazy-decoding pre-dims session rows from the data URL.
+- `EstimateTokens` (agent.go) now uses `llm.PartTokens` per part.
+
+### Item 3 — image normalization at ingest
+`internal/llm/normalize.go`; wired in `internal/tui/paste.go`
+(`saveClipboardImage`) and `internal/tui/mentions.go` (`imageParts`).
+- `NormalizeImage`: pass-through if already ≤2000×2000 and ≤5MiB; else decode
+  → `x/image/draw` scale to fit → JPEG q80→40 ladder until ≤5MiB → shrink
+  ×0.75 per round (≤32 rounds). Corrupt input passes through unchanged.
+- New dependency: `golang.org/x/image v0.45.0` (promoted to direct via
+  `go mod tidy`).
+
+### Item 4 — token-budgeted compaction tail + incremental summaries
+`internal/agent/agent.go`
+- `compactKeepBack = 6` (messages) → `compactTailBudget()` = `min(15k,
+  max(2k, usable×0.25))` where `usable = ContextLimit × (1 − threshold)`.
+- `compactTailStart` walks **whole user turns** newest→oldest accumulating
+  tokens until the next turn would bust the budget; the existing orphan
+  tool-pair walk-back is preserved.
+- Summary `MaxTokens` 1024 → **4096**. Summaries are **incremental**: a prior
+  fold (marked by `summaryPrefix`) is passed to `buildSummaryPrompt(history,
+  prior)` and merged forward instead of re-derived from truncated transcripts.
+
+### Item 5 — image stripping in decay
+`internal/agent/decay.go`
+- New **Pass 3** in `decay()`: image parts past the hot window are swapped for
+  a text placeholder naming dims + the spilled file path (`spillImage` writes
+  the base64 payload to `$TMPDIR/whip-img-<pid>/`, mirroring bash's spill).
+  The model can re-attach via `@<path>` if it genuinely needs the pixels.
+  Text parts of the message stay inline.
+
+### Item 6 — doom-loop guard
+`internal/agent/agent.go` (`markDoomLoops`, `doomLoopRefusal`)
+- Tracks the last (tool name + `\x00` + args) key and a consecutive-run
+  counter. The **3rd consecutive identical** call (`doomLoopMaxRun = 3`)
+  returns a refusal tool-result without executing. **Any different call
+  resets the run** (so legit test→fix→test alternation is safe), and `wait`
+  is exempt (repetition is its designed use).
+- Marked in **issue order before the worker goroutines spawn**, so the
+  parallel `runTools` batch can't scramble ordering.
+
+### Item 7 — usage single-count
+`internal/agent/background.go` (`launchBackground`), `internal/agent/subagent.go`
+(follow-up path)
+- Removed the `OnUsage: parent.AddUsage` fan-in for **background** subagents
+  and follow-ups (their spend persists on the task's own attributed session
+  via `SaveSubagentTranscript`). **Foreground** subs keep `AddUsage` — their
+  spend has no other persisted record.
+- Net: each session row now reflects its own conversation's spend; the ~2×
+  cost-UI inflation is gone. Each sub still compacts on its own real usage.
+
+---
+
+## 3. Bugs found *by the new tests* (not in the original plan)
+
+1. **`stripAuthored` shallow-copied `Parts`.** Zeroing W/H on the wire copy
+   would have mutated the caller's persisted history. Fixed with a proper
+   slice copy. Covered by `TestContentPartDimsPersistedAndStripped`.
+2. **End-of-turn compaction gap (item 1).** A single-round turn returned
+   before round-2 `maybeCompact`, so the just-landed usage never triggered a
+   fold. Closed (see item 1), with the `a.compacted` guard preventing a
+   re-fold of a fresh fold.
+
+## Pre-existing failures (NOT this branch)
+
+`internal/tui` `TestStartupReportUnknownBgNotice` and
+`TestStartupReportSkillsAndWarnings` fail on clean `main` (verified via a
+`git worktree` checkout). They don't fail CI's `test` job. **Candidate
+follow-up:** fix these two in a separate small PR.
+
+---
+
+## 4. Verification (how to reproduce)
+
+```bash
+cd /home/abe/code/whip
+git checkout perf/context-cost-management
+go build ./...          # clean
+go vet ./...            # clean
+golangci-lint run       # clean
+go test ./...           # all pass except the 2 pre-existing internal/tui
+                        # TestStartupReport* failures (fail on main too)
+go test ./internal/agent/ ./internal/llm/ -count=1   # fresh, not cached
+```
+
+**CI:** PR #113 → 12/12 checks pass (lint, test, codeql ×2, driver,
+govulncheck, `go`, build ×4 platforms) at HEAD `f3ba3a8`.
+
+**New tests by item:**
+- 1: `TestMaybeCompactUsesRealUsage`, `TestMaybeCompactEstimateFallback`
+- 2: `TestImageTokensPixelFormula`, `TestImagePartRecordsDimensions`,
+  `TestContentPartDimsPersistedAndStripped`, `TestPartTokensLazyDecode`,
+  `TestDecodeImageSize`
+- 3: `TestNormalizeImage{OversizedShrinksToBudget,SmallPassthrough,CorruptPassthrough,NoiseFitsBudget}`
+- 5: `TestDecayStripsColdImageParts`
+- 6: `TestDoomLoopGuard`, `TestDoomLoopRefusalText`,
+  `TestDoomLoopRefusalSkipsExecution`
+- 7: `TestBackgroundTaskUsageNotDoubleCounted` (rewrote the old
+  `TestBackgroundTaskUsageRollsIntoParent`)
+- Updated for the budgeted tail: `TestCompactKeepsToolCallPair`,
+  `TestCompactionEventsCarryModelAndUsage`
+
+**Non-goals held:** no tokenizer vendored; the 50KB tool-output truncation +
+spill-to-disk is untouched.
+
+---
+
+## 5. What's left / possible follow-ups
+
+1. **Merge PR #113** once reviewed. Watch loupe review / any human comments.
+2. **Fix the 2 pre-existing TUI test failures** (separate PR; they fail on
+   `main`, so landing them first de-noises this branch's CI signal).
+3. **Optional quality pass on compaction:** opencode preserves the overflowed
+   user message (media stripped) or injects a synthetic "continue" after a
+   fold — whip currently re-derives from the tail. Evaluate whether that
+   improves post-compaction continuation.
+4. **Cache-hit observability:** the session had a 90.3% cache-hit rate; the
+   TUI could surface a warning when the hit rate drops (a leading indicator
+   of prefix churn / doom loops) — not implemented, just an idea from the
+   analysis.
+5. **Empirical $ validation:** after merge, rerun a comparable long session
+   and diff `usage_in`/cost against the ~$210 baseline. The items target
+   roughly a **$210 → ~$60–80** reduction on that workload profile.
+
+---
+
+## 6. Pointers for a fresh session
+
+- Start here: `docs/context-cost-plan.md` (the plan, with per-item rationale)
+  then this file (what shipped + how to verify).
+- The cost forensics live in `~/.whip/sessions.db` (session `7ec5ba63`); the
+  reconstruction used Python + `sqlite3` against the `messages` table (each
+  assistant row carries a `usage` JSON blob).
+- Branch is clean and rebased-safe: `git log --oneline origin/main..HEAD`
+  shows the 5 commits; nothing else diverges from `main` except these.

--- a/docs/context-cost-handoff.md
+++ b/docs/context-cost-handoff.md
@@ -53,7 +53,8 @@ a85be57 feat(agent): real-usage compaction trigger, budgeted tail, doom-loop gua
 e57ad57 feat(tui): normalize pasted and @-mentioned images at ingest
 f3ba3a8 lint: goimports grouping in images.go, drop predeclared 'real', remove unused encodePNG
 fb61707 docs: handoff doc for the context-cost work
-(HEAD)  fix(agent): lastPrompt only from own requests + reset on fold; refused calls fire tool events; cleanup
+2d593bb fix(agent): lastPrompt only from own requests + reset on fold; refused calls fire tool events; cleanup
+(HEAD)  feat(usage): per-model subagent ledger — accurate totals, persisted on session/task/compaction rows
 ```
 
 ### Item 1 — real-usage compaction trigger
@@ -120,15 +121,28 @@ fb61707 docs: handoff doc for the context-cost work
 - A refused call still fires `OnToolStart`/`OnToolEnd` so the TUI's queued
   row (opened on `OnToolCall`) closes instead of sticking at "⋯".
 
-### Item 7 — usage single-count
-`internal/agent/background.go` (`launchBackground`), `internal/agent/subagent.go`
-(follow-up path)
-- Removed the `OnUsage: parent.AddUsage` fan-in for **background** subagents
-  and follow-ups (their spend persists on the task's own attributed session
-  via `SaveSubagentTranscript`). **Foreground** subs keep `AddUsage` — their
-  spend has no other persisted record.
-- Net: each session row now reflects its own conversation's spend; the ~2×
-  cost-UI inflation is gone. Each sub still compacts on its own real usage.
+### Item 7 — usage accounting: accurate totals, counted once
+`internal/agent/agent.go`, `internal/agent/subagent.go`, `internal/session/session.go`, `internal/tui/tui.go`
+- `Agent.usage` = this agent's **own** requests (turns + its compaction
+  summaries). `Agent.subUsage` = a per-model ledger (`"model @ provider"` →
+  `llm.Usage`) of every subagent under it. `TotalUsage()` = own + subs.
+- Every sub gets `usageSink = parent.AddSubUsage` in `newSub`. `AddUsage`
+  and `AddSubUsage` forward through the sink, so foreground, background,
+  follow-up, **nested** subs and their compaction calls all reach the root
+  ledger exactly once. The old `OnUsage: parent.AddUsage` fan-ins are gone
+  (they mixed sub spend into the parent's own counter — the ~2× inflation).
+- **Persisted:** `sessions.usage_*` = own; new `sessions.sub_usage` JSON =
+  the ledger. Task rows (`task-<parent>-<id>`) now get their own `usage_*`
+  + `sub_usage` stamped via `BackgroundTask.SubUsage/SubSubUsage`.
+  `compactions` gains `model` + `usage` columns (the summary request's bill).
+  Resume and fork restore the ledger (`SetSubUsage`).
+- **Displayed:** header/status/opencode sidebar/context doctor show
+  `TotalUsage()`. `sessionCost` prices own spend at the session model's
+  rates plus each ledger entry at **its** model's rates (falls back to any
+  catalog that knows the model when the sub has no provider); if any
+  component is unpriceable the cost segment hides rather than under-report.
+- Old rows have an empty ledger; historical sub spend before this change is
+  only recoverable from the task sessions' per-message `usage` blobs.
 
 ---
 
@@ -188,8 +202,8 @@ govulncheck, `go`, build ×4 platforms).
 - 5: `TestDecayStripsColdImageParts`
 - 6: `TestDoomLoopGuard`, `TestDoomLoopRefusalText`,
   `TestDoomLoopRefusalSkipsExecution`
-- 7: `TestBackgroundTaskUsageNotDoubleCounted` (rewrote the old
-  `TestBackgroundTaskUsageRollsIntoParent`)
+- 7: `TestBackgroundTaskUsageNotDoubleCounted`, `TestSubUsageForwardsThroughNestedSubs`,
+  session `TestRecordCompactionCarriesModelAndUsage` + sub_usage round-trip in the usage test
 - Updated for the budgeted tail: `TestCompactKeepsToolCallPair`,
   `TestCompactionEventsCarryModelAndUsage`
 

--- a/docs/context-cost-plan.md
+++ b/docs/context-cost-plan.md
@@ -1,0 +1,116 @@
+# Plan: cut context/token cost without losing quality
+
+Evidence: session `7ec5ba63` (kimi-k3, 2026-09-01 → 09-03) — 731 main-loop
+requests + 1,365 subagent requests, 283M input tokens served (264M cached,
+19M fresh), ≈ $210 at inference-net rates. Peak per-request prompt: 392k
+tokens. Two compactions in 48h; user had `compactPct: 30` set and it never
+fired after the second compaction because the estimator never saw the context
+cross 30% of the 1M window while the provider was billing 391k.
+
+## Diagnosis (confirmed against the session DB)
+
+1. **Compaction trigger runs on `EstimateTokens` (chars/4 + flat 1200/image),
+   not real usage.** In session 7ec5ba63 the estimate peaked at 296k (28% of
+   window) while real prompt tokens hit 392k (37%). With `compactPct: 30` the
+   proactive path stayed asleep for the last ~150 requests. opencode triggers
+   off provider-reported usage on every step (`processor.ts:435-484`,
+   `overflow.ts`), cutting the stream mid-turn when full.
+2. **Image tokens are undercounted ~7×** (`agent.go:693`: `1200*len(m.Parts)`).
+   Four screenshots in that session actually cost 4.1k–11.4k tokens each
+   (28px-patch vision models); whip counted 1.2k. Images also never leave
+   context: ~7.1M tokens of the session's input was re-sending old
+   screenshots.
+3. **No image normalization at ingest.** Clipboard PNGs go in verbatim
+   (3410×2646 observed). opencode caps at 2000×2000 and re-encodes JPEG
+   q80→40 until ≤5MiB (`image/image.ts`).
+4. **Compaction tail is 6 *messages* (`compactKeepBack`), not a token
+   budget** — six messages can be six 50KB tool dumps; and the summary is
+   capped at 1024 output tokens with 500-char tool-result truncation in the
+   transcript, so each fold is small-lossy instead of small-lossless.
+   opencode keeps a token-budgeted tail (`min(15k, max(2k, usable×0.25))`)
+   and summarizes incrementally (carry the prior summary forward).
+5. **No doom-loop guard.** One subagent (`rewrite-flight-parser…-4`) made 789
+   sequential calls at 110–137k tokens each (85M tokens, ~$35) rewriting one
+   parser. opencode blocks the 3rd identical (tool, args) call behind a
+   permission prompt (`processor.ts:356-380`).
+6. **Usage accounting double-counts subagents** — fanned into the parent via
+   `AddUsage` (subagent.go:147) *and* persisted on the task session — and the
+   resume path (`tui.go:811-829`) can re-seed from per-message usage when the
+   columns are zero, inflating reported spend ~2× in this session (550M
+   reported vs 283M provider-truth).
+
+## Work items (ordered by $ saved per line changed)
+
+### 1. Real-usage compaction trigger — `internal/agent/agent.go`
+- After each `Stream` returns (we already have `usage` at agent.go:448),
+  record `lastUsage` and fire the proactive check off
+  `usage.PromptTokens + usage.CompletionTokens ≥ threshold × ContextLimit`
+  instead of (strictly, in addition to as a pre-flight fallback)
+  `EstimateTokens`.
+- Keep the chars/4 estimate only when the provider returns no usage.
+- Ref: opencode `session/overflow.ts`, `session/processor.ts:435-484`.
+
+### 2. Honest image token estimate — `internal/llm` + `internal/agent`
+- Decode PNG/JPEG dimensions from the first bytes of each `image_url` part;
+  estimate `⌈w/28⌉·⌈h/28⌉ + 2` (moonshot/qwen patching), floor at 85,
+  keep 1200 only when undecodable.
+- Store decoded dims on the ContentPart at ingest so the estimator never
+  re-decodes.
+
+### 3. Paste/ingest image normalization — `internal/tui/paste.go`, `mentions.go`, browser screenshot sink
+- Cap at 2000×2000 (Lanczos via `golang.org/x/image/draw`), re-encode JPEG
+  q≈80 (fall through 70/55/40) until base64 ≤5MiB. Port of opencode
+  `image/image.ts:10-14`. PNG kept only when JPEG can't beat the byte cap.
+- No-op for images already under the caps (cheap fast path).
+
+### 4. Token-budgeted compaction tail + incremental summary — `internal/agent/agent.go`
+- Replace `compactKeepBack = 6` messages with a token budget:
+  `min(15k, max(2k, usable×0.25))`, walking whole user turns newest-first
+  (never split a tool_call/result pair — keep the existing orphan walk-back).
+- Summary `MaxTokens` 1024 → 4096.
+- Thread the previous summary into `buildSummaryPrompt` ("merge, don't
+  re-summarize; anything you don't carry forward is lost") so fold N builds
+  on fold N−1 instead of re-deriving from truncated transcripts.
+
+### 5. Image strip in decay — `internal/agent/decay.go`
+- Once an image-bearing message exits the hot window and the conversation
+  has moved on (≥2 user turns later), replace the image part with a text
+  placeholder pointing at the paste file on disk (`~/.whip/pastes/…` already
+  persists it): `[screenshot 3410×2646 omitted; at PATH — re-paste if needed]`.
+  Zero quality loss for UI-iteration workflows; the file is recoverable.
+- Largest single win for long UI-polish sessions (would have removed ~5% of
+  this session's total spend, and much more in screenshot-heavy runs).
+
+### 6. Doom-loop guard — `internal/agent/agent.go` runTools
+- Key tool calls by (name, sha256(args)) per turn; on the 3rd identical call
+  return an error tool result: "refused: identical call repeated — change
+  approach or ask the user". Breaks subagent retry spirals that burn 10s of
+  millions of tokens (opencode `processor.ts:356-380`).
+
+### 7. Usage accounting fix — `internal/agent/subagent.go`, `internal/tui/tui.go`
+- Persist usage on exactly one row: the task session keeps its own usage;
+  the parent displays `own + Σ tasks` at render time instead of fanning into
+  its cumulative counters. On resume, never re-seed from per-message usage
+  once the columns are non-zero (already true) — additionally stop the
+  fan-in double-add for subagents whose task session persisted usage.
+
+### 8. Tests
+- Estimator: synthetic history with a 3410×2646 PNG part must estimate
+  within 20% of the provider-reported prompt tokens.
+- Trigger: fake client returning usage{prompt=320k} on a 1M-window agent
+  with threshold 0.3 compacts before the next request.
+- Doom loop: three identical `bash` calls in one turn → third returns the
+  refusal, no exec.
+- Image strip: paste a 2-image message, age it out of the hot window, run
+  decay, assert placeholder text + paste path, assert Parts empty.
+- Compaction tail: 50k-token tail budget keeps whole turns and never
+  orphans a tool result.
+
+## Non-goals
+- No tokenizer vendoring (tiktoken etc.) — real-usage trigger removes the
+  need for precision.
+- No change to the 50KB tool-output cap / middle-elision / spill-to-disk
+  (already matches opencode's 50KB truncation + disk recovery).
+- Prune of text tool results outside the hot window already exists as
+  `decay`; this plan extends the same idea to images rather than adding a
+  second mechanism.

--- a/docs/context-cost-plan.md
+++ b/docs/context-cost-plan.md
@@ -39,6 +39,11 @@ cross 30% of the 1M window while the provider was billing 391k.
    columns are zero, inflating reported spend ~2× in this session (550M
    reported vs 283M provider-truth).
 
+> **Status: implemented on this branch.** Items 1–7 landed with tests;
+> `go build ./...` and `go test ./...` pass (the two `internal/tui`
+> `TestStartupReport*` failures pre-date this branch — verified failing on
+> clean `main`). Implementation notes per item are marked "as built".
+
 ## Work items (ordered by $ saved per line changed)
 
 ### 1. Real-usage compaction trigger — `internal/agent/agent.go`

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.28
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/muesli/termenv v0.16.0
+	golang.org/x/image v0.45.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/tools v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
 golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=

--- a/internal/acp/bridge.go
+++ b/internal/acp/bridge.go
@@ -434,6 +434,10 @@ func (b *Bridge) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Prom
 		OnToolStart: func(id, name, args string) { _ = b.update(turnCtx, s.id, startToolCall(id, name, args)) },
 		OnToolEnd:   func(id, name, result string) { _ = b.update(turnCtx, s.id, b.endTool(s, id, name, result)) },
 		OnUsage:     func(u llm.Usage) { b.sendUsage(turnCtx, s, u) },
+		// Decay rewrote prefix messages in place (tool dumps, cold images);
+		// the incremental watermark would leave the original multi-MB rows in
+		// the store to resurrect on resume. Re-save from the first message.
+		OnDecay: func(int) { s.storeFrom = 1 },
 	})
 
 	// Persist like run.go: best-effort, incremental. When the save lands and

--- a/internal/acp/translate.go
+++ b/internal/acp/translate.go
@@ -187,7 +187,8 @@ func promptFromBlocks(blocks []acp.ContentBlock, vision bool) (text string, part
 		case b.Image != nil:
 			if vision {
 				if data, err := base64.StdEncoding.DecodeString(b.Image.Data); err == nil {
-					parts = append(parts, llm.ImagePart(mimeExt(b.Image.MimeType), data))
+					ext, data := llm.NormalizeImage(mimeExt(b.Image.MimeType), data) // same caps as paste/@mention
+					parts = append(parts, llm.ImagePart(ext, data))
 					continue
 				}
 			}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -125,6 +125,14 @@ type Agent struct {
 	// consistent slice. Mutations hold it only for the append.
 	msgsMu sync.Mutex
 
+	// Doom-loop bookkeeping: the last tool call's identity and how many times
+	// in a row it has run. Any different call resets the run, so a legit
+	// test→fix→test alternation never trips the guard — only the pure
+	// stuck-on-repeat pattern (a subagent sleep-polling git 500×) does.
+	loopMu      sync.Mutex
+	lastCallKey string
+	lastCallRun int
+
 	files *fileLocks // per-path mutation locks for parallel tool calls
 	bg    *taskRegistry
 
@@ -170,6 +178,11 @@ type Agent struct {
 
 	usageMu sync.Mutex
 	usage   llm.Usage // session totals across every API call (PromptTokens = input)
+	// lastPrompt is the provider-reported prompt tokens of the most recent
+	// request that returned usage — the real context size the next request
+	// starts from. Drives the compaction trigger (the chars/4 estimate
+	// undercounts images ~7×; real usage is the provider's bill).
+	lastPrompt int
 }
 
 // TurnRunning reports whether a turn is currently in flight. The wait
@@ -230,11 +243,17 @@ func (a *Agent) drainPending() []pendingSteer {
 	return p
 }
 
-// AddUsage folds one request's usage into the session totals.
+// AddUsage folds one request's usage into the session totals. It also
+// remembers the request's prompt size: that is the provider's own measure of
+// the context the NEXT request starts from, and maybeCompact triggers off it
+// (the chars/4 estimate is a fallback for providers that report no usage).
 func (a *Agent) AddUsage(u llm.Usage) {
 	a.usageMu.Lock()
 	a.usage.PromptTokens += u.PromptTokens
 	a.usage.CompletionTokens += u.CompletionTokens
+	if u.PromptTokens > 0 {
+		a.lastPrompt = u.PromptTokens
+	}
 	if u.PromptTokensDetails != nil {
 		if a.usage.PromptTokensDetails == nil {
 			a.usage.PromptTokensDetails = &struct {
@@ -508,6 +527,18 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 			a.msgsMu.Unlock()
 		}
 		if len(msg.ToolCalls) == 0 && len(steered) == 0 {
+			// Final round: the response that just landed may have pushed the
+			// real context over the threshold (its usage is now in lastPrompt)
+			// without a round-2 maybeCompact ever running — a single-round turn
+			// returns immediately otherwise. Fold now so the NEXT request
+			// doesn't pay for an over-threshold prefix. Skip when this turn
+			// already compacted (a.fold set a.compacted): the history is
+			// already small, and a second summary would re-fold a fresh fold.
+			if !a.compacted {
+				if cerr := a.maybeCompact(ctx, ev); cerr != nil {
+					return "", cerr
+				}
+			}
 			a.compacted = false // reset for the next Turn
 			return msg.Content, nil
 		}
@@ -570,12 +601,23 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 	}
 	outCh := make(chan outcome, len(calls)) // buffered: never blocks the workers
 
+	// Doom-loop guard: mark (in the batch's own order, before any goroutine
+	// scrambles completion order) which calls are stuck-on-repeat refusals.
+	// A refused call returns the refusal text without executing.
+	refused := a.markDoomLoops(calls)
+
 	var wg sync.WaitGroup
 	for i, tc := range calls {
 		wg.Add(1)
 		go func(i int, tc llm.ToolCall) {
 			defer wg.Done()
 			name, args := tc.Function.Name, tc.Function.Arguments
+
+			if refused[i] {
+				out := doomLoopRefusal(name)
+				outCh <- outcome{i, out, 0, 1}
+				return
+			}
 
 			// Serialize against other mutations before starting. Acquiring here
 			// (before OnToolStart) keeps "running" rows honest: a tool only
@@ -624,6 +666,49 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 	return results
 }
 
+// doomLoopMaxRun is how many consecutive identical (name, args) tool calls
+// are allowed before the guard refuses to execute another. The incident that
+// motivated it: a subagent sleep-polled `git status` 516 times (235 in a
+// row) waiting for an external change, burning 85M tokens. 3 lets a model
+// retry a flaky command once, but stops the pure stuck-on-repeat pattern.
+const doomLoopMaxRun = 3
+
+// doomLoopExempt tools are allowed to repeat identically: repetition is
+// their designed use (wait polls a condition internally and returns only on
+// change/timeout — each call carries fresh information).
+var doomLoopExempt = map[string]bool{"wait": true}
+
+// markDoomLoops walks the batch in issue order, updates the consecutive-run
+// counter per call, and returns the set of calls to refuse. Any call that
+// differs from the last resets the run, so test→edit→test alternation never
+// trips the guard — only an unbroken streak of identical calls does.
+func (a *Agent) markDoomLoops(calls []llm.ToolCall) []bool {
+	refused := make([]bool, len(calls))
+	a.loopMu.Lock()
+	defer a.loopMu.Unlock()
+	for i, tc := range calls {
+		key := tc.Function.Name + "\x00" + tc.Function.Arguments
+		if key == a.lastCallKey {
+			a.lastCallRun++
+		} else {
+			a.lastCallKey = key
+			a.lastCallRun = 1
+		}
+		if a.lastCallRun >= doomLoopMaxRun && !doomLoopExempt[tc.Function.Name] {
+			refused[i] = true
+		}
+	}
+	return refused
+}
+
+// doomLoopRefusal is the tool-result text a refused call returns. It names
+// the pattern and the two ways out so the model recovers instead of just
+// retrying (which would hit the guard again) or giving up.
+func doomLoopRefusal(name string) string {
+	return fmt.Sprintf("Error: refused to run %s — this exact call (same arguments) has already run %d times in a row with no other tool call in between. Repeating it will not produce new information. Change the approach: adjust the command/arguments, do the work instead of polling for it, or ask the user for guidance.",
+		name, doomLoopMaxRun)
+}
+
 // toolExitCode infers an exit status from a tool's output. Tools signal errors
 // by prefixing their output; 0 means success, 1 means the tool reported a
 // failure. Best-effort: the exact status lives in the tool, not the output.
@@ -634,11 +719,18 @@ func toolExitCode(out string) int {
 	return 0
 }
 
-// compactKeepBack counts assistant turns (and any tool results they pulled in)
-// preserved verbatim at the tail of the history. Keeping recent context means
-// any in-flight task the model is working on keeps its tool results in view,
-// and we never leave an orphaned tool_call whose result the summary dropped.
-const compactKeepBack = 6
+// Compaction keeps a token-budgeted TAIL of whole user turns verbatim, not a
+// fixed message count: six messages can be six 50KB tool dumps or six one-line
+// acks, and only the token budget treats them alike. The budget scales with
+// the model's usable window (min/max clamped) — a 1M-window model keeps more
+// recent context than a 128k one. Keeping whole turns means any in-flight
+// task the model is working on keeps its tool results in view, and we never
+// leave an orphaned tool_call whose result the summary dropped.
+const (
+	compactTailMinTokens = 2_000  // budget floor: even a tiny window keeps the last exchange
+	compactTailMaxTokens = 15_000 // budget ceiling: recent turns beyond this re-derive via tools
+	compactTailFraction  = 0.25   // of the usable window
+)
 
 // defaultCompactThreshold is the fraction of the provider-advertised context
 // window at which Turn compacts proactively when CompactThreshold is unset.
@@ -653,12 +745,28 @@ func (a *Agent) threshold() float64 {
 	return defaultCompactThreshold
 }
 
-// maybeCompact folds old turns into a summary once the estimated token count
-// crosses the threshold fraction of ContextLimit. It no-ops when the provider
-// didn't advertise a limit (ContextLimit == 0) — the reactive context-limit
-// retry in Turn still covers that case.
+// maybeCompact folds old turns into a summary once the context size crosses
+// the threshold fraction of ContextLimit. The primary measure is the
+// provider-reported prompt size of the last request (real billing truth);
+// the chars/4 estimate is the fallback for providers that return no usage.
+// It no-ops when the provider didn't advertise a limit (ContextLimit == 0) —
+// the reactive context-limit retry in Turn still covers that case.
 func (a *Agent) maybeCompact(ctx context.Context, ev Events) error {
-	if a.ContextLimit == 0 || EstimateTokens(a.Messages) < int(a.threshold()*float64(a.ContextLimit)) {
+	if a.ContextLimit == 0 {
+		return nil
+	}
+	limit := int(a.threshold() * float64(a.ContextLimit))
+	a.usageMu.Lock()
+	real := a.lastPrompt
+	a.usageMu.Unlock()
+	if real > 0 {
+		// The last request's prompt is what the next one starts from. Compacts
+		// the moment the real bill crosses the user's compactPct even when the
+		// chars/4 estimate (which undercounts images) says we're below it.
+		if real < limit {
+			return nil
+		}
+	} else if EstimateTokens(a.Messages) < limit {
 		return nil
 	}
 	took := len(a.Messages)
@@ -678,6 +786,10 @@ func (a *Agent) maybeCompact(ctx context.Context, ev Events) error {
 	if ev.OnCompacted != nil {
 		ev.OnCompacted(sum, cutoff, info)
 	}
+	// Mark that this turn compacted so the final-round check doesn't fold a
+	// fresh fold again. (Only the proactive path needs this — the reactive
+	// error path sets a.compacted itself.)
+	a.compacted = true
 	return nil
 }
 
@@ -690,7 +802,10 @@ func (a *Agent) maybeCompact(ctx context.Context, ev Events) error {
 func EstimateTokens(msgs []llm.Message) int {
 	total := 0
 	for _, m := range msgs {
-		total += 4 + (len(m.TextContent())+3)/4 + 1200*len(m.Parts) // ~tokens for an image
+		total += 4 + (len(m.TextContent())+3)/4
+		for _, p := range m.Parts {
+			total += llm.PartTokens(p) // pixel-true for images (was: flat 1200)
+		}
 		for _, tc := range m.ToolCalls {
 			total += 8 + (len(tc.Function.Name)+len(tc.Function.Arguments)+3)/4
 		}
@@ -698,12 +813,56 @@ func EstimateTokens(msgs []llm.Message) int {
 	return total
 }
 
+// compactTailBudget is the token budget for the kept tail of a compaction:
+// a quarter of the usable window, clamped to [compactTailMinTokens,
+// compactTailMaxTokens]. usable = ContextLimit minus what the threshold
+// reserves (the headroom we compact INTO); when ContextLimit is unknown the
+// ceiling is the budget.
+func (a *Agent) compactTailBudget() int {
+	budget := compactTailMaxTokens
+	if a.ContextLimit > 0 {
+		usable := float64(a.ContextLimit) * (1 - a.threshold())
+		budget = int(usable * compactTailFraction)
+	}
+	return max(min(budget, compactTailMaxTokens), compactTailMinTokens)
+}
+
+// compactTailStart picks the tail boundary: the index where the kept tail
+// begins. It walks user turns newest→oldest, accumulating each turn's tokens
+// (the user message plus its assistant replies and tool results) until adding
+// one more turn would exceed the budget. Whole turns only — a turn boundary
+// is the only place a summary can start without orphaning a tool_call.
+// Returns len(msgs) when nothing fits the budget (tail of zero), and clamps
+// to sysIdx+2 so the first user message is never dropped entirely.
+func compactTailStart(msgs []llm.Message, budget int) int {
+	if len(msgs) <= 2 {
+		return len(msgs)
+	}
+	acc := 0
+	start := len(msgs)
+	// Walk back turn by turn. A turn starts at each authored (or first) user
+	// message and runs to just before the next one.
+	for i := len(msgs) - 1; i >= 1; i-- {
+		acc += EstimateTokens(msgs[i : i+1])
+		if msgs[i].Role == "user" {
+			if acc > budget && start < len(msgs) {
+				break // adding this turn would bust the budget; tail stays as-is
+			}
+			start = i
+		}
+	}
+	if start <= 1 {
+		start = 2 // keep system + first user message out of the fold
+	}
+	return start
+}
+
 // compact replaces old turns with an LLM-generated summary, keeping the
-// system prompt and the last compactKeepBack (ish) messages so recent tool
-// results and any in-flight assistant action stay intact. It runs a single
-// non-streaming completion — on CompactClient/CompactModel when set, else
-// on the conversation's own client and model — and stores the summary as a
-// system-role message (it must carry no tool_call IDs that the kept tail
+// system prompt and a token-budgeted tail of recent whole turns so recent
+// tool results and any in-flight assistant action stay intact. It runs a
+// single non-streaming completion — on CompactClient/CompactModel when set,
+// else on the conversation's own client and model — and stores the summary as
+// a system-role message (it must carry no tool_call IDs that the kept tail
 // would orphan).
 //
 // It returns the summary text, the cutoff (the index in the pre-compaction
@@ -712,12 +871,13 @@ func EstimateTokens(msgs []llm.Message) int {
 // surface the compaction in the transcript. The caller records the summary
 // and cutoff as a compaction event so the raw log survives on disk.
 func (a *Agent) compact(ctx context.Context) (summary string, cutoff int, info CompactInfo, err error) {
-	if len(a.Messages) <= compactKeepBack+2 { // system + ≥1 user + tail: nothing to fold
+	if len(a.Messages) <= 3 { // system + ≥1 user + tail: nothing to fold
 		return "", 0, CompactInfo{}, errors.New("not enough history to compact")
 	}
 	const sysIdx = 0
 	sysPrompt := a.Messages[sysIdx]
-	tailStart := len(a.Messages) - compactKeepBack
+	budget := a.compactTailBudget()
+	tailStart := compactTailStart(a.Messages, budget)
 	if tailStart <= sysIdx+1 {
 		tailStart = sysIdx + 2 // never drop the first user message entirely
 	}
@@ -730,7 +890,17 @@ func (a *Agent) compact(ctx context.Context) (summary string, cutoff int, info C
 		tailStart--
 	}
 	history := a.Messages[sysIdx+1 : tailStart]
-	summaryPrompt := buildSummaryPrompt(history)
+	// Incremental compaction: when a previous summary message exists it
+	// carries the folded state forward, so the new fold merges into it
+	// instead of re-deriving everything from truncated transcripts. Anything
+	// the merge drops is lost — the prompt says so explicitly.
+	prior := ""
+	if len(history) > 0 && history[0].Role == "system" &&
+		strings.HasPrefix(history[0].Content, summaryPrefix) {
+		prior = strings.TrimPrefix(history[0].Content, summaryPrefix)
+		history = history[1:] // don't re-transcript the summary itself
+	}
+	summaryPrompt := buildSummaryPrompt(history, prior)
 	cli, mdl := a.CompactClient, a.CompactModel
 	dedicated := cli != nil
 	if cli == nil {
@@ -749,7 +919,7 @@ func (a *Agent) compact(ctx context.Context) (summary string, cutoff int, info C
 	}
 	sum, usage, cerr := cli.Complete(ctx, llm.Request{
 		Model:     mdl,
-		MaxTokens: 1024,
+		MaxTokens: 4096, // room for a real state digest; 1024 clipped multi-hour sessions
 		Messages: []llm.Message{
 			sysPrompt,
 			{Role: "user", Content: summaryPrompt},
@@ -763,23 +933,40 @@ func (a *Agent) compact(ctx context.Context) (summary string, cutoff int, info C
 	kept := append([]llm.Message(nil), tail...)
 	a.msgsMu.Lock()
 	a.Messages = append(append([]llm.Message{}, sysPrompt,
-		llm.Message{Role: "system", Content: "Summary of the conversation so far:\n\n" + summary},
+		llm.Message{Role: "system", Content: summaryPrefix + summary},
 	), kept...)
 	a.msgsMu.Unlock()
 	return summary, tailStart, CompactInfo{Model: label, Usage: usage}, nil
 }
 
+// summaryPrefix marks the folded-summary system message so a later compaction
+// recognizes and merges it (incremental fold) instead of re-summarizing it.
+const summaryPrefix = "Summary of the conversation so far:\n\n"
+
 // buildSummaryPrompt renders the unsummarized turns as a transcript the model
 // folds into a concise digest. Tool results are truncated so a giant file
 // read doesn't push the summary request over the window we just overflowed.
-func buildSummaryPrompt(msgs []llm.Message) string {
+// When prior is non-empty this is an incremental fold: the model merges the
+// new transcript into the running summary rather than starting over — each
+// fold then stays small and nothing the summary already captured is
+// re-derived from (lossy) truncated tool output.
+func buildSummaryPrompt(msgs []llm.Message, prior string) string {
 	var b strings.Builder
-	b.WriteString("Summarize the following conversation between the user and the assistant. ")
+	if prior != "" {
+		b.WriteString("Here is the running summary of the earlier conversation:\n\n<summary>\n")
+		b.WriteString(prior)
+		b.WriteString("\n</summary>\n\n")
+		b.WriteString("Below are the new turns since that summary was written. Merge them into the summary: ")
+		b.WriteString("keep everything still relevant (decisions, files touched, state), drop what the new turns ")
+		b.WriteString("obsolete, and add the new work. Anything you do not carry into the new summary is lost. ")
+	} else {
+		b.WriteString("Summarize the following conversation between the user and the assistant. ")
+	}
 	b.WriteString("Capture the user's intent, decisions made, work completed, files touched, ")
 	b.WriteString("and any open task the assistant is mid-way through. ")
-	b.WriteString("Be concise (a few short paragraphs at most); use bullet points for code/files. ")
-	b.WriteString("Do not include verbatim tool output. End with a single line: ")
-	b.WriteString("\"Open task: <what the assistant was doing last, or none>\".\n\n")
+	b.WriteString("Use these sections: Objective / Key decisions / Completed / Active (with the exact next step) / Blocked / Relevant files. ")
+	b.WriteString("Be concise; use bullet points for code/files. Do not include verbatim tool output. ")
+	b.WriteString("End with a single line: \"Open task: <what the assistant was doing last, or none>\".\n\n")
 	b.WriteString("---\n\n")
 	writeTranscript(&b, msgs)
 	b.WriteString("\n---\n\nWrite the summary now.")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -757,13 +757,13 @@ func (a *Agent) maybeCompact(ctx context.Context, ev Events) error {
 	}
 	limit := int(a.threshold() * float64(a.ContextLimit))
 	a.usageMu.Lock()
-	real := a.lastPrompt
+	reported := a.lastPrompt
 	a.usageMu.Unlock()
-	if real > 0 {
+	if reported > 0 {
 		// The last request's prompt is what the next one starts from. Compacts
 		// the moment the real bill crosses the user's compactPct even when the
 		// chars/4 estimate (which undercounts images) says we're below it.
-		if real < limit {
+		if reported < limit {
 			return nil
 		}
 	} else if EstimateTokens(a.Messages) < limit {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -178,10 +178,14 @@ type Agent struct {
 
 	usageMu sync.Mutex
 	usage   llm.Usage // session totals across every API call (PromptTokens = input)
-	// lastPrompt is the provider-reported prompt tokens of the most recent
-	// request that returned usage — the real context size the next request
+	// lastPrompt is the provider-reported prompt tokens of this agent's most
+	// recent conversation request — the real context size the next request
 	// starts from. Drives the compaction trigger (the chars/4 estimate
-	// undercounts images ~7×; real usage is the provider's bill).
+	// undercounts images ~7×; real usage is the provider's bill). Set by
+	// notePrompt from the turn loop only: AddUsage also receives foreground
+	// subagent and summary-call usage, whose prompt sizes say nothing about
+	// this conversation. Reset to 0 by compact (estimate fallback until the
+	// next real request lands).
 	lastPrompt int
 }
 
@@ -243,17 +247,23 @@ func (a *Agent) drainPending() []pendingSteer {
 	return p
 }
 
-// AddUsage folds one request's usage into the session totals. It also
-// remembers the request's prompt size: that is the provider's own measure of
-// the context the NEXT request starts from, and maybeCompact triggers off it
-// (the chars/4 estimate is a fallback for providers that report no usage).
+// notePrompt records the prompt size of one of this agent's own conversation
+// requests (see lastPrompt). Zero (provider reported no usage) is ignored so
+// the previous real value keeps driving the trigger.
+func (a *Agent) notePrompt(u llm.Usage) {
+	if u.PromptTokens <= 0 {
+		return
+	}
+	a.usageMu.Lock()
+	a.lastPrompt = u.PromptTokens
+	a.usageMu.Unlock()
+}
+
+// AddUsage folds one request's usage into the session totals.
 func (a *Agent) AddUsage(u llm.Usage) {
 	a.usageMu.Lock()
 	a.usage.PromptTokens += u.PromptTokens
 	a.usage.CompletionTokens += u.CompletionTokens
-	if u.PromptTokens > 0 {
-		a.lastPrompt = u.PromptTokens
-	}
 	if u.PromptTokensDetails != nil {
 		if a.usage.PromptTokensDetails == nil {
 			a.usage.PromptTokensDetails = &struct {
@@ -465,6 +475,7 @@ func (a *Agent) turn(ctx context.Context, input string, parts []llm.ContentPart,
 		}, ev.OnText, ev.OnThink, ev.OnToolCall)
 		a.Client.OnRetry = nil
 		a.AddUsage(usage)
+		a.notePrompt(usage)
 		if ev.OnUsage != nil {
 			ev.OnUsage(usage)
 		}
@@ -614,7 +625,15 @@ func (a *Agent) runTools(ctx context.Context, calls []llm.ToolCall, ev Events) [
 			name, args := tc.Function.Name, tc.Function.Arguments
 
 			if refused[i] {
+				// Fire the lifecycle events anyway: the UI opened a queued row
+				// on OnToolCall and only OnToolEnd closes it.
 				out := doomLoopRefusal(name)
+				if ev.OnToolStart != nil {
+					ev.OnToolStart(tc.ID, name, args)
+				}
+				if ev.OnToolEnd != nil {
+					ev.OnToolEnd(tc.ID, name, out)
+				}
 				outCh <- outcome{i, out, 0, 1}
 				return
 			}
@@ -831,13 +850,10 @@ func (a *Agent) compactTailBudget() int {
 // begins. It walks user turns newest→oldest, accumulating each turn's tokens
 // (the user message plus its assistant replies and tool results) until adding
 // one more turn would exceed the budget. Whole turns only — a turn boundary
-// is the only place a summary can start without orphaning a tool_call.
-// Returns len(msgs) when nothing fits the budget (tail of zero), and clamps
-// to sysIdx+2 so the first user message is never dropped entirely.
+// is the only place a summary can start without orphaning a tool_call. The
+// newest turn is always kept even when it alone exceeds the budget; the caller
+// clamps so the first user message is never folded.
 func compactTailStart(msgs []llm.Message, budget int) int {
-	if len(msgs) <= 2 {
-		return len(msgs)
-	}
 	acc := 0
 	start := len(msgs)
 	// Walk back turn by turn. A turn starts at each authored (or first) user
@@ -850,9 +866,6 @@ func compactTailStart(msgs []llm.Message, budget int) int {
 			}
 			start = i
 		}
-	}
-	if start <= 1 {
-		start = 2 // keep system + first user message out of the fold
 	}
 	return start
 }
@@ -936,6 +949,12 @@ func (a *Agent) compact(ctx context.Context) (summary string, cutoff int, info C
 		llm.Message{Role: "system", Content: summaryPrefix + summary},
 	), kept...)
 	a.msgsMu.Unlock()
+	// The pre-fold prompt size is stale now; fall back to the estimate until
+	// the next request reports the real post-fold size, else the next round
+	// would re-fold the fresh fold.
+	a.usageMu.Lock()
+	a.lastPrompt = 0
+	a.usageMu.Unlock()
 	return summary, tailStart, CompactInfo{Model: label, Usage: usage}, nil
 }
 
@@ -1079,6 +1098,7 @@ func (a *Agent) finalAnswer(ctx context.Context, ev Events) (string, error) {
 	}, ev.OnText, ev.OnThink, ev.OnToolCall)
 	a.Client.OnRetry = nil
 	a.AddUsage(usage)
+	a.notePrompt(usage)
 	if ev.OnUsage != nil {
 		ev.OnUsage(usage)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -177,7 +177,17 @@ type Agent struct {
 	OnOrphanedSteer func(text string)
 
 	usageMu sync.Mutex
-	usage   llm.Usage // session totals across every API call (PromptTokens = input)
+	usage   llm.Usage // this agent's own API calls (PromptTokens = input), incl. its compaction summaries
+	// subUsage is the spend of every subagent under this agent (foreground,
+	// background, follow-ups, and their own nested subs), keyed by the sub's
+	// model label so it can be priced per model. Kept apart from usage so
+	// each is counted exactly once: usage is what this conversation's own
+	// requests cost, TotalUsage adds the subs.
+	subUsage map[string]llm.Usage
+	// usageSink, set on subagents, forwards every request this agent (or a
+	// sub of it) makes to the parent's AddSubUsage — a single funnel that
+	// also catches compaction-summary calls, which no Events hook reports.
+	usageSink func(model string, u llm.Usage)
 	// lastPrompt is the provider-reported prompt tokens of this agent's most
 	// recent conversation request — the real context size the next request
 	// starts from. Drives the compaction trigger (the chars/4 estimate
@@ -259,20 +269,52 @@ func (a *Agent) notePrompt(u llm.Usage) {
 	a.usageMu.Unlock()
 }
 
-// AddUsage folds one request's usage into the session totals.
+// AddUsage folds one of this agent's own requests into its totals and, on a
+// subagent, forwards it to the parent's sub-usage ledger.
 func (a *Agent) AddUsage(u llm.Usage) {
 	a.usageMu.Lock()
-	a.usage.PromptTokens += u.PromptTokens
-	a.usage.CompletionTokens += u.CompletionTokens
+	addUsage(&a.usage, u)
+	sink := a.usageSink
+	a.usageMu.Unlock()
+	if sink != nil {
+		sink(a.usageLabel(), u)
+	}
+}
+
+// AddSubUsage folds one request made by a subagent (any depth) under this
+// agent into the per-model sub ledger, forwarding up again if this agent is
+// itself a sub.
+func (a *Agent) AddSubUsage(model string, u llm.Usage) {
+	a.usageMu.Lock()
+	if a.subUsage == nil {
+		a.subUsage = map[string]llm.Usage{}
+	}
+	cur := a.subUsage[model]
+	addUsage(&cur, u)
+	a.subUsage[model] = cur
+	sink := a.usageSink
+	a.usageMu.Unlock()
+	if sink != nil {
+		sink(model, u)
+	}
+}
+
+// usageLabel is the key sub spend is ledgered under: the same "model @
+// provider" form stamped on assistant messages.
+func (a *Agent) usageLabel() string { return a.Model + " @ " + a.Provider }
+
+// addUsage accumulates u into dst, including the cached-token detail.
+func addUsage(dst *llm.Usage, u llm.Usage) {
+	dst.PromptTokens += u.PromptTokens
+	dst.CompletionTokens += u.CompletionTokens
 	if u.PromptTokensDetails != nil {
-		if a.usage.PromptTokensDetails == nil {
-			a.usage.PromptTokensDetails = &struct {
+		if dst.PromptTokensDetails == nil {
+			dst.PromptTokensDetails = &struct {
 				CachedTokens int `json:"cached_tokens"`
 			}{}
 		}
-		a.usage.PromptTokensDetails.CachedTokens += u.PromptTokensDetails.CachedTokens
+		dst.PromptTokensDetails.CachedTokens += u.PromptTokensDetails.CachedTokens
 	}
-	a.usageMu.Unlock()
 }
 
 // SetUsage seeds the session totals with stored values — a resumed session
@@ -283,26 +325,69 @@ func (a *Agent) SetUsage(u llm.Usage) {
 	a.usageMu.Unlock()
 }
 
+// SetSubUsage seeds the per-model subagent ledger from a stored session.
+func (a *Agent) SetSubUsage(m map[string]llm.Usage) {
+	a.usageMu.Lock()
+	a.subUsage = copyUsageMap(m)
+	a.usageMu.Unlock()
+}
+
 // ResetUsage zeroes the session totals — /clear starts the spend counter
 // over along with the conversation.
 func (a *Agent) ResetUsage() {
 	a.usageMu.Lock()
 	a.usage = llm.Usage{}
+	a.subUsage = nil
 	a.usageMu.Unlock()
 }
 
-// Usage returns the session's cumulative token usage: input, output, and
-// cached-input tokens across every streamed call (plus compaction and
-// subagent calls on this agent).
+// Usage returns this agent's own cumulative token usage: input, output, and
+// cached-input tokens across every request it made itself (streamed turns
+// and compaction summaries). Subagent spend is in SubUsage; TotalUsage sums
+// both.
 func (a *Agent) Usage() llm.Usage {
 	a.usageMu.Lock()
 	defer a.usageMu.Unlock()
-	u := a.usage
-	if a.usage.PromptTokensDetails != nil {
-		d := *a.usage.PromptTokensDetails
+	return copyUsage(a.usage)
+}
+
+// SubUsage returns the spend of every subagent under this agent, by model
+// label (see usageLabel). Nil when no sub has run.
+func (a *Agent) SubUsage() map[string]llm.Usage {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
+	return copyUsageMap(a.subUsage)
+}
+
+// TotalUsage is Usage plus every subagent's spend: the session's whole bill
+// in tokens. For dollars price each SubUsage entry at its own model's rates.
+func (a *Agent) TotalUsage() llm.Usage {
+	a.usageMu.Lock()
+	defer a.usageMu.Unlock()
+	t := copyUsage(a.usage)
+	for _, u := range a.subUsage {
+		addUsage(&t, u)
+	}
+	return t
+}
+
+func copyUsage(u llm.Usage) llm.Usage {
+	if u.PromptTokensDetails != nil {
+		d := *u.PromptTokensDetails
 		u.PromptTokensDetails = &d
 	}
 	return u
+}
+
+func copyUsageMap(m map[string]llm.Usage) map[string]llm.Usage {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]llm.Usage, len(m))
+	for k, u := range m {
+		out[k] = copyUsage(u)
+	}
+	return out
 }
 
 func New(client *llm.Client, model string, maxTokens int, systemPrompt string) *Agent {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -658,18 +658,23 @@ func TestCompactKeepsToolCallPair(t *testing.T) {
 	}))
 	defer srv.Close()
 	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
-	// system, user, asst(with tool call "t1"), tool("t1" result), user, asst, user
-	for i := range 4 {
-		ag.Messages = append(ag.Messages, llm.Message{Role: "user", Content: fmt.Sprintf("u%d", i)})
-		if i == 0 {
-			ag.Messages = append(ag.Messages,
-				llm.Message{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "t1", Type: "function"}}},
-			)
-			ag.Messages = append(ag.Messages, llm.Message{Role: "tool", Content: "tool-out", ToolCallID: "t1"})
-		} else {
-			ag.Messages = append(ag.Messages, llm.Message{Role: "assistant", Content: fmt.Sprintf("a%d", i)})
-		}
+	ag.ContextLimit = 1000 // tiny window → tail budget clamps to the 2000-token floor
+	// Pad the early turns so they exceed the tail budget and fold. The
+	// tool-call pair comes LAST so it sits in the kept tail; the orphan guard
+	// must keep the tool result's owning assistant message alongside it.
+	pad := strings.Repeat("x", 8000) // ~2000 tokens per padded message
+	for i := range 3 {
+		ag.Messages = append(ag.Messages,
+			llm.Message{Role: "user", Content: pad + fmt.Sprintf("u%d", i)},
+			llm.Message{Role: "assistant", Content: pad + fmt.Sprintf("a%d", i)},
+		)
 	}
+	// final turn: small user + assistant(with tool call "t1") + tool("t1")
+	ag.Messages = append(ag.Messages,
+		llm.Message{Role: "user", Content: "final question"},
+		llm.Message{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "t1", Type: "function"}}},
+		llm.Message{Role: "tool", Content: "tool-out", ToolCallID: "t1"},
+	)
 	before := len(ag.Messages)
 	if _, _, _, err := ag.compact(context.Background()); err != nil {
 		t.Fatalf("compact: %v", err)
@@ -989,10 +994,13 @@ func TestCompactionEventsCarryModelAndUsage(t *testing.T) {
 	if starts != 1 || dones != 1 {
 		t.Fatalf("start/done should each fire exactly once, got %d/%d", starts, dones)
 	}
-	if startTook != len(ag.Messages) { // post-compaction length: the count the UI prints
-		if startTook < len(ag.Messages) {
-			t.Fatalf("start should report the pre-compaction count, got %d (post %d)", startTook, len(ag.Messages))
-		}
+	// startTook is the PRE-compaction message count (what OnCompact's took
+	// param means). With the token-budgeted tail the post-compaction length
+	// can exceed it on a tiny history (the ≥2000-token budget keeps nearly all
+	// of it, plus the summary message), so assert only that it fired and is
+	// plausible, not an exact post/pre relationship.
+	if startTook < 2 {
+		t.Fatalf("start should report the pre-compaction count, got %d", startTook)
 	}
 	if startEst <= 0 {
 		t.Fatalf("start should carry a positive token estimate, got %d", startEst)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -355,6 +355,7 @@ func TestTaskToolSpawnsSubagent(t *testing.T) {
 		switch call {
 		case 1: // outer agent delegates
 			fmt.Fprint(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","type":"function","function":{"name":"subagent","arguments":"{\"description\":\"probe\",\"prompt\":\"find the answer\"}"}}]}}]}`+"\n\n")
+			fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":1}}`+"\n\n")
 		case 2: // inner subagent: fresh context, no task tool, gets the prompt
 			if len(req.Messages) != 2 || req.Messages[1].Content != "find the answer" {
 				t.Errorf("subagent context wrong: %+v", req.Messages)
@@ -365,12 +366,14 @@ func TestTaskToolSpawnsSubagent(t *testing.T) {
 				}
 			}
 			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"the answer is 42"}}]}`+"\n\n")
+			fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":70,"completion_tokens":7}}`+"\n\n")
 		case 3: // outer agent sees the report as the tool result
 			last := req.Messages[len(req.Messages)-1]
 			if last.Role != "tool" || last.Content != "the answer is 42" {
 				t.Errorf("task result not fed back: %+v", last)
 			}
 			fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"done"}}]}`+"\n\n")
+			fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":1}}`+"\n\n")
 		}
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
@@ -383,6 +386,17 @@ func TestTaskToolSpawnsSubagent(t *testing.T) {
 	}
 	if call != 3 {
 		t.Fatalf("expected 3 API calls, got %d", call)
+	}
+	// Spend splits cleanly: the parent's two requests in Usage, the
+	// foreground sub's one request in the ledger, the total counting each once.
+	if u := ag.Usage(); u.PromptTokens != 20 || u.CompletionTokens != 2 {
+		t.Fatalf("parent's own usage should be its two requests (20/2), got %+v", u)
+	}
+	if u := ag.SubUsage()["m @ "]; u.PromptTokens != 70 || u.CompletionTokens != 7 {
+		t.Fatalf("foreground sub's request should be ledgered under its model: %+v", ag.SubUsage())
+	}
+	if u := ag.TotalUsage(); u.PromptTokens != 90 || u.CompletionTokens != 9 {
+		t.Fatalf("total should be 90/9, got %+v", u)
 	}
 }
 

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -401,7 +401,7 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 		// Usage() reports the session's own requests; per-sub spend is on the
 		// task sessions. The sub compacts on its own real usage, so dropping
 		// the fan-in doesn't blind the compaction trigger either.
-		report, err := t.sub.Turn(taskCtx, prompt, FanIn(a.bg.emitter(id), Events{}))
+		report, err := t.sub.Turn(taskCtx, prompt, a.bg.emitter(id))
 		status := TaskDone
 		text := report
 		switch {

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -393,7 +393,15 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 	id, description, prompt := t.ID, t.Description, t.Prompt
 	taskCtx := t.ctx
 	go func() {
-		report, err := t.sub.Turn(taskCtx, prompt, FanIn(a.bg.emitter(id), Events{OnUsage: a.AddUsage}))
+		// No OnUsage fan-in to the parent: the background subagent's spend is
+		// persisted on its own attributed task-session transcript (OnRecord →
+		// SaveSubagentTranscript), and each sub runs its own Turn/AddUsage, so
+		// folding it into the parent's totals too double-counts it (this drove
+		// one session's reported spend to ~2× the provider bill). The parent's
+		// Usage() reports the session's own requests; per-sub spend is on the
+		// task sessions. The sub compacts on its own real usage, so dropping
+		// the fan-in doesn't blind the compaction trigger either.
+		report, err := t.sub.Turn(taskCtx, prompt, FanIn(a.bg.emitter(id), Events{}))
 		status := TaskDone
 		text := report
 		switch {

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -61,6 +61,11 @@ type BackgroundTask struct {
 	// after settle, and a shared slice would let a follow-up mutate an
 	// already-saved snapshot. nil while running and on restored tasks.
 	SubMessages []llm.Message
+	// SubUsage is the sub's own spend and SubSubUsage its nested subs' spend
+	// (by model label), snapshotted with SubMessages so the task's session
+	// row carries its bill.
+	SubUsage    llm.Usage
+	SubSubUsage map[string]llm.Usage
 
 	// SubModel names the route the subagent actually ran on, for transcript
 	// attribution — the sub often runs a DIFFERENT model than the parent
@@ -393,14 +398,11 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 	id, description, prompt := t.ID, t.Description, t.Prompt
 	taskCtx := t.ctx
 	go func() {
-		// No OnUsage fan-in to the parent: the background subagent's spend is
-		// persisted on its own attributed task-session transcript (OnRecord →
-		// SaveSubagentTranscript), and each sub runs its own Turn/AddUsage, so
-		// folding it into the parent's totals too double-counts it (this drove
-		// one session's reported spend to ~2× the provider bill). The parent's
-		// Usage() reports the session's own requests; per-sub spend is on the
-		// task sessions. The sub compacts on its own real usage, so dropping
-		// the fan-in doesn't blind the compaction trigger either.
+		// No OnUsage fan-in into the parent's own totals: the sub's spend
+		// reaches parent.SubUsage through usageSink (set in newSub), so it is
+		// counted once there, and once more only on the task's own session
+		// row — never in the parent's usage_* columns (that double count once
+		// drove a session's reported spend to ~2× the provider bill).
 		report, err := t.sub.Turn(taskCtx, prompt, a.bg.emitter(id))
 		status := TaskDone
 		text := report
@@ -416,7 +418,15 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 		// every Update, so an unlocked write here is a live data race.
 		a.bg.mu.Lock()
 		t.SubMessages = t.sub.MessagesSnapshot()
+		// Snapshot the transcript and bill BEFORE settle: settle fires OnRecord
+		// (which persists them), so they must be populated first. Under the
+		// registry lock: List copies *t under it on every dock redraw, so an
+		// unlocked write here is a live data race.
+		a.bg.mu.Lock()
+		t.SubMessages = t.sub.MessagesSnapshot()
+		t.SubUsage, t.SubSubUsage = t.sub.Usage(), t.sub.SubUsage()
 		a.bg.mu.Unlock()
+		a.bg.settle(id, status, text)
 		a.bg.settle(id, status, text)
 		// subscribers stop here; late events after settle go nowhere (Subscribe
 		// rejects non-running tasks, and settled state is visible via List/Get)
@@ -439,6 +449,7 @@ func (r *taskRegistry) refreshTranscript(id string, sub *Agent) {
 	t, ok := r.tasks[id]
 	if ok {
 		t.SubMessages = sub.MessagesSnapshot()
+		t.SubUsage, t.SubSubUsage = sub.Usage(), sub.SubUsage()
 	}
 	r.mu.Unlock()
 	if !ok || r.OnRecord == nil {

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -412,12 +412,6 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 		case err != nil:
 			status, text = TaskError, err.Error()
 		}
-		// Snapshot the transcript BEFORE settle: settle fires OnRecord (which
-		// persists SubMessages), so it must be populated first. Under the
-		// registry lock: List copies *t under it, and the dock calls List on
-		// every Update, so an unlocked write here is a live data race.
-		a.bg.mu.Lock()
-		t.SubMessages = t.sub.MessagesSnapshot()
 		// Snapshot the transcript and bill BEFORE settle: settle fires OnRecord
 		// (which persists them), so they must be populated first. Under the
 		// registry lock: List copies *t under it on every dock redraw, so an
@@ -426,7 +420,6 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 		t.SubMessages = t.sub.MessagesSnapshot()
 		t.SubUsage, t.SubSubUsage = t.sub.Usage(), t.sub.SubUsage()
 		a.bg.mu.Unlock()
-		a.bg.settle(id, status, text)
 		a.bg.settle(id, status, text)
 		// subscribers stop here; late events after settle go nowhere (Subscribe
 		// rejects non-running tasks, and settled state is visible via List/Get)

--- a/internal/agent/cost_test.go
+++ b/internal/agent/cost_test.go
@@ -199,3 +199,50 @@ func TestDoomLoopRefusalSkipsExecution(t *testing.T) {
 		t.Fatalf("OnToolEnd should fire for the refused call too, got %d", ended.Load())
 	}
 }
+
+// A subagent's compaction summary request is spend too, and no Events hook
+// reports it — the usageSink funnel is what carries it to the parent. The
+// sub's streamed request and its summary call both land in the ledger.
+func TestSubCompactionUsageReachesParentLedger(t *testing.T) {
+	var summaryCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		if !req.Stream { // the sub's compaction summary
+			summaryCalls.Add(1)
+			w.Write([]byte(`{"choices":[{"message":{"content":"folded"}}],"usage":{"prompt_tokens":100,"completion_tokens":10}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":400000,"completion_tokens":5}}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	parent := New(llm.New(srv.URL, "k"), "parent-m", 100, "sys")
+	sub := parent.newSub(SubModel{Client: parent.Client, Model: "sub-m", ContextLimit: 1_000_000})
+	sub.CompactThreshold = 0.30
+	for range 6 {
+		sub.Messages = append(sub.Messages,
+			llm.Message{Role: "user", Content: strings.Repeat("q", 2000)},
+			llm.Message{Role: "assistant", Content: strings.Repeat("a", 2000)},
+		)
+	}
+	if _, err := sub.Turn(context.Background(), "continue", Events{}); err != nil {
+		t.Fatal(err)
+	}
+	if summaryCalls.Load() != 1 {
+		t.Fatalf("sub should have compacted once, summary calls = %d", summaryCalls.Load())
+	}
+	if u := parent.Usage(); u.PromptTokens != 0 {
+		t.Fatalf("parent's own usage must stay 0, got %+v", u)
+	}
+	got := parent.SubUsage()["sub-m @ "]
+	if got.PromptTokens != 400_100 || got.CompletionTokens != 15 {
+		t.Fatalf("ledger should hold the sub's stream (400000/5) + summary (100/10): %+v", got)
+	}
+	if own := sub.Usage(); own != got {
+		t.Fatalf("sub's own usage %+v should equal what the parent ledgered %+v", own, got)
+	}
+}

--- a/internal/agent/cost_test.go
+++ b/internal/agent/cost_test.go
@@ -58,6 +58,27 @@ func TestMaybeCompactUsesRealUsage(t *testing.T) {
 	if summaryCalls.Load() == 0 {
 		t.Fatal("real prompt size 400k (>30% of 1M) should have triggered compaction despite the low text estimate")
 	}
+	// The fold invalidates the pre-fold prompt size: it must not linger and
+	// re-trigger a fold of the fresh fold on the next round.
+	if ag.lastPrompt != 0 {
+		t.Fatalf("lastPrompt should reset after compaction, got %d", ag.lastPrompt)
+	}
+}
+
+// Only the agent's own conversation requests drive lastPrompt. AddUsage also
+// receives foreground-subagent and summary-call usage (session spend), whose
+// prompt sizes say nothing about this conversation's context.
+func TestLastPromptIgnoresFannedInUsage(t *testing.T) {
+	ag := New(nil, "m", 100, "sys")
+	ag.AddUsage(llm.Usage{PromptTokens: 900_000})
+	if ag.lastPrompt != 0 {
+		t.Fatalf("AddUsage must not set lastPrompt, got %d", ag.lastPrompt)
+	}
+	ag.notePrompt(llm.Usage{PromptTokens: 1234})
+	ag.notePrompt(llm.Usage{}) // no usage reported: keep the last real value
+	if ag.lastPrompt != 1234 {
+		t.Fatalf("notePrompt should set lastPrompt to 1234, got %d", ag.lastPrompt)
+	}
 }
 
 // When the provider reports no usage, the estimate fallback still drives the
@@ -99,13 +120,6 @@ func TestMaybeCompactEstimateFallback(t *testing.T) {
 // without executing; an intervening different call resets the run.
 func TestDoomLoopGuard(t *testing.T) {
 	ag := New(nil, "m", 100, "sys")
-	calls := []llm.ToolCall{
-		{ID: "1", Function: struct {
-			Name      string `json:"name"`
-			Arguments string `json:"arguments"`
-		}{Name: "bash", Arguments: `{"command":"git status"}`}},
-	}
-	// helper to build a call
 	mk := func(id, name, args string) llm.ToolCall {
 		var tc llm.ToolCall
 		tc.ID = id
@@ -132,7 +146,6 @@ func TestDoomLoopGuard(t *testing.T) {
 		t.Fatal("after a reset, the same call runs again (run restarts at 1)")
 	}
 	// wait is exempt (repetition is its design).
-	_ = calls
 	w1 := ag.markDoomLoops([]llm.ToolCall{mk("g", "wait", `{"cmd":"true"}`)})
 	w2 := ag.markDoomLoops([]llm.ToolCall{mk("h", "wait", `{"cmd":"true"}`)})
 	w3 := ag.markDoomLoops([]llm.ToolCall{mk("i", "wait", `{"cmd":"true"}`)})
@@ -169,14 +182,20 @@ func TestDoomLoopRefusalSkipsExecution(t *testing.T) {
 		tc.Function.Arguments = `{"x":"same"}`
 		return tc
 	}
-	// Run the same call 3×; the 3rd must be refused (tool body runs only 2×).
-	ag.runTools(context.Background(), []llm.ToolCall{mk("1")}, Events{})
-	ag.runTools(context.Background(), []llm.ToolCall{mk("2")}, Events{})
-	res := ag.runTools(context.Background(), []llm.ToolCall{mk("3")}, Events{})
+	// Run the same call 3×; the 3rd must be refused (tool body runs only 2×)
+	// but still close its UI row via OnToolEnd.
+	var ended atomic.Int32
+	ev := Events{OnToolEnd: func(string, string, string) { ended.Add(1) }}
+	ag.runTools(context.Background(), []llm.ToolCall{mk("1")}, ev)
+	ag.runTools(context.Background(), []llm.ToolCall{mk("2")}, ev)
+	res := ag.runTools(context.Background(), []llm.ToolCall{mk("3")}, ev)
 	if ran.Load() != 2 {
 		t.Fatalf("tool body should run twice, ran %d", ran.Load())
 	}
 	if !strings.Contains(res[0], "refused") {
 		t.Fatalf("3rd call should return the refusal, got %q", res[0])
+	}
+	if ended.Load() != 3 {
+		t.Fatalf("OnToolEnd should fire for the refused call too, got %d", ended.Load())
 	}
 }

--- a/internal/agent/cost_test.go
+++ b/internal/agent/cost_test.go
@@ -1,0 +1,182 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/tools"
+)
+
+// The proactive compaction trigger must fire on the provider-REPORTED prompt
+// size, not the chars/4 estimate: a session whose real context crosses
+// compactPct of the window compacts even when the text estimate stays below
+// it (images are undercounted by the estimator).
+func TestMaybeCompactUsesRealUsage(t *testing.T) {
+	var summaryCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		if !req.Stream { // compaction summary call
+			summaryCalls.Add(1)
+			w.Write([]byte(`{"choices":[{"message":{"content":"folded"}}],"usage":{"prompt_tokens":100,"completion_tokens":10}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`+"\n\n")
+		// Report a prompt size that is 40% of a 1M window — over compactPct=30
+		// even though the tiny text history estimates to a few hundred tokens.
+		fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":400000,"completion_tokens":5}}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.ContextLimit = 1_000_000
+	ag.CompactThreshold = 0.30
+	// Seed enough history that there's something to fold.
+	for range 6 {
+		ag.Messages = append(ag.Messages,
+			llm.Message{Role: "user", Content: strings.Repeat("q", 2000)},
+			llm.Message{Role: "assistant", Content: strings.Repeat("a", 2000)},
+		)
+	}
+	// Estimate is far below 30% of 1M, so this ONLY compacts if the trigger
+	// reads the real 400k prompt size.
+	if est := EstimateTokens(ag.Messages); est >= 300_000 {
+		t.Fatalf("test setup: estimate %d should be well under 300k for the real-usage path to matter", est)
+	}
+	if _, err := ag.Turn(context.Background(), "continue", Events{}); err != nil {
+		t.Fatal(err)
+	}
+	if summaryCalls.Load() == 0 {
+		t.Fatal("real prompt size 400k (>30% of 1M) should have triggered compaction despite the low text estimate")
+	}
+}
+
+// When the provider reports no usage, the estimate fallback still drives the
+// trigger (no regression for usage-less providers).
+func TestMaybeCompactEstimateFallback(t *testing.T) {
+	var summaryCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llm.Request
+		json.NewDecoder(r.Body).Decode(&req)
+		if !req.Stream {
+			summaryCalls.Add(1)
+			w.Write([]byte(`{"choices":[{"message":{"content":"folded"}}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n") // no usage chunk
+	}))
+	defer srv.Close()
+
+	ag := New(llm.New(srv.URL, "k"), "m", 100, "sys")
+	ag.ContextLimit = 1000 // tiny window so the estimate crosses 30%
+	ag.CompactThreshold = 0.30
+	for range 6 {
+		ag.Messages = append(ag.Messages,
+			llm.Message{Role: "user", Content: strings.Repeat("q", 2000)},
+			llm.Message{Role: "assistant", Content: strings.Repeat("a", 2000)},
+		)
+	}
+	if _, err := ag.Turn(context.Background(), "continue", Events{}); err != nil {
+		t.Fatal(err)
+	}
+	if summaryCalls.Load() == 0 {
+		t.Fatal("with no usage reported, the estimate (>30% of the tiny window) should still trigger compaction")
+	}
+}
+
+// Doom loop: the 3rd consecutive identical (name, args) call is refused
+// without executing; an intervening different call resets the run.
+func TestDoomLoopGuard(t *testing.T) {
+	ag := New(nil, "m", 100, "sys")
+	calls := []llm.ToolCall{
+		{ID: "1", Function: struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{Name: "bash", Arguments: `{"command":"git status"}`}},
+	}
+	// helper to build a call
+	mk := func(id, name, args string) llm.ToolCall {
+		var tc llm.ToolCall
+		tc.ID = id
+		tc.Function.Name = name
+		tc.Function.Arguments = args
+		return tc
+	}
+
+	// Three identical in a row: 1st and 2nd run, 3rd refused.
+	batch := []llm.ToolCall{mk("a", "bash", `{"command":"git status"}`), mk("b", "bash", `{"command":"git status"}`), mk("c", "bash", `{"command":"git status"}`)}
+	refused := ag.markDoomLoops(batch)
+	if refused[0] || refused[1] || !refused[2] {
+		t.Fatalf("3rd identical call should be refused, 1st/2nd allowed: %v", refused)
+	}
+	// 4th identical still refused (run continues).
+	if r := ag.markDoomLoops([]llm.ToolCall{mk("d", "bash", `{"command":"git status"}`)}); !r[0] {
+		t.Fatal("4th identical call should also be refused")
+	}
+	// A different call resets the run.
+	if r := ag.markDoomLoops([]llm.ToolCall{mk("e", "read", `{"path":"x"}`)}); r[0] {
+		t.Fatal("a different call must reset the run")
+	}
+	if r := ag.markDoomLoops([]llm.ToolCall{mk("f", "bash", `{"command":"git status"}`)}); r[0] {
+		t.Fatal("after a reset, the same call runs again (run restarts at 1)")
+	}
+	// wait is exempt (repetition is its design).
+	_ = calls
+	w1 := ag.markDoomLoops([]llm.ToolCall{mk("g", "wait", `{"cmd":"true"}`)})
+	w2 := ag.markDoomLoops([]llm.ToolCall{mk("h", "wait", `{"cmd":"true"}`)})
+	w3 := ag.markDoomLoops([]llm.ToolCall{mk("i", "wait", `{"cmd":"true"}`)})
+	if w1[0] || w2[0] || w3[0] {
+		t.Fatal("wait must be exempt from the doom-loop guard")
+	}
+}
+
+// The refusal text names the tool and the recovery paths.
+func TestDoomLoopRefusalText(t *testing.T) {
+	msg := doomLoopRefusal("bash")
+	if !strings.Contains(msg, "bash") || !strings.Contains(msg, "refused") {
+		t.Fatalf("refusal should name the tool and the refusal: %q", msg)
+	}
+}
+
+// A refused call returns the refusal as its tool result WITHOUT executing the
+// tool body.
+func TestDoomLoopRefusalSkipsExecution(t *testing.T) {
+	var ran atomic.Int32
+	tool := tools.Tool{
+		Def: llm.NewTool("noop", "noop", `{"type":"object","properties":{"x":{"type":"string"}}}`),
+		Run: func(ctx context.Context, args json.RawMessage) (string, error) {
+			ran.Add(1)
+			return "ran", nil
+		},
+	}
+	ag := New(nil, "m", 100, "sys")
+	ag.Tools = []tools.Tool{tool}
+	mk := func(id string) llm.ToolCall {
+		var tc llm.ToolCall
+		tc.ID = id
+		tc.Function.Name = "noop"
+		tc.Function.Arguments = `{"x":"same"}`
+		return tc
+	}
+	// Run the same call 3×; the 3rd must be refused (tool body runs only 2×).
+	ag.runTools(context.Background(), []llm.ToolCall{mk("1")}, Events{})
+	ag.runTools(context.Background(), []llm.ToolCall{mk("2")}, Events{})
+	res := ag.runTools(context.Background(), []llm.ToolCall{mk("3")}, Events{})
+	if ran.Load() != 2 {
+		t.Fatalf("tool body should run twice, ran %d", ran.Load())
+	}
+	if !strings.Contains(res[0], "refused") {
+		t.Fatalf("3rd call should return the refusal, got %q", res[0])
+	}
+}

--- a/internal/agent/decay.go
+++ b/internal/agent/decay.go
@@ -185,9 +185,8 @@ func (a *Agent) decay() int {
 
 // stripImageParts replaces every image part of m with a text placeholder
 // naming the image's pixel size and the disk path the bytes were spilled to.
-// Returns the number of parts stripped. A message whose images were all
-// stripped keeps its text parts; if it had no text at all the placeholder
-// also becomes Content so the message still reads coherently.
+// Returns the number of parts stripped. The message's text parts (and
+// Content) are untouched.
 func stripImageParts(m *llm.Message) int {
 	stripped := 0
 	var kept []llm.ContentPart
@@ -212,17 +211,10 @@ func stripImageParts(m *llm.Message) int {
 	if stripped == 0 {
 		return 0
 	}
+	// Content stays as it was: the wire form prepends a non-empty Content as
+	// its own text part, so mirroring the placeholder there would send it
+	// twice. TextContent() already reads text parts for a pure-image message.
 	m.Parts = kept
-	// Mirror the first placeholder into Content when the message was pure
-	// image (Content mirrors the text part for multimodal messages).
-	if m.Content == "" {
-		for _, p := range kept {
-			if p.Type == "text" {
-				m.Content = p.Text
-				break
-			}
-		}
-	}
 	return stripped
 }
 

--- a/internal/agent/decay.go
+++ b/internal/agent/decay.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -166,7 +168,115 @@ func (a *Agent) decay() int {
 		m.Content = decayNotice(a.Messages, i, turns)
 		rewritten++
 	}
+
+	// Pass 3: image decay. An image part past the hot window costs thousands
+	// of tokens per request and is almost never looked at again — screenshots
+	// of a UI the user has since iterated on, error dialogs already fixed.
+	// Swap the part for a text placeholder pointing at the spilled file on
+	// disk; the model re-attaches it via @mention if it genuinely needs the
+	// pixels again. Text parts of the message stay inline (the prompt that
+	// accompanied the image is semantic glue). Runs after Pass 2 so turns
+	// already reflects authored-user distance.
+	for i := boundary - 1; i > 0; i-- {
+		m := &a.Messages[i]
+		if len(m.Parts) == 0 {
+			continue
+		}
+		n := stripImageParts(m)
+		if n > 0 {
+			rewritten += n
+		}
+	}
 	return rewritten
+}
+
+// stripImageParts replaces every image part of m with a text placeholder
+// naming the image's pixel size and the disk path the bytes were spilled to.
+// Returns the number of parts stripped. A message whose images were all
+// stripped keeps its text parts; if it had no text at all the placeholder
+// also becomes Content so the message still reads coherently.
+func stripImageParts(m *llm.Message) int {
+	stripped := 0
+	var kept []llm.ContentPart
+	for _, p := range m.Parts {
+		if p.Type != "image_url" || p.ImageURL == nil {
+			kept = append(kept, p)
+			continue
+		}
+		path := spillImage(p.ImageURL.URL)
+		w, h := p.Dimensions()
+		size := "image"
+		if w > 0 {
+			size = fmt.Sprintf("%d×%d image", w, h)
+		}
+		note := decayedMarker + size + " omitted"
+		if path != "" {
+			note += " — bytes at " + path + " (re-attach with @" + path + " if needed)"
+		}
+		note += "⟩"
+		kept = append(kept, llm.ContentPart{Type: "text", Text: note})
+		stripped++
+	}
+	if stripped == 0 {
+		return 0
+	}
+	m.Parts = kept
+	// Mirror the first placeholder into Content when the message was pure
+	// image (Content mirrors the text part for multimodal messages).
+	if m.Content == "" {
+		for _, p := range kept {
+			if p.Type == "text" {
+				m.Content = p.Text
+				break
+			}
+		}
+	}
+	return stripped
+}
+
+// spillImage writes a base64 data URL's bytes to disk and returns the path,
+// or "" on any failure (the placeholder then just says the image is gone —
+// a failed spill must never break decay). Files live beside bash spills.
+func spillImage(dataURL string) string {
+	const prefix = ";base64,"
+	i := strings.Index(dataURL, prefix)
+	if i < 0 {
+		return ""
+	}
+	mime := dataURL[len("data:"):i]
+	ext := "png"
+	switch mime {
+	case "image/jpeg":
+		ext = "jpg"
+	case "image/gif":
+		ext = "gif"
+	case "image/webp":
+		ext = "webp"
+	case "image/bmp":
+		ext = "bmp"
+	}
+	raw, err := base64.StdEncoding.DecodeString(dataURL[i+len(prefix):])
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("whip-img-%d", os.Getpid()))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return ""
+	}
+	f, err := os.CreateTemp(dir, "*."+ext)
+	if err != nil {
+		return ""
+	}
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return ""
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return ""
+	}
+	return f.Name()
 }
 
 // hotBoundary returns the index in msgs where the hot window begins. Walking

--- a/internal/agent/decay.go
+++ b/internal/agent/decay.go
@@ -183,13 +183,14 @@ func (a *Agent) decay() int {
 	return rewritten
 }
 
-// stripImageParts replaces every image part of m with a text placeholder
-// naming the image's pixel size and the disk path the bytes were spilled to.
-// Returns the number of parts stripped. The message's text parts (and
-// Content) are untouched.
+// stripImageParts removes every image part of m and rewrites it as a plain
+// text message: its own text, then one placeholder per image naming the pixel
+// size and the disk path the bytes were spilled to. Returns the number of
+// parts stripped.
 func stripImageParts(m *llm.Message) int {
 	stripped := 0
 	var kept []llm.ContentPart
+	var notes []string
 	for _, p := range m.Parts {
 		if p.Type != "image_url" || p.ImageURL == nil {
 			kept = append(kept, p)
@@ -205,16 +206,28 @@ func stripImageParts(m *llm.Message) int {
 			note += " — bytes at " + path + " (re-attach with @" + path + " if needed)"
 		}
 		note += "⟩"
-		kept = append(kept, llm.ContentPart{Type: "text", Text: note})
+		notes = append(notes, note)
 		stripped++
 	}
 	if stripped == 0 {
 		return 0
 	}
-	// Content stays as it was: the wire form prepends a non-empty Content as
-	// its own text part, so mirroring the placeholder there would send it
-	// twice. TextContent() already reads text parts for a pure-image message.
-	m.Parts = kept
+	// Every image is gone, so collapse to a plain text message: Content is
+	// the one text field that survives a persist/reload round trip (a
+	// multimodal row reloads with its LAST text part as Content, see
+	// Message.UnmarshalJSON), so leaving a text part behind — or adding the
+	// placeholder as one — would replace the user's own text on resume.
+	texts := []string{}
+	if m.Content != "" {
+		texts = append(texts, m.Content)
+	}
+	for _, p := range kept {
+		if p.Type == "text" && p.Text != "" && p.Text != m.Content { // Content usually mirrors the text part
+			texts = append(texts, p.Text)
+		}
+	}
+	m.Content = strings.Join(append(texts, notes...), "\n")
+	m.Parts = nil
 	return stripped
 }
 
@@ -224,8 +237,8 @@ func stripImageParts(m *llm.Message) int {
 func spillImage(dataURL string) string {
 	const prefix = ";base64,"
 	i := strings.Index(dataURL, prefix)
-	if i < 0 {
-		return ""
+	if !strings.HasPrefix(dataURL, "data:") || i < len("data:") {
+		return "" // not a data URL we built (persisted rows are loaded verbatim)
 	}
 	mime := dataURL[len("data:"):i]
 	ext := "png"

--- a/internal/agent/decay.go
+++ b/internal/agent/decay.go
@@ -178,14 +178,7 @@ func (a *Agent) decay() int {
 	// accompanied the image is semantic glue). Runs after Pass 2 so turns
 	// already reflects authored-user distance.
 	for i := boundary - 1; i > 0; i-- {
-		m := &a.Messages[i]
-		if len(m.Parts) == 0 {
-			continue
-		}
-		n := stripImageParts(m)
-		if n > 0 {
-			rewritten += n
-		}
+		rewritten += stripImageParts(&a.Messages[i])
 	}
 	return rewritten
 }
@@ -204,10 +197,9 @@ func stripImageParts(m *llm.Message) int {
 			continue
 		}
 		path := spillImage(p.ImageURL.URL)
-		w, h := p.Dimensions()
 		size := "image"
-		if w > 0 {
-			size = fmt.Sprintf("%d×%d image", w, h)
+		if p.W > 0 {
+			size = fmt.Sprintf("%d×%d image", p.W, p.H)
 		}
 		note := decayedMarker + size + " omitted"
 		if path != "" {

--- a/internal/agent/decay.go
+++ b/internal/agent/decay.go
@@ -296,7 +296,14 @@ func msgTokens(m llm.Message) int {
 	for _, tc := range m.ToolCalls {
 		n += len(tc.Function.Name) + len(tc.Function.Arguments)
 	}
-	return n / 4
+	t := n / 4
+	for _, p := range m.Parts {
+		// image parts cost thousands of tokens and carry no Content; without
+		// this an image-only screenshot turn never spends the hot budget and
+		// Pass 3 never gets to strip it
+		t += llm.PartTokens(p)
+	}
+	return t
 }
 
 // readPathFromCall finds the assistant tool_call that produced the tool

--- a/internal/agent/decay_test.go
+++ b/internal/agent/decay_test.go
@@ -1,7 +1,10 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
+	"image"
+	"image/png"
 	"os"
 	"strings"
 	"testing"
@@ -250,4 +253,73 @@ func TestSpillPathOfParsesBothMarkerShapes(t *testing.T) {
 	if got := spillPathOf("no marker here"); got != "" {
 		t.Errorf("no marker should give empty, got %q", got)
 	}
+}
+
+// Image parts past the hot window are swapped for a text placeholder naming
+// the pixel size and the spilled file; text parts and Content stay. The image
+// is recoverable by re-attaching the spilled path.
+func TestDecayStripsColdImageParts(t *testing.T) {
+	png := pngFixtureForDecay(t, 640, 480) // ⌈640/28⌉=23, ⌈480/28⌉=18 → 414 tokens
+	img := llm.ImagePart("png", png)
+
+	a := &Agent{}
+	a.Messages = padHotWindow([]llm.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "look at this", Parts: []llm.ContentPart{{Type: "text", Text: "look at this"}, img}},
+	})
+	before := EstimateTokens(a.Messages)
+	n := a.decay()
+	if n == 0 {
+		t.Fatal("image past the hot window should be stripped")
+	}
+	m := a.Messages[1]
+	// no image parts remain
+	for _, p := range m.Parts {
+		if p.Type == "image_url" {
+			t.Fatal("image part should be replaced")
+		}
+	}
+	// a placeholder text part names the dims and the spill path
+	var placeholder string
+	for _, p := range m.Parts {
+		if p.Type == "text" && strings.Contains(p.Text, "omitted") {
+			placeholder = p.Text
+		}
+	}
+	if !strings.Contains(placeholder, "640×480") {
+		t.Errorf("placeholder should name the pixel size, got %q", placeholder)
+	}
+	if !strings.Contains(placeholder, "whip-img-") {
+		t.Errorf("placeholder should point at the spilled file, got %q", placeholder)
+	}
+	// text part survives
+	foundText := false
+	for _, p := range m.Parts {
+		if p.Type == "text" && p.Text == "look at this" {
+			foundText = true
+		}
+	}
+	if !foundText {
+		t.Error("the accompanying text part must stay inline")
+	}
+	// the estimate dropped by roughly the image's token cost
+	after := EstimateTokens(a.Messages)
+	if before-after < 300 {
+		t.Errorf("stripping should drop the estimate (before=%d after=%d)", before, after)
+	}
+	// idempotent
+	if n := a.decay(); n != 0 {
+		t.Errorf("second decay should be a no-op, rewrote %d", n)
+	}
+}
+
+// pngFixtureForDecay builds a real PNG so ImagePart can record dims.
+func pngFixtureForDecay(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode fixture: %v", err)
+	}
+	return buf.Bytes()
 }

--- a/internal/agent/decay_test.go
+++ b/internal/agent/decay_test.go
@@ -344,4 +344,9 @@ func TestDecayImageOnlyMessagesSpendHotWindow(t *testing.T) {
 	if last.Parts[0].Type != "image_url" {
 		t.Fatal("the newest image must stay hot")
 	}
+	// Content stays empty: the wire form prepends Content as a text part, so
+	// mirroring the placeholder there would send it twice.
+	if a.Messages[1].Content != "" {
+		t.Fatalf("placeholder must live in Parts only, Content=%q", a.Messages[1].Content)
+	}
 }

--- a/internal/agent/decay_test.go
+++ b/internal/agent/decay_test.go
@@ -323,3 +323,25 @@ func pngFixtureForDecay(t *testing.T, w, h int) []byte {
 	}
 	return buf.Bytes()
 }
+
+// Image-only messages (screenshot steers, ACP image blocks) carry no Content,
+// so they must spend the hot-window budget through their parts: a run of
+// large images alone pushes the oldest past the window and Pass 3 strips it.
+func TestDecayImageOnlyMessagesSpendHotWindow(t *testing.T) {
+	big := llm.ImagePart("png", pngFixtureForDecay(t, 2000, 2000)) // ⌈2000/28⌉² = 5184 tokens
+	a := &Agent{}
+	a.Messages = []llm.Message{{Role: "system", Content: "sys"}}
+	for range 6 { // 6 × 5184 > the 24k hot window with no text at all
+		a.Messages = append(a.Messages, llm.Message{Role: "user", Parts: []llm.ContentPart{big}})
+	}
+	if n := a.decay(); n == 0 {
+		t.Fatal("the oldest image-only message should fall past the hot window and be stripped")
+	}
+	if len(a.Messages[1].Parts) != 1 || a.Messages[1].Parts[0].Type != "text" {
+		t.Fatalf("oldest message should now hold a text placeholder, got %+v", a.Messages[1].Parts)
+	}
+	last := a.Messages[len(a.Messages)-1]
+	if last.Parts[0].Type != "image_url" {
+		t.Fatal("the newest image must stay hot")
+	}
+}

--- a/internal/agent/decay_test.go
+++ b/internal/agent/decay_test.go
@@ -279,12 +279,11 @@ func TestDecayStripsColdImageParts(t *testing.T) {
 			t.Fatal("image part should be replaced")
 		}
 	}
-	// a placeholder text part names the dims and the spill path
-	var placeholder string
-	for _, p := range m.Parts {
-		if p.Type == "text" && strings.Contains(p.Text, "omitted") {
-			placeholder = p.Text
-		}
+	// the placeholder lands in Content (the one text field that survives a
+	// persist/reload round trip) after the user's own text
+	placeholder := m.Content
+	if !strings.HasPrefix(placeholder, "look at this\n") || !strings.Contains(placeholder, "omitted") {
+		t.Fatalf("Content should keep the user's text and append the placeholder, got %q", placeholder)
 	}
 	if !strings.Contains(placeholder, "640×480") {
 		t.Errorf("placeholder should name the pixel size, got %q", placeholder)
@@ -292,15 +291,9 @@ func TestDecayStripsColdImageParts(t *testing.T) {
 	if !strings.Contains(placeholder, "whip-img-") {
 		t.Errorf("placeholder should point at the spilled file, got %q", placeholder)
 	}
-	// text part survives
-	foundText := false
-	for _, p := range m.Parts {
-		if p.Type == "text" && p.Text == "look at this" {
-			foundText = true
-		}
-	}
-	if !foundText {
-		t.Error("the accompanying text part must stay inline")
+	// collapsed to plain text: no parts left, the user's text leads Content
+	if len(m.Parts) != 0 {
+		t.Errorf("stripped message should carry no parts, got %+v", m.Parts)
 	}
 	// the estimate dropped by roughly the image's token cost
 	after := EstimateTokens(a.Messages)
@@ -337,16 +330,44 @@ func TestDecayImageOnlyMessagesSpendHotWindow(t *testing.T) {
 	if n := a.decay(); n == 0 {
 		t.Fatal("the oldest image-only message should fall past the hot window and be stripped")
 	}
-	if len(a.Messages[1].Parts) != 1 || a.Messages[1].Parts[0].Type != "text" {
-		t.Fatalf("oldest message should now hold a text placeholder, got %+v", a.Messages[1].Parts)
+	if len(a.Messages[1].Parts) != 0 || !strings.Contains(a.Messages[1].Content, "omitted") {
+		t.Fatalf("oldest message should now be a text placeholder in Content, got parts=%+v content=%q", a.Messages[1].Parts, a.Messages[1].Content)
 	}
 	last := a.Messages[len(a.Messages)-1]
 	if last.Parts[0].Type != "image_url" {
 		t.Fatal("the newest image must stay hot")
 	}
-	// Content stays empty: the wire form prepends Content as a text part, so
-	// mirroring the placeholder there would send it twice.
-	if a.Messages[1].Content != "" {
-		t.Fatalf("placeholder must live in Parts only, Content=%q", a.Messages[1].Content)
+}
+
+// The decayed message must survive a persist/reload round trip with the
+// user's text intact: UnmarshalJSON keeps only the last text part as Content.
+func TestDecayedImageMessageRoundTripsKeepingText(t *testing.T) {
+	img := llm.ImagePart("png", pngFixtureForDecay(t, 640, 480))
+	m := llm.Message{Role: "user", Content: "look at this", Parts: []llm.ContentPart{{Type: "text", Text: "look at this"}, img}}
+	if stripImageParts(&m) != 1 {
+		t.Fatal("one image should strip")
+	}
+	raw, err := m.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back llm.Message
+	if err := back.UnmarshalJSON(raw); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(back.TextContent(), "look at this") || !strings.Contains(back.TextContent(), "omitted") {
+		t.Fatalf("reload should keep the user's text and the placeholder, got %q", back.TextContent())
+	}
+	if strings.Count(string(raw), "omitted") != 1 {
+		t.Fatalf("placeholder must be sent once on the wire, got %d in %s", strings.Count(string(raw), "omitted"), raw)
+	}
+}
+
+// spillImage must never panic on a persisted URL that isn't one we built.
+func TestSpillImageRejectsNonDataURL(t *testing.T) {
+	for _, u := range []string{"x;base64,y", ";base64,abcd", "http://example/img.png", ""} {
+		if got := spillImage(u); got != "" {
+			t.Errorf("spillImage(%q) = %q, want \"\"", u, got)
+		}
 	}
 }

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -507,7 +507,12 @@ func TestSubscribeUnknownTask(t *testing.T) {
 
 // Usage from a background subagent's API calls folds into the parent's
 // session totals (the FanIn second leg alongside the event emitter).
-func TestBackgroundTaskUsageRollsIntoParent(t *testing.T) {
+// A background subagent's spend is persisted on its own attributed
+// task-session transcript, so it must NOT also roll into the parent's
+// cumulative totals — folding it in counted the same tokens twice (one real
+// session's row read ~2× the provider bill). The parent's Usage() reports
+// only the session's own requests.
+func TestBackgroundTaskUsageNotDoubleCounted(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}`+"\n\n")
@@ -523,8 +528,8 @@ func TestBackgroundTaskUsageRollsIntoParent(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("task never settled")
 	}
-	if u := ag.Usage(); u.PromptTokens != 50 || u.CompletionTokens != 5 {
-		t.Fatalf("subagent usage should roll into the parent: %+v", u)
+	if u := ag.Usage(); u.PromptTokens != 0 || u.CompletionTokens != 0 {
+		t.Fatalf("background subagent usage must not roll into the parent (double count): %+v", u)
 	}
 }
 

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -507,11 +507,10 @@ func TestSubscribeUnknownTask(t *testing.T) {
 
 // Usage from a background subagent's API calls folds into the parent's
 // session totals (the FanIn second leg alongside the event emitter).
-// A background subagent's spend is persisted on its own attributed
-// task-session transcript, so it must NOT also roll into the parent's
-// cumulative totals — folding it in counted the same tokens twice (one real
-// session's row read ~2× the provider bill). The parent's Usage() reports
-// only the session's own requests.
+// A background subagent's spend lands in the parent's per-model SUB ledger,
+// never in its own Usage(): the two are disjoint so TotalUsage counts each
+// token once (fanning subs into Usage once made a session's row read ~2× the
+// provider bill).
 func TestBackgroundTaskUsageNotDoubleCounted(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -529,7 +528,46 @@ func TestBackgroundTaskUsageNotDoubleCounted(t *testing.T) {
 		t.Fatal("task never settled")
 	}
 	if u := ag.Usage(); u.PromptTokens != 0 || u.CompletionTokens != 0 {
-		t.Fatalf("background subagent usage must not roll into the parent (double count): %+v", u)
+		t.Fatalf("background subagent usage must not roll into the parent's own Usage: %+v", u)
+	}
+	if u := ag.SubUsage()["m @ "]; u.PromptTokens != 50 || u.CompletionTokens != 5 {
+		t.Fatalf("background subagent usage should be ledgered under its model: %+v", ag.SubUsage())
+	}
+	if u := ag.TotalUsage(); u.PromptTokens != 50 || u.CompletionTokens != 5 {
+		t.Fatalf("TotalUsage should be own + subs: %+v", u)
+	}
+}
+
+// Sub spend forwards up through every level: a sub's own request and a
+// sub-of-a-sub's request both land in the root's ledger, keyed by the model
+// that made them, and only there.
+func TestSubUsageForwardsThroughNestedSubs(t *testing.T) {
+	root := New(llm.New("http://x", "k"), "root", 100, "sys")
+	sub := root.newSub(SubModel{})
+	sub.Model = "sub-m"
+	subsub := sub.newSub(SubModel{})
+	subsub.Model = "leaf-m"
+
+	sub.AddUsage(llm.Usage{PromptTokens: 10, CompletionTokens: 1})
+	subsub.AddUsage(llm.Usage{PromptTokens: 20, CompletionTokens: 2})
+
+	if u := root.Usage(); u.PromptTokens != 0 {
+		t.Fatalf("root's own usage must stay 0, got %+v", u)
+	}
+	got := root.SubUsage()
+	if got["sub-m @ "].PromptTokens != 10 || got["leaf-m @ "].PromptTokens != 20 {
+		t.Fatalf("root ledger should hold both levels by model: %+v", got)
+	}
+	if u := root.TotalUsage(); u.PromptTokens != 30 || u.CompletionTokens != 3 {
+		t.Fatalf("root total should be 30/3, got %+v", u)
+	}
+	// The middle sub sees only its child, in its own ledger.
+	if u := sub.SubUsage()["leaf-m @ "]; u.PromptTokens != 20 {
+		t.Fatalf("sub ledger should hold the leaf's spend: %+v", sub.SubUsage())
+	}
+	root.ResetUsage()
+	if root.SubUsage() != nil {
+		t.Fatal("ResetUsage should clear the sub ledger too")
 	}
 }
 

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -227,7 +227,10 @@ func (a *Agent) FollowupTask(ctx context.Context, id, text string, ev Events) (s
 	if t.sub == nil {
 		return "", fmt.Errorf("subagent %s is not live (restored from a previous session)", id)
 	}
-	out, err := t.sub.Turn(ctx, text, FanIn(ev, Events{OnUsage: a.AddUsage}))
+	// No OnUsage fan-in: the follow-up's spend is persisted on the task's own
+	// session transcript (refreshTranscript below), so adding it to the
+	// parent's totals would count it twice.
+	out, err := t.sub.Turn(ctx, text, ev)
 	// The follow-up grew the sub's conversation; refresh the persisted
 	// transcript so a resume sees it (no-op without a store).
 	r.refreshTranscript(id, t.sub)

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -57,6 +57,9 @@ func (a *Agent) newSub(o SubModel) *Agent {
 	}
 	sub.ContextLimit = o.ContextLimit
 	sub.Tools = tools.All()
+	// Every request the sub (or its own subs) makes lands in the parent's
+	// per-model sub ledger — the one place sub spend is counted.
+	sub.usageSink = a.AddSubUsage
 	return sub
 }
 
@@ -142,9 +145,8 @@ func taskTool(parent *Agent) tools.Tool {
 				}
 				return fmt.Sprintf("Started background subagent %s: %s. Keep working on something else; the report will arrive as a message when it finishes. Do not poll for it.", t.ID, desc), nil
 			}
-			sub := parent.newSub(o)
-			// roll the subagent's spend into the parent's session totals
-			report, err := sub.Turn(ctx, prompt, Events{OnUsage: parent.AddUsage})
+			sub := parent.newSub(o) // its spend reaches parent.SubUsage via usageSink
+			report, err := sub.Turn(ctx, prompt, Events{})
 			if err != nil {
 				return report, err
 			}
@@ -227,10 +229,7 @@ func (a *Agent) FollowupTask(ctx context.Context, id, text string, ev Events) (s
 	if t.sub == nil {
 		return "", fmt.Errorf("subagent %s is not live (restored from a previous session)", id)
 	}
-	// No OnUsage fan-in: the follow-up's spend is persisted on the task's own
-	// session transcript (refreshTranscript below), so adding it to the
-	// parent's totals would count it twice.
-	out, err := t.sub.Turn(ctx, text, ev)
+	out, err := t.sub.Turn(ctx, text, ev) // spend reaches the parent via usageSink
 	// The follow-up grew the sub's conversation; refresh the persisted
 	// transcript so a resume sees it (no-op without a store).
 	r.refreshTranscript(id, t.sub)

--- a/internal/llm/images.go
+++ b/internal/llm/images.go
@@ -1,0 +1,67 @@
+package llm
+
+import (
+	"bytes"
+	"image"
+	// Register the decoders image.DecodeConfig dispatches on. whip builds and
+	// sends these formats everywhere (paste.go, mentions, browser
+	// screenshots), so the blank imports carry no new dependency.
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	_ "golang.org/x/image/bmp"
+	_ "golang.org/x/image/webp"
+)
+
+// ImageTokenFloor is the minimum token count an image part is ever estimated
+// at: tiny thumbnails cost the provider's fixed wrapper even at 1×1 px.
+const ImageTokenFloor = 85
+
+// imagePatch is the vision encoder's patch edge in pixels for the
+// moonshot/qwen-style models whip routes to. Token cost of an image is
+// ceil(w/patch)·ceil(h/patch) plus a small fixed wrapper.
+const imagePatch = 28
+
+// DecodeImageSize returns the pixel dimensions of an encoded image (png, jpg,
+// gif, webp, bmp). It reads only the header — no pixel data is decoded.
+func DecodeImageSize(data []byte) (w, h int, ok bool) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return 0, 0, false
+	}
+	return cfg.Width, cfg.Height, true
+}
+
+// ImageTokens estimates the token cost of one image from its pixel
+// dimensions. Unknown dimensions (0×0) fall back to the historical flat
+// estimate so callers never undercount an image they failed to measure.
+func ImageTokens(w, h int) int {
+	if w <= 0 || h <= 0 {
+		return 1200
+	}
+	patchCeil := func(n int) int { return (n + imagePatch - 1) / imagePatch }
+	t := patchCeil(w) * patchCeil(h)
+	if t < ImageTokenFloor {
+		return ImageTokenFloor
+	}
+	return t
+}
+
+// PartTokens estimates the token cost of one content part: image parts use
+// the pixel estimate when dimensions were recorded at ingest (ContentPart
+// carries them as zero-cost struct fields); text parts use chars/4.
+func PartTokens(p ContentPart) int {
+	if p.Type == "image_url" {
+		if w, h := p.Dimensions(); w > 0 {
+			return ImageTokens(w, h)
+		}
+		// Dimensions missing (old session rows, hand-built parts): decode the
+		// data URL now rather than falling back blind.
+		if w, h, ok := p.DecodeDimensions(); ok {
+			return ImageTokens(w, h)
+		}
+		return ImageTokens(0, 0)
+	}
+	return (len(p.Text) + 3) / 4
+}

--- a/internal/llm/images.go
+++ b/internal/llm/images.go
@@ -54,8 +54,8 @@ func ImageTokens(w, h int) int {
 // carries them as zero-cost struct fields); text parts use chars/4.
 func PartTokens(p ContentPart) int {
 	if p.Type == "image_url" {
-		if w, h := p.Dimensions(); w > 0 {
-			return ImageTokens(w, h)
+		if p.W > 0 {
+			return ImageTokens(p.W, p.H)
 		}
 		// Dimensions missing (old session rows, hand-built parts): decode the
 		// data URL now rather than falling back blind.

--- a/internal/llm/images.go
+++ b/internal/llm/images.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"image"
+
 	// Register the decoders image.DecodeConfig dispatches on. whip builds and
 	// sends these formats everywhere (paste.go, mentions, browser
 	// screenshots), so the blank imports carry no new dependency.

--- a/internal/llm/images_test.go
+++ b/internal/llm/images_test.go
@@ -1,0 +1,108 @@
+package llm
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"strings"
+	"testing"
+)
+
+// pngFixture builds an in-memory PNG of the given size (a solid color — the
+// estimator and normalizer only read headers/dims, so content doesn't matter).
+func pngFixture(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode fixture: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// The pixel estimator: a full-HiDPI screenshot must cost its real patch
+// count, not the old flat 1200. ⌈w/28⌉·⌈h/28⌉.
+func TestImageTokensPixelFormula(t *testing.T) {
+	// 3410×2646 (the real screenshot from the cost incident): ⌈3410/28⌉=122,
+	// ⌈2646/28⌉=95 → 122·95 = 11590.
+	if got := ImageTokens(3410, 2646); got != 122*95 {
+		t.Fatalf("3410×2646: got %d, want %d", got, 122*95)
+	}
+	if got := ImageTokens(2556, 2734); got != 92*98 {
+		t.Fatalf("2556×2734: got %d, want %d", got, 92*98)
+	}
+	// Unknown dims fall back to the historical flat estimate.
+	if got := ImageTokens(0, 0); got != 1200 {
+		t.Fatalf("unknown dims: got %d, want 1200 fallback", got)
+	}
+	// Tiny images floor at the wrapper cost.
+	if got := ImageTokens(8, 8); got != ImageTokenFloor {
+		t.Fatalf("8×8: got %d, want floor %d", got, ImageTokenFloor)
+	}
+}
+
+// DecodeImageSize reads dims from headers without decoding pixels.
+func TestDecodeImageSize(t *testing.T) {
+	png := pngFixture(t, 640, 480)
+	w, h, ok := DecodeImageSize(png)
+	if !ok || w != 640 || h != 480 {
+		t.Fatalf("png: got %d×%d ok=%v", w, h, ok)
+	}
+	if _, _, ok := DecodeImageSize([]byte("not an image")); ok {
+		t.Fatal("garbage must not decode")
+	}
+}
+
+// ImagePart records dims at ingest; PartTokens uses them.
+func TestImagePartRecordsDimensions(t *testing.T) {
+	png := pngFixture(t, 560, 420) // ⌈560/28⌉=20, ⌈420/28⌉=15 → 300
+	p := ImagePart("png", png)
+	w, h := p.Dimensions()
+	if w != 560 || h != 420 {
+		t.Fatalf("dims: got %d×%d", w, h)
+	}
+	if got := PartTokens(p); got != 300 {
+		t.Fatalf("PartTokens: got %d, want 300", got)
+	}
+	// A text part estimates by chars/4.
+	tp := ContentPart{Type: "text", Text: strings.Repeat("a", 100)}
+	if got := PartTokens(tp); got != 25 {
+		t.Fatalf("text PartTokens: got %d, want 25", got)
+	}
+}
+
+// W/H ride the persisted JSON but are stripped before a provider request.
+func TestContentPartDimsPersistedAndStripped(t *testing.T) {
+	p := ImagePart("png", pngFixture(t, 280, 140))
+	m := Message{Role: "user", Content: "look", Parts: []ContentPart{p}}
+
+	// Persisted form keeps the dims.
+	raw, err := m.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte(`"w":280`)) || !bytes.Contains(raw, []byte(`"h":140`)) {
+		t.Fatalf("persisted form should carry dims: %s", raw)
+	}
+
+	// stripAuthored clears them for the wire.
+	out := stripAuthored([]Message{m})
+	for _, part := range out[0].Parts {
+		if part.W != 0 || part.H != 0 {
+			t.Fatalf("wire form must strip dims, got %d×%d", part.W, part.H)
+		}
+	}
+	// In-memory original is untouched.
+	if m.Parts[0].W != 280 {
+		t.Fatal("stripAuthored must copy, not mutate the caller's slice")
+	}
+}
+
+// A zero-dim part (old session row) decodes dims lazily from the data URL.
+func TestPartTokensLazyDecode(t *testing.T) {
+	p := ImagePart("png", pngFixture(t, 280, 140))
+	p.W, p.H = 0, 0 // simulate a pre-dims session row
+	if got := PartTokens(p); got != ImageTokens(280, 140) {
+		t.Fatalf("lazy decode: got %d, want %d", got, ImageTokens(280, 140))
+	}
+}

--- a/internal/llm/images_test.go
+++ b/internal/llm/images_test.go
@@ -57,9 +57,8 @@ func TestDecodeImageSize(t *testing.T) {
 func TestImagePartRecordsDimensions(t *testing.T) {
 	png := pngFixture(t, 560, 420) // ⌈560/28⌉=20, ⌈420/28⌉=15 → 300
 	p := ImagePart("png", png)
-	w, h := p.Dimensions()
-	if w != 560 || h != 420 {
-		t.Fatalf("dims: got %d×%d", w, h)
+	if p.W != 560 || p.H != 420 {
+		t.Fatalf("dims: got %d×%d", p.W, p.H)
 	}
 	if got := PartTokens(p); got != 300 {
 		t.Fatalf("PartTokens: got %d, want 300", got)

--- a/internal/llm/normalize.go
+++ b/internal/llm/normalize.go
@@ -28,6 +28,10 @@ const (
 	// stays under ~6.9MB of wire payload (opencode's 5MiB base64 budget
 	// translated to pre-encode bytes).
 	NormalizeMaxBytes = 5 * 1024 * 1024
+	// NormalizeMaxPixels bounds what NormalizeImage will pixel-decode at all:
+	// 64 megapixels (~256MiB RGBA) covers any real display capture; a header
+	// declaring more is a decompression bomb, not an image to re-encode.
+	NormalizeMaxPixels = 64_000_000
 	// normalizeMinScale bounds the quality-fallback loop: below this the
 	// image would be illegible anyway, so we stop and return what we have.
 	normalizeMinScale = 0.05
@@ -60,6 +64,12 @@ func NormalizeImage(ext string, data []byte) (string, []byte) {
 	}
 	if len(data) <= NormalizeMaxBytes && w <= NormalizeMaxDim && h <= NormalizeMaxDim {
 		return ext, data // already cheap enough; keep the original encoding
+	}
+	if w*h > NormalizeMaxPixels {
+		// A header can declare a canvas no real capture has (a 40-byte PNG
+		// claiming 100000²) and image.Decode would allocate for all of it.
+		// Pass it through untouched: the provider rejects it, whip stays up.
+		return ext, data
 	}
 	src, err := decodeAny(data)
 	if err != nil {
@@ -100,15 +110,19 @@ func decodeAny(data []byte) (image.Image, error) {
 	return img, err
 }
 
-// scaleToFit returns src scaled down to fit inside maxW×maxH, preserving
-// aspect. A src already inside the box is returned unchanged (no resample).
+// scaleToFit returns src drawn onto an opaque white canvas, scaled down to
+// fit inside maxW×maxH (aspect preserved) when it does not already.
 func scaleToFit(src image.Image, maxW, maxH int) image.Image {
 	w, h := src.Bounds().Dx(), src.Bounds().Dy()
-	if w <= maxW && h <= maxH {
-		return src
+	nw, nh := w, h
+	if w > maxW || h > maxH {
+		scale := min(float64(maxW)/float64(w), float64(maxH)/float64(h))
+		nw, nh = max(int(float64(w)*scale), 1), max(int(float64(h)*scale), 1)
 	}
-	scale := min(float64(maxW)/float64(w), float64(maxH)/float64(h))
-	nw, nh := max(int(float64(w)*scale), 1), max(int(float64(h)*scale), 1)
+	// Always redraw, even at the same size: the result is JPEG-encoded, and
+	// JPEG has no alpha, so the source must be composited onto opaque white
+	// (transparent pixels otherwise encode black). An in-cap image reaches
+	// here when it is over the byte budget.
 	dst := image.NewRGBA(image.Rect(0, 0, nw, nh))
 	// JPEG has no alpha: composite onto opaque white first, or transparent
 	// pixels (logos, UI exports) come out black after the re-encode.

--- a/internal/llm/normalize.go
+++ b/internal/llm/normalize.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"image"
+	"image/color"
 	"image/jpeg"
 
 	"golang.org/x/image/draw"
@@ -109,6 +110,9 @@ func scaleToFit(src image.Image, maxW, maxH int) image.Image {
 	scale := min(float64(maxW)/float64(w), float64(maxH)/float64(h))
 	nw, nh := max(int(float64(w)*scale), 1), max(int(float64(h)*scale), 1)
 	dst := image.NewRGBA(image.Rect(0, 0, nw, nh))
+	// JPEG has no alpha: composite onto opaque white first, or transparent
+	// pixels (logos, UI exports) come out black after the re-encode.
+	draw.Draw(dst, dst.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
 	draw.ApproxBiLinear.Scale(dst, dst.Bounds(), src, src.Bounds(), draw.Over, nil)
 	return dst
 }

--- a/internal/llm/normalize.go
+++ b/internal/llm/normalize.go
@@ -1,0 +1,122 @@
+package llm
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"image/png"
+
+	"golang.org/x/image/draw"
+)
+
+// Image normalization bounds what a pasted/attached/screenshot image can cost
+// before it ever enters the conversation. A 3410×2646 clipboard PNG costs
+// ~11.4k tokens on a 28px-patch vision model and is re-billed on every
+// request until compaction drops it; capping at 2000×2000 and re-encoding as
+// JPEG cuts that ~4× with no legibility loss a model can perceive.
+//
+// Ported from opencode's image/image.ts policy: fit inside a max-dims box,
+// then re-encode at descending JPEG qualities until the base64 payload fits a
+// byte budget.
+
+const (
+	// NormalizeMaxDim caps width and height at ingest. 2000px keeps full
+	// legibility for UI screenshots (text down to ~9pt stays readable) while
+	// bounding the token cost to ~5.1k per image.
+	NormalizeMaxDim = 2000
+	// NormalizeMaxBytes caps the ENCODED image bytes so the base64 data URL
+	// stays under ~6.9MB of wire payload (opencode's 5MiB base64 budget
+	// translated to pre-encode bytes).
+	NormalizeMaxBytes = 5 * 1024 * 1024
+	// normalizeMinScale bounds the quality-fallback loop: below this the
+	// image would be illegible anyway, so we stop and return what we have.
+	normalizeMinScale = 0.05
+)
+
+// jpegQualities are tried in order until the encoded output fits
+// NormalizeMaxBytes. 80 is visually lossless for screenshots; 40 is the last
+// resort for pathological noise-heavy captures.
+var jpegQualities = []int{80, 85, 70, 55, 40}
+
+// NormalizeImage re-encodes an attached image within the size budget:
+//
+//  1. If the raw bytes already fit NormalizeMaxBytes AND both dims fit
+//     NormalizeMaxDim, the input passes through untouched (ext preserved).
+//  2. Otherwise the image is decoded, Lanczos-scaled to fit NormalizeMaxDim,
+//     and re-encoded as JPEG at descending qualities; if it still exceeds the
+//     byte budget the image shrinks by ×0.75 per round and the quality ladder
+//     retries (up to 32 rounds, mirroring opencode).
+//
+// Returns the (possibly unchanged) bytes and the extension of the returned
+// encoding. On any decode failure the input is returned as-is — a corrupt
+// image is the provider's problem to reject, not a reason to block the paste.
+func NormalizeImage(ext string, data []byte) (string, []byte) {
+	src, err := decodeAny(data)
+	if err != nil {
+		return ext, data
+	}
+	w, h := src.Bounds().Dx(), src.Bounds().Dy()
+	if len(data) <= NormalizeMaxBytes && w <= NormalizeMaxDim && h <= NormalizeMaxDim {
+		return ext, data // already cheap enough; keep the original encoding
+	}
+
+	img := scaleToFit(src, NormalizeMaxDim, NormalizeMaxDim)
+	for range 32 {
+		for _, q := range jpegQualities {
+			var buf bytes.Buffer
+			if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: q}); err != nil {
+				return ext, data
+			}
+			if buf.Len() <= NormalizeMaxBytes {
+				return "jpg", buf.Bytes()
+			}
+		}
+		// Still too big: shrink ×0.75 and retry the quality ladder.
+		nw, nh := img.Bounds().Dx()*3/4, img.Bounds().Dy()*3/4
+		if nw < int(float64(NormalizeMaxDim)*normalizeMinScale) || nh < 8 || nw < 8 {
+			break
+		}
+		img = scaleToFit(img, nw, nh)
+	}
+	// Give up gracefully: return the last (smallest) attempt rather than the
+	// giant original — an over-budget JPEG is still cheaper than the PNG.
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: jpegQualities[len(jpegQualities)-1]}); err != nil {
+		return ext, data
+	}
+	return "jpg", buf.Bytes()
+}
+
+// decodeAny decodes any image format registered via the blank imports in
+// images.go (png, jpeg, gif, webp, bmp).
+func decodeAny(data []byte) (image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	return img, err
+}
+
+// scaleToFit returns src scaled down to fit inside maxW×maxH, preserving
+// aspect. A src already inside the box is returned unchanged (no resample).
+func scaleToFit(src image.Image, maxW, maxH int) image.Image {
+	w, h := src.Bounds().Dx(), src.Bounds().Dy()
+	if w <= maxW && h <= maxH {
+		return src
+	}
+	scale := min(float64(maxW)/float64(w), float64(maxH)/float64(h))
+	nw, nh := max(int(float64(w)*scale), 1), max(int(float64(h)*scale), 1)
+	dst := image.NewRGBA(image.Rect(0, 0, nw, nh))
+	draw.ApproxBiLinear.Scale(dst, dst.Bounds(), src, src.Bounds(), draw.Over, nil)
+	return dst
+}
+
+// NormalizeImagePNG is NormalizeImage for callers holding PNG bytes whose
+// extension they don't know (browser screenshot sinks).
+func NormalizeImagePNG(data []byte) (string, []byte) {
+	return NormalizeImage("png", data)
+}
+
+// encodePNG is exported for tests that build fixtures.
+func encodePNG(img image.Image) ([]byte, error) {
+	var buf bytes.Buffer
+	err := png.Encode(&buf, img)
+	return buf.Bytes(), err
+}

--- a/internal/llm/normalize.go
+++ b/internal/llm/normalize.go
@@ -50,13 +50,19 @@ var jpegQualities = []int{80, 70, 55, 40}
 // encoding. On any decode failure the input is returned as-is — a corrupt
 // image is the provider's problem to reject, not a reason to block the paste.
 func NormalizeImage(ext string, data []byte) (string, []byte) {
+	// Header-only check first: the passthrough decision never needs pixels,
+	// and a small-file/huge-canvas PNG must not force a full decode on the
+	// paste path just to learn it is already within budget.
+	w, h, ok := DecodeImageSize(data)
+	if !ok {
+		return ext, data
+	}
+	if len(data) <= NormalizeMaxBytes && w <= NormalizeMaxDim && h <= NormalizeMaxDim {
+		return ext, data // already cheap enough; keep the original encoding
+	}
 	src, err := decodeAny(data)
 	if err != nil {
 		return ext, data
-	}
-	w, h := src.Bounds().Dx(), src.Bounds().Dy()
-	if len(data) <= NormalizeMaxBytes && w <= NormalizeMaxDim && h <= NormalizeMaxDim {
-		return ext, data // already cheap enough; keep the original encoding
 	}
 
 	img := scaleToFit(src, NormalizeMaxDim, NormalizeMaxDim)

--- a/internal/llm/normalize.go
+++ b/internal/llm/normalize.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"image"
 	"image/jpeg"
-	"image/png"
 
 	"golang.org/x/image/draw"
 )
@@ -112,11 +111,4 @@ func scaleToFit(src image.Image, maxW, maxH int) image.Image {
 // extension they don't know (browser screenshot sinks).
 func NormalizeImagePNG(data []byte) (string, []byte) {
 	return NormalizeImage("png", data)
-}
-
-// encodePNG is exported for tests that build fixtures.
-func encodePNG(img image.Image) ([]byte, error) {
-	var buf bytes.Buffer
-	err := png.Encode(&buf, img)
-	return buf.Bytes(), err
 }

--- a/internal/llm/normalize.go
+++ b/internal/llm/normalize.go
@@ -35,7 +35,7 @@ const (
 // jpegQualities are tried in order until the encoded output fits
 // NormalizeMaxBytes. 80 is visually lossless for screenshots; 40 is the last
 // resort for pathological noise-heavy captures.
-var jpegQualities = []int{80, 85, 70, 55, 40}
+var jpegQualities = []int{80, 70, 55, 40}
 
 // NormalizeImage re-encodes an attached image within the size budget:
 //
@@ -105,10 +105,4 @@ func scaleToFit(src image.Image, maxW, maxH int) image.Image {
 	dst := image.NewRGBA(image.Rect(0, 0, nw, nh))
 	draw.ApproxBiLinear.Scale(dst, dst.Bounds(), src, src.Bounds(), draw.Over, nil)
 	return dst
-}
-
-// NormalizeImagePNG is NormalizeImage for callers holding PNG bytes whose
-// extension they don't know (browser screenshot sinks).
-func NormalizeImagePNG(data []byte) (string, []byte) {
-	return NormalizeImage("png", data)
 }

--- a/internal/llm/normalize_test.go
+++ b/internal/llm/normalize_test.go
@@ -2,10 +2,13 @@ package llm
 
 import (
 	"bytes"
+	"encoding/binary"
+	"hash/crc32"
 	"image"
 	"image/png"
 	"math/rand"
 	"testing"
+	"time"
 )
 
 // bigNoisyPNG builds a photo-like PNG (per-pixel noise) so the encoded size
@@ -113,5 +116,58 @@ func TestNormalizeImageTransparentFlattensToWhite(t *testing.T) {
 	r, g, b, _ := dec.At(10, 10).RGBA()
 	if r>>8 < 240 || g>>8 < 240 || b>>8 < 240 {
 		t.Fatalf("transparent pixels should flatten to white, got rgb(%d,%d,%d)", r>>8, g>>8, b>>8)
+	}
+}
+
+// Alpha flattens to white on the byte-budget path too: an in-cap canvas that
+// is over 5MiB re-encodes without scaling and must still composite onto white.
+func TestNormalizeImageTransparentInCapOverBytesFlattensToWhite(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 1500, 1500))
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < len(img.Pix); i += 4 {
+		img.Pix[i], img.Pix[i+1], img.Pix[i+2], img.Pix[i+3] = byte(rng.Intn(256)), byte(rng.Intn(256)), byte(rng.Intn(256)), 0
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() <= NormalizeMaxBytes {
+		t.Skipf("fixture compressed to %d bytes, under the budget", buf.Len())
+	}
+	ext, out := NormalizeImage("png", buf.Bytes())
+	if ext != "jpg" {
+		t.Fatalf("over-budget image should re-encode, got %q", ext)
+	}
+	dec, _, err := image.Decode(bytes.NewReader(out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, g, b, _ := dec.At(700, 700).RGBA()
+	if r>>8 < 240 || g>>8 < 240 || b>>8 < 240 {
+		t.Fatalf("fully transparent pixels should flatten to white, got rgb(%d,%d,%d)", r>>8, g>>8, b>>8)
+	}
+}
+
+// A tiny file whose header declares an absurd canvas is passed through, never
+// pixel-decoded (image.Decode would allocate for the declared size).
+func TestNormalizeImageDeclaredBombPassesThrough(t *testing.T) {
+	data := pngFixture(t, 8, 8)
+	// IHDR: bytes 16..19 width, 20..23 height, CRC over "IHDR"+13 data bytes at 29..32
+	binary.BigEndian.PutUint32(data[16:], 100000)
+	binary.BigEndian.PutUint32(data[20:], 100000)
+	binary.BigEndian.PutUint32(data[29:], crc32.ChecksumIEEE(data[12:29]))
+	if w, h, ok := DecodeImageSize(data); !ok || w != 100000 || h != 100000 {
+		t.Fatalf("fixture: header should decode as 100000², got %d×%d ok=%v", w, h, ok)
+	}
+	done := make(chan struct{})
+	go func() { NormalizeImage("png", data); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("NormalizeImage tried to decode the declared canvas")
+	}
+	ext, out := NormalizeImage("png", data)
+	if ext != "png" || !bytes.Equal(out, data) {
+		t.Fatal("bomb-shaped header must pass through untouched")
 	}
 }

--- a/internal/llm/normalize_test.go
+++ b/internal/llm/normalize_test.go
@@ -76,3 +76,20 @@ func TestNormalizeImageNoiseFitsBudget(t *testing.T) {
 		t.Fatalf("even max-dim noise must fit the budget, got %d bytes (%s)", len(out), ext)
 	}
 }
+
+// The passthrough decision reads only the header: a tiny file whose header
+// claims a huge canvas (a decompression-bomb shape) must not be pixel-decoded
+// when it is over the dim cap either — it goes to the re-encode path only if
+// it actually decodes. Here a header-only truncated PNG within the caps passes
+// through without ever needing pixels.
+func TestNormalizeImageHeaderOnlyPassthrough(t *testing.T) {
+	full := pngFixture(t, 800, 600)
+	head := full[:64] // IHDR is complete; pixel data is gone
+	if w, h, ok := DecodeImageSize(head); !ok || w != 800 || h != 600 {
+		t.Fatalf("fixture: header should still decode, got %d×%d ok=%v", w, h, ok)
+	}
+	ext, out := NormalizeImage("png", head)
+	if ext != "png" || !bytes.Equal(out, head) {
+		t.Fatal("an in-budget image must pass through on its header alone (no pixel decode)")
+	}
+}

--- a/internal/llm/normalize_test.go
+++ b/internal/llm/normalize_test.go
@@ -1,0 +1,78 @@
+package llm
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"math/rand"
+	"testing"
+)
+
+// bigNoisyPNG builds a photo-like PNG (per-pixel noise) so the encoded size
+// is large even at moderate dims — solid-color fixtures compress to nothing
+// and never exercise the quality ladder.
+func bigNoisyPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	rng := rand.New(rand.NewSource(1))
+	for i := range img.Pix {
+		img.Pix[i] = byte(rng.Intn(256))
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestNormalizeImageOversizedShrinksToBudget(t *testing.T) {
+	// 2600×2000 noisy PNG — over the 2000px cap, so it must be scaled+re-encoded.
+	data := bigNoisyPNG(t, 2600, 2000)
+	ext, out := NormalizeImage("png", data)
+	if ext != "jpg" {
+		t.Fatalf("oversized image should re-encode as jpg, got %q", ext)
+	}
+	w, h, ok := DecodeImageSize(out)
+	if !ok {
+		t.Fatal("output must decode")
+	}
+	if w > NormalizeMaxDim || h > NormalizeMaxDim {
+		t.Fatalf("dims must fit the cap, got %d×%d", w, h)
+	}
+	if len(out) > NormalizeMaxBytes {
+		t.Fatalf("output must fit the byte budget, got %d", len(out))
+	}
+	// aspect preserved: 2600×2000 → 2000×1538
+	if w != 2000 || h < 1500 || h > 1545 {
+		t.Fatalf("aspect should be preserved, got %d×%d", w, h)
+	}
+}
+
+func TestNormalizeImageSmallPassthrough(t *testing.T) {
+	// A small image already within both budgets passes through untouched —
+	// no decode, no re-encode, original bytes and ext.
+	data := pngFixture(t, 800, 600)
+	ext, out := NormalizeImage("png", data)
+	if ext != "png" {
+		t.Fatalf("small image should keep its encoding, got %q", ext)
+	}
+	if !bytes.Equal(out, data) {
+		t.Fatal("small image should pass through byte-identical")
+	}
+}
+
+func TestNormalizeImageCorruptPassthrough(t *testing.T) {
+	ext, out := NormalizeImage("png", []byte("definitely not an image"))
+	if ext != "png" || !bytes.Equal(out, []byte("definitely not an image")) {
+		t.Fatal("undecodable input must pass through unchanged")
+	}
+}
+
+func TestNormalizeImageNoiseFitsBudget(t *testing.T) {
+	// Worst case: max-dim pure noise. The quality ladder must still land ≤5MiB.
+	data := bigNoisyPNG(t, 2000, 2000)
+	ext, out := NormalizeImage("png", data)
+	if len(out) > NormalizeMaxBytes {
+		t.Fatalf("even max-dim noise must fit the budget, got %d bytes (%s)", len(out), ext)
+	}
+}

--- a/internal/llm/normalize_test.go
+++ b/internal/llm/normalize_test.go
@@ -93,3 +93,25 @@ func TestNormalizeImageHeaderOnlyPassthrough(t *testing.T) {
 		t.Fatal("an in-budget image must pass through on its header alone (no pixel decode)")
 	}
 }
+
+// A transparent source re-encoded to JPEG (no alpha) must land on white, not
+// on the zero-initialized (black) canvas.
+func TestNormalizeImageTransparentFlattensToWhite(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 2400, 100)) // over the dim cap; fully transparent
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	ext, out := NormalizeImage("png", buf.Bytes())
+	if ext != "jpg" {
+		t.Fatalf("oversized image should re-encode, got %q", ext)
+	}
+	dec, _, err := image.Decode(bytes.NewReader(out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, g, b, _ := dec.At(10, 10).RGBA()
+	if r>>8 < 240 || g>>8 < 240 || b>>8 < 240 {
+		t.Fatalf("transparent pixels should flatten to white, got rgb(%d,%d,%d)", r>>8, g>>8, b>>8)
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -61,12 +61,20 @@ type Message struct {
 // as an array of these parts rather than a plain string when images are
 // attached. The wire shape is {"type":"text","text":...} and
 // {"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}.
+//
+// W and H record the pixel dimensions of an image part, measured once at
+// ingest. They ride along in the persisted session (so token estimates stay
+// honest across resumes) and are stripped before any provider request — the
+// wire shape is unchanged. Zero means "unmeasured": estimators decode the
+// data URL lazily in that case.
 type ContentPart struct {
 	Type     string `json:"type"`
 	Text     string `json:"text,omitempty"`
 	ImageURL *struct {
 		URL string `json:"url"`
 	} `json:"image_url,omitempty"`
+	W int `json:"w,omitempty"`
+	H int `json:"h,omitempty"`
 }
 
 // TextContent returns the message's text, whether it was set directly
@@ -94,13 +102,48 @@ func imageDataURL(ext string, data []byte) string {
 	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
 }
 
-// ImagePart builds an image ContentPart from raw bytes and a format extension.
+// ImagePart builds an image ContentPart from raw bytes and a format
+// extension, recording the pixel dimensions for token estimation.
 func ImagePart(ext string, data []byte) ContentPart {
 	p := ContentPart{Type: "image_url"}
 	p.ImageURL = &struct {
 		URL string `json:"url"`
 	}{URL: imageDataURL(ext, data)}
+	p.W, p.H, _ = DecodeImageSize(data)
 	return p
+}
+
+// Dimensions returns the recorded pixel size of an image part (0,0 when
+// unmeasured).
+func (p ContentPart) Dimensions() (w, h int) {
+	return p.W, p.H
+}
+
+// DecodeDimensions measures the image carried by the part's data URL. Used
+// when W/H are zero (session rows written before the fields existed).
+func (p ContentPart) DecodeDimensions() (w, h int, ok bool) {
+	if p.ImageURL == nil {
+		return 0, 0, false
+	}
+	const prefix = ";base64,"
+	i := strings.Index(p.ImageURL.URL, prefix)
+	if i < 0 {
+		return 0, 0, false
+	}
+	// Decode only the header: 4KB of base64 covers every format's config.
+	b64 := p.ImageURL.URL[i+len(prefix):]
+	if len(b64) > 4096 {
+		b64 = b64[:4096]
+	}
+	head, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		// Truncated base64: decode what we have (headers sit at the front).
+		head, err = base64.StdEncoding.DecodeString(b64[:len(b64)-len(b64)%4])
+		if err != nil {
+			return 0, 0, false
+		}
+	}
+	return DecodeImageSize(head)
 }
 
 // messageWire is the JSON shape of a Message. Content is `any` so it can be a
@@ -204,6 +247,19 @@ func stripAuthored(msgs []Message) []Message {
 		for j := range out[i].ToolCalls {
 			out[i].ToolCalls[j].DurationMs = 0
 			out[i].ToolCalls[j].ExitCode = 0
+		}
+		// W/H are whip-local estimation bookkeeping; the provider's wire shape
+		// for image parts is just the data URL. Copy the Parts slice first —
+		// a shallow struct copy shares it, so zeroing here would otherwise
+		// mutate the caller's history (and its persisted dims).
+		if len(out[i].Parts) > 0 {
+			parts := make([]ContentPart, len(out[i].Parts))
+			copy(parts, out[i].Parts)
+			for j := range parts {
+				parts[j].W = 0
+				parts[j].H = 0
+			}
+			out[i].Parts = parts
 		}
 	}
 	// Backfill tool-message Name from the owning call (older sessions predate

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -113,12 +113,6 @@ func ImagePart(ext string, data []byte) ContentPart {
 	return p
 }
 
-// Dimensions returns the recorded pixel size of an image part (0,0 when
-// unmeasured).
-func (p ContentPart) Dimensions() (w, h int) {
-	return p.W, p.H
-}
-
 // DecodeDimensions measures the image carried by the part's data URL. Used
 // when W/H are zero (session rows written before the fields existed).
 func (p ContentPart) DecodeDimensions() (w, h int, ok bool) {
@@ -130,18 +124,16 @@ func (p ContentPart) DecodeDimensions() (w, h int, ok bool) {
 	if i < 0 {
 		return 0, 0, false
 	}
-	// Decode only the header: 4KB of base64 covers every format's config.
+	// Decode only the head: 64KB of base64 (a multiple of 4, so the cut is
+	// a clean quantum boundary) covers every format's config, including
+	// JPEGs that front-load a large ICC profile before the size marker.
 	b64 := p.ImageURL.URL[i+len(prefix):]
-	if len(b64) > 4096 {
-		b64 = b64[:4096]
+	if len(b64) > 65536 {
+		b64 = b64[:65536]
 	}
 	head, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
-		// Truncated base64: decode what we have (headers sit at the front).
-		head, err = base64.StdEncoding.DecodeString(b64[:len(b64)-len(b64)%4])
-		if err != nil {
-			return 0, 0, false
-		}
+		return 0, 0, false
 	}
 	return DecodeImageSize(head)
 }

--- a/internal/session/failure_test.go
+++ b/internal/session/failure_test.go
@@ -287,7 +287,7 @@ func TestApplyCompactionKeepsPriorSummary(t *testing.T) {
 	if err := st.Save(id, 1, msgs, "m", "p"); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.RecordCompaction(id, 3, "second gen"); err != nil {
+	if err := st.RecordCompaction(id, 3, "second gen", "", llm.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 	_, got, err := st.Load(id)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -99,6 +99,14 @@ var extraColumns = []struct{ name, def string }{
 	{"usage_out", "usage_out INTEGER NOT NULL DEFAULT 0"},       // cumulative output tokens
 	{"todos", "todos TEXT NOT NULL DEFAULT ''"},                 // todowrite plan JSON ([]agent.Todo)
 	{"task_id", "task_id TEXT NOT NULL DEFAULT ''"},             // non-empty = this session is a subagent's transcript; the value is the task id
+	{"sub_usage", "sub_usage TEXT NOT NULL DEFAULT ''"},         // JSON {"model @ provider": llm.Usage}: spend of every subagent under this session, by model
+}
+
+// compactionColumns are the compactions table's post-schema additions,
+// migrated the same way as extraColumns.
+var compactionColumns = []struct{ name, def string }{
+	{"model", "model TEXT NOT NULL DEFAULT ''"}, // route that wrote the summary ("model @ provider")
+	{"usage", "usage TEXT NOT NULL DEFAULT ''"}, // JSON llm.Usage of the summary request
 }
 
 // Meta is a session's bookkeeping row.
@@ -117,7 +125,11 @@ type Meta struct {
 	UsageIn     int      // cumulative input tokens across the session's API calls
 	UsageCached int      // of UsageIn, tokens served from the provider's prompt cache
 	UsageOut    int      // cumulative output tokens
-	UpdatedAt   time.Time
+	// SubUsage is the spend of every subagent under this session by model
+	// label, kept apart from UsageIn/Out (this session's own requests) so the
+	// two sum to the whole bill without double counting.
+	SubUsage  map[string]llm.Usage
+	UpdatedAt time.Time
 	// TaskID is non-empty when this session is a subagent's persisted
 	// transcript (the value is the task id, e.g. "survey-context-3"); the
 	// parent session id is ForkedFrom. Empty for ordinary sessions.
@@ -151,6 +163,9 @@ func Open(path string) (*Store, error) {
 	// duplicate-column-tolerant migration as goal
 	for _, c := range extraColumns {
 		_, _ = db.ExecContext(context.Background(), `ALTER TABLE sessions ADD COLUMN `+c.def)
+	}
+	for _, c := range compactionColumns {
+		_, _ = db.ExecContext(context.Background(), `ALTER TABLE compactions ADD COLUMN `+c.def)
 	}
 	return &Store{db: db}, nil
 }
@@ -189,8 +204,16 @@ func (s *Store) SetEffort(id, effort string) error {
 // deltas) so a resumed session keeps its spend across restarts and
 // compactions. Rows from before this column existed read as zero and get
 // stamped with real totals on the next save.
-func (s *Store) SetUsage(id string, in, cached, out int) error {
-	_, err := s.db.ExecContext(context.Background(), `UPDATE sessions SET usage_in=?, usage_cached=?, usage_out=? WHERE id=?`, in, cached, out, id)
+func (s *Store) SetUsage(id string, in, cached, out int, sub map[string]llm.Usage) error {
+	subJSON := ""
+	if len(sub) > 0 {
+		b, err := json.Marshal(sub)
+		if err != nil {
+			return err
+		}
+		subJSON = string(b)
+	}
+	_, err := s.db.ExecContext(context.Background(), `UPDATE sessions SET usage_in=?, usage_cached=?, usage_out=?, sub_usage=? WHERE id=?`, in, cached, out, subJSON, id)
 	return err
 }
 
@@ -351,7 +374,7 @@ func (s *Store) Save(id string, from int, msgs []llm.Message, model, provider st
 
 // Load resolves idOrPrefix to a session and returns its metadata and messages.
 func (s *Store) Load(idOrPrefix string) (Meta, []llm.Message, error) {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, updated_at FROM sessions WHERE id LIKE ?||'%' LIMIT 3`, idOrPrefix)
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, sub_usage, updated_at FROM sessions WHERE id LIKE ?||'%' LIMIT 3`, idOrPrefix)
 	if err != nil {
 		return Meta{}, nil, err
 	}
@@ -493,7 +516,7 @@ func answerDanglingToolCalls(msgs []llm.Message) []llm.Message {
 
 // Recent returns up to n sessions, newest first.
 func (s *Store) Recent(n int) ([]Meta, error) {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, updated_at FROM sessions
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, sub_usage, updated_at FROM sessions
 		WHERE EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)
 		ORDER BY updated_at DESC LIMIT ?`, n)
 	if err != nil {
@@ -687,22 +710,29 @@ func (s *Store) ClearSnapshots(id string) error {
 
 // Compaction is one recorded compaction event.
 type Compaction struct {
-	Seq     int    // generation (1-based)
-	Cutoff  int    // raw-log seq the summary replaces
-	Summary string // the generated summary text
+	Seq     int       // generation (1-based)
+	Cutoff  int       // raw-log seq the summary replaces
+	Summary string    // the generated summary text
+	Model   string    // route that wrote the summary ("model @ provider"; "" on old rows)
+	Usage   llm.Usage // the summary request's own usage (zero on old rows)
 }
 
-// RecordCompaction appends a compaction event. The raw messages stay.
-func (s *Store) RecordCompaction(id string, cutoff int, summary string) error {
-	_, err := s.db.ExecContext(context.Background(), `INSERT INTO compactions (session_id, seq, cutoff, summary, created_at)
-		SELECT ?, COALESCE(MAX(seq),0)+1, ?, ?, ? FROM compactions WHERE session_id=?`,
-		id, cutoff, summary, now(), id)
+// RecordCompaction appends a compaction event with the route and usage of the
+// summary request, so the fold's own cost is auditable. The raw messages stay.
+func (s *Store) RecordCompaction(id string, cutoff int, summary, model string, usage llm.Usage) error {
+	u, err := json.Marshal(usage)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(context.Background(), `INSERT INTO compactions (session_id, seq, cutoff, summary, created_at, model, usage)
+		SELECT ?, COALESCE(MAX(seq),0)+1, ?, ?, ?, ?, ? FROM compactions WHERE session_id=?`,
+		id, cutoff, summary, now(), model, string(u), id)
 	return err
 }
 
 // Compactions returns a session's compaction events, oldest first.
 func (s *Store) Compactions(id string) []Compaction {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT seq, cutoff, summary FROM compactions WHERE session_id=? ORDER BY seq`, id)
+	rows, err := s.db.QueryContext(context.Background(), `SELECT seq, cutoff, summary, model, usage FROM compactions WHERE session_id=? ORDER BY seq`, id)
 	if err != nil {
 		return nil
 	}
@@ -710,7 +740,11 @@ func (s *Store) Compactions(id string) []Compaction {
 	var out []Compaction
 	for rows.Next() {
 		var c Compaction
-		if rows.Scan(&c.Seq, &c.Cutoff, &c.Summary) == nil {
+		var u string
+		if rows.Scan(&c.Seq, &c.Cutoff, &c.Summary, &c.Model, &u) == nil {
+			if u != "" {
+				_ = json.Unmarshal([]byte(u), &c.Usage)
+			}
 			out = append(out, c)
 		}
 	}
@@ -807,7 +841,7 @@ func (s *Store) SetPinned(id string, pinned bool) error {
 // ForksOf lists sessions forked from id, newest first — the session tree's
 // children of one node.
 func (s *Store) ForksOf(id string) ([]Meta, error) {
-	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, updated_at
+	rows, err := s.db.QueryContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, sub_usage, updated_at
 		FROM sessions WHERE forked_from=? ORDER BY updated_at DESC`, id)
 	if err != nil {
 		return nil, err
@@ -867,15 +901,18 @@ func scanMetas(rows *sql.Rows) ([]Meta, error) {
 	var out []Meta
 	for rows.Next() {
 		var m Meta
-		var updated, tags string
+		var updated, tags, subUsage string
 		var pinned int
 		if err := rows.Scan(&m.ID, &m.Title, &m.Model, &m.Provider, &m.CWD, &m.Goal,
 			&m.ForkedFrom, &m.ForkSeq, &tags, &pinned, &m.Effort,
-			&m.UsageIn, &m.UsageCached, &m.UsageOut, &m.TaskID, &updated); err != nil {
+			&m.UsageIn, &m.UsageCached, &m.UsageOut, &m.TaskID, &subUsage, &updated); err != nil {
 			return nil, err
 		}
 		if tags != "" {
 			m.Tags = strings.Split(tags, ",")
+		}
+		if subUsage != "" {
+			_ = json.Unmarshal([]byte(subUsage), &m.SubUsage)
 		}
 		m.Pinned = pinned != 0
 		m.UpdatedAt, _ = time.Parse(time.RFC3339, updated)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -395,7 +395,7 @@ func TestCompactionEvent(t *testing.T) {
 	rawBefore := len(st.RawMessages(id))
 
 	// compact: fold q1/a1/q2 into a summary, keep the tail from seq 4
-	if err := st.RecordCompaction(id, 4, "q1/q2 were about testing"); err != nil {
+	if err := st.RecordCompaction(id, 4, "q1/q2 were about testing", "", llm.Usage{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -495,7 +495,8 @@ func TestTodosAndUsagePersistence(t *testing.T) {
 	}
 
 	// usage totals are absolute and survive a reload
-	if err := st.SetUsage(id, 100, 40, 7); err != nil {
+	subs := map[string]llm.Usage{"sub-m @ p": {PromptTokens: 9, CompletionTokens: 3}}
+	if err := st.SetUsage(id, 100, 40, 7, subs); err != nil {
 		t.Fatal(err)
 	}
 	meta, _, err := st.Load(id)
@@ -504,6 +505,32 @@ func TestTodosAndUsagePersistence(t *testing.T) {
 	}
 	if meta.UsageIn != 100 || meta.UsageCached != 40 || meta.UsageOut != 7 {
 		t.Fatalf("usage did not round-trip: %+v", meta)
+	}
+	if u := meta.SubUsage["sub-m @ p"]; u.PromptTokens != 9 || u.CompletionTokens != 3 {
+		t.Fatalf("sub usage did not round-trip: %+v", meta.SubUsage)
+	}
+	// An empty ledger clears the column.
+	if err := st.SetUsage(id, 100, 40, 7, nil); err != nil {
+		t.Fatal(err)
+	}
+	if meta, _, _ = st.Load(id); meta.SubUsage != nil {
+		t.Fatalf("nil ledger should clear sub_usage, got %+v", meta.SubUsage)
+	}
+}
+
+// A compaction event records the route and usage of the summary request.
+func TestRecordCompactionCarriesModelAndUsage(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := st.Create("/tmp", "m", "p")
+	if err := st.RecordCompaction(id, 2, "sum", "cheap @ p", llm.Usage{PromptTokens: 500, CompletionTokens: 50}); err != nil {
+		t.Fatal(err)
+	}
+	evs := st.Compactions(id)
+	if len(evs) != 1 || evs[0].Model != "cheap @ p" || evs[0].Usage.PromptTokens != 500 || evs[0].Usage.CompletionTokens != 50 {
+		t.Fatalf("compaction should carry model+usage: %+v", evs)
 	}
 }
 

--- a/internal/tui/context_doctor.go
+++ b/internal/tui/context_doctor.go
@@ -113,7 +113,7 @@ func (m *model) doctorReport() string {
 		rows = append(rows, ctxRow{"conversation history", hist * 4, "estimated"})
 	}
 	// Session spend so far (real usage, if any request has happened).
-	if u := m.agent.Usage(); u.PromptTokens > 0 {
+	if u := m.agent.TotalUsage(); u.PromptTokens > 0 {
 		rows = append(rows, ctxRow{"session spend so far", 0, fmt.Sprintf("%s in / %s out (actual)", tok(u.PromptTokens), tok(u.CompletionTokens))})
 	}
 

--- a/internal/tui/effort_test.go
+++ b/internal/tui/effort_test.go
@@ -300,6 +300,27 @@ func TestResumeRestoresUsage(t *testing.T) {
 		t.Fatalf("persist should store cumulative totals, got in=%d out=%d", meta.UsageIn, meta.UsageOut)
 	}
 
+	// subagent spend persists as its own ledger (never folded into usage_*)
+	// and a resume restores it, so the total survives a restart intact
+	m.agent.AddSubUsage("sub-m @ p", llm.Usage{PromptTokens: 5000, CompletionTokens: 40})
+	m.persist()
+	meta, _, _ = st.Load(id)
+	if meta.UsageIn != 15000 || meta.UsageOut != 2000 {
+		t.Fatalf("sub spend must not leak into the session's own usage columns: %+v", meta)
+	}
+	if su := meta.SubUsage["sub-m @ p"]; su.PromptTokens != 5000 || su.CompletionTokens != 40 {
+		t.Fatalf("sub ledger did not persist: %+v", meta.SubUsage)
+	}
+	if err := m.resume(id); err != nil {
+		t.Fatal(err)
+	}
+	if su := m.agent.SubUsage()["sub-m @ p"]; su.PromptTokens != 5000 {
+		t.Fatalf("resume should restore the sub ledger, got %+v", m.agent.SubUsage())
+	}
+	if tot := m.agent.TotalUsage(); tot.PromptTokens != 20000 || tot.CompletionTokens != 2040 {
+		t.Fatalf("restored total should be own + subs, got %+v", tot)
+	}
+
 	// legacy row (no usage columns stamped): totals are reconstructed from the
 	// per-message usage stored on assistant messages, then stamped on the next
 	// persist so reconstruction happens once

--- a/internal/tui/effort_test.go
+++ b/internal/tui/effort_test.go
@@ -278,7 +278,7 @@ func TestResumeRestoresUsage(t *testing.T) {
 	if err := st.Save(id, 1, msgs, m.modelName, m.provName); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.SetUsage(id, 12000, 8000, 1500); err != nil {
+	if err := st.SetUsage(id, 12000, 8000, 1500, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/tui/fork.go
+++ b/internal/tui/fork.go
@@ -220,6 +220,7 @@ func (m *model) switchToForked(id string) {
 		}
 		m.agent.SetUsage(u)
 	}
+	m.agent.SetSubUsage(meta.SubUsage)
 	m.sessionID = meta.ID
 	bashrun.SetMarkers(meta.ID, m.agent.Model)
 	m.agent.Messages = append(m.agent.Messages, msgs...)

--- a/internal/tui/mentions.go
+++ b/internal/tui/mentions.go
@@ -101,6 +101,10 @@ func imageParts(text string) ([]llm.ContentPart, string) {
 			continue
 		}
 		ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(abs)), ".")
+		// Normalize before inlining: a HiDPI screenshot at full resolution
+		// costs 4–10× the tokens of the capped re-encode, with no legibility
+		// gain the model can use.
+		ext, data = llm.NormalizeImage(ext, data)
 		parts = append(parts, llm.ImagePart(ext, data))
 		names = append(names, abs)
 	}

--- a/internal/tui/opencode.go
+++ b/internal/tui/opencode.go
@@ -251,7 +251,7 @@ func (m *model) sidebarView(height int) string {
 
 	// Context: tokens used, share of the window, spend.
 	b.WriteString(head.Render("Context") + "\n")
-	u := m.agent.Usage()
+	u := m.agent.TotalUsage()
 	b.WriteString(dim.Render(fmtTok(u.PromptTokens+u.CompletionTokens)+" tokens") + "\n")
 	if m.agent.ContextLimit > 0 {
 		pct := agent.EstimateTokens(m.agent.Messages) * 100 / m.agent.ContextLimit
@@ -426,7 +426,7 @@ func (m *model) opencodeStatus() string {
 	txt := lipgloss.NewStyle().Foreground(ocTextCol())
 	// right side: "{tokens} ({pct})  " muted, then "ctrl+p" in text, " commands" muted.
 	rightRaw := ""
-	if u := m.agent.Usage(); u.PromptTokens+u.CompletionTokens > 0 {
+	if u := m.agent.TotalUsage(); u.PromptTokens+u.CompletionTokens > 0 {
 		rightRaw = strings.ToUpper(fmtTok(u.PromptTokens + u.CompletionTokens)) // opencode uses uppercase (15.8K)
 		if m.agent.ContextLimit > 0 {
 			rightRaw += fmt.Sprintf(" (%d%%)", agent.EstimateTokens(m.agent.Messages)*100/m.agent.ContextLimit)

--- a/internal/tui/opencode.go
+++ b/internal/tui/opencode.go
@@ -249,10 +249,12 @@ func (m *model) sidebarView(height int) string {
 	var b strings.Builder
 	b.WriteString(head.Render(truncLine(title, sidebarWidth-4)) + "\n\n")
 
-	// Context: tokens used, share of the window, spend.
+	// Context: share of the window the conversation occupies, then the
+	// session's spend (all requests, subagents included) — two different
+	// quantities, each labeled as what it is.
 	b.WriteString(head.Render("Context") + "\n")
 	u := m.agent.TotalUsage()
-	b.WriteString(dim.Render(fmtTok(u.PromptTokens+u.CompletionTokens)+" tokens") + "\n")
+	b.WriteString(dim.Render(fmtTok(u.PromptTokens+u.CompletionTokens)+" tokens spent") + "\n")
 	if m.agent.ContextLimit > 0 {
 		pct := agent.EstimateTokens(m.agent.Messages) * 100 / m.agent.ContextLimit
 		b.WriteString(dim.Render(fmt.Sprintf("%d%% used", pct)) + "\n")
@@ -426,10 +428,13 @@ func (m *model) opencodeStatus() string {
 	txt := lipgloss.NewStyle().Foreground(ocTextCol())
 	// right side: "{tokens} ({pct})  " muted, then "ctrl+p" in text, " commands" muted.
 	rightRaw := ""
-	if u := m.agent.TotalUsage(); u.PromptTokens+u.CompletionTokens > 0 {
-		rightRaw = strings.ToUpper(fmtTok(u.PromptTokens + u.CompletionTokens)) // opencode uses uppercase (15.8K)
+	// "{tokens} ({pct})" is opencode's CONTEXT readout: both numbers describe
+	// the current conversation size, not the session bill (the sidebar shows
+	// spend, labeled as such).
+	if ctx := agent.EstimateTokens(m.agent.Messages); ctx > 0 && len(m.agent.Messages) > 1 {
+		rightRaw = strings.ToUpper(fmtTok(ctx)) // opencode uses uppercase (15.8K)
 		if m.agent.ContextLimit > 0 {
-			rightRaw += fmt.Sprintf(" (%d%%)", agent.EstimateTokens(m.agent.Messages)*100/m.agent.ContextLimit)
+			rightRaw += fmt.Sprintf(" (%d%%)", ctx*100/m.agent.ContextLimit)
 		}
 		rightRaw += "  "
 	}

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -18,6 +18,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/context-labs/whip/internal/config"
+	"github.com/context-labs/whip/internal/llm"
 )
 
 // readClipboardImage returns image bytes and their format extension from the
@@ -260,7 +261,11 @@ func pasteImageFileCmd(path string) tea.Msg {
 }
 
 // saveClipboardImage writes data to ~/.whip/pastes/ and returns the path.
+// Images are normalized first (bounded dims, byte budget) so a HiDPI
+// screenshot doesn't ride the context at full pixel cost for the rest of the
+// session.
 func saveClipboardImage(ext string, data []byte) (string, error) {
+	ext, data = llm.NormalizeImage(ext, data)
 	dir, err := config.Dir()
 	if err != nil {
 		return "", err

--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -282,4 +282,24 @@ func TestSessionCostUsesFetchedPricing(t *testing.T) {
 	if want := 0.064215; fast != want {
 		t.Errorf("kimi-k3-fast cost = %v, want %v", fast, want)
 	}
+
+	// Subagent spend is priced at ITS model's rates, not the session's: a
+	// fast-variant sub under a standard-variant parent costs the fast price.
+	// The sub carries no provider (label "model @ "), so the catalog is found
+	// by scanning for the model.
+	m.agent.AddSubUsage("kimi-k3-fast @ ", llm.Usage{PromptTokens: 1000, CompletionTokens: 100})
+	withSub, ok := m.sessionCost()
+	if !ok {
+		t.Fatal("sub under a known model should be priced")
+	}
+	subCost := 1000*4.5e-6 + 100*22.5e-6 // 0.0045 + 0.00225
+	if diff := withSub - std - subCost; diff > 1e-12 || diff < -1e-12 {
+		t.Errorf("cost with sub = %v, want own %v + sub %v", withSub, std, subCost)
+	}
+	// A sub on a model no catalog prices makes the whole figure unknown:
+	// hide it rather than show a number that is knowingly low.
+	m.agent.AddSubUsage("mystery-model @ elsewhere", llm.Usage{PromptTokens: 1})
+	if _, ok := m.sessionCost(); ok {
+		t.Error("an unpriceable sub must hide the cost segment")
+	}
 }

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -1071,3 +1071,41 @@ func TestDockClickMapsThroughScrollWindow(t *testing.T) {
 		t.Fatalf("clicking the +N more row must not change the selection: %d → %d", before, m.taskSel)
 	}
 }
+
+// A settled task's session row carries the sub's own bill (usage_*), stamped
+// alongside its transcript, while the parent's own usage stays untouched.
+func TestTaskRowCarriesSubUsage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"report"},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":123,"completion_tokens":45}}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+	m := tasksModelStore(t, srv.URL)
+	m.wireTasks()
+	id, err := m.store.Create("/tmp", "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.sessionID = id
+	m.agent.Tasks().SetSessionID(id)
+
+	task := m.agent.StartBackground("probe", "p", agent.SubModel{})
+	defer m.agent.Tasks().Cancel(task.ID)
+	waitSettled(t, task)
+
+	meta, _, err := m.store.Load("task-" + id + "-" + task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.UsageIn != 123 || meta.UsageOut != 45 {
+		t.Fatalf("task row should carry the sub's own bill, got in=%d out=%d", meta.UsageIn, meta.UsageOut)
+	}
+	if u := m.agent.Usage(); u.PromptTokens != 0 {
+		t.Fatalf("parent's own usage must not include the sub: %+v", u)
+	}
+	if u := m.agent.SubUsage()["m @ "]; u.PromptTokens != 123 || u.CompletionTokens != 45 {
+		t.Fatalf("parent ledger should hold the sub's spend: %+v", m.agent.SubUsage())
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1272,7 +1272,10 @@ func buildAgent(cfg *config.Config, modelName, provName, sysPrompt string) (*age
 		tools.ScreenshotSink = func(jpegs [][]byte) {
 			parts := make([]llm.ContentPart, 0, len(jpegs))
 			for _, j := range jpegs {
-				parts = append(parts, llm.ImagePart("jpg", j))
+				// a HiDPI full-display capture exceeds both the dim and byte
+				// caps; bound it like every other image entering history
+				ext, data := llm.NormalizeImage("jpg", j)
+				parts = append(parts, llm.ImagePart(ext, data))
 			}
 			ag.SteerImages("browser_exec screenshots attached:", parts)
 		}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -966,6 +966,7 @@ func (m *model) resume(id string) error {
 		}
 		m.agent.SetUsage(u)
 	}
+	m.agent.SetSubUsage(meta.SubUsage)
 	if slices.Contains(m.effortsFor(), effort) {
 		m.agent.Effort = effort
 	}
@@ -1083,8 +1084,10 @@ func (m *model) persist() {
 	_ = m.store.SetGoal(m.sessionID, m.goal)
 	_ = m.store.SetEffort(m.sessionID, m.agent.Effort)
 	_ = m.store.SetTodos(m.sessionID, m.agent.TodosJSON())
-	if u := m.agent.Usage(); u.PromptTokens > 0 || u.CompletionTokens > 0 {
-		_ = m.store.SetUsage(m.sessionID, u.PromptTokens, u.Cached(), u.CompletionTokens)
+	// Own requests in usage_*, subagent spend (by model) in sub_usage: the
+	// two columns sum to the session's whole bill without double counting.
+	if u, subs := m.agent.Usage(), m.agent.SubUsage(); u.PromptTokens > 0 || u.CompletionTokens > 0 || len(subs) > 0 {
+		_ = m.store.SetUsage(m.sessionID, u.PromptTokens, u.Cached(), u.CompletionTokens, subs)
 	}
 	if len(m.agent.Messages) <= m.saved {
 		return
@@ -2557,7 +2560,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.store != nil && m.sessionID != "" {
 				// the agent's cutoff is in compacted coordinates; store the raw
 				// seq so Load never double-folds a summary
-				if err := m.store.RecordCompaction(m.sessionID, m.rawCutoff(msg.cutoff), msg.summary); err != nil {
+				if err := m.store.RecordCompaction(m.sessionID, m.rawCutoff(msg.cutoff), msg.summary, msg.info.Model, msg.info.Usage); err != nil {
 					config.LogEvent("session.compact", "record failed: "+err.Error())
 				} else {
 					recorded = true
@@ -3498,7 +3501,7 @@ func (m *model) busyStats() string {
 	d := max(m.nowFn().Sub(m.turnStart), 0)
 	elapsed := d.Round(time.Second)
 	stats := fmt.Sprintf(" %d:%02d", int(elapsed.Minutes()), int(elapsed.Seconds())%60)
-	if u := m.agent.Usage(); u.PromptTokens > 0 || u.CompletionTokens > 0 {
+	if u := m.agent.TotalUsage(); u.PromptTokens > 0 || u.CompletionTokens > 0 {
 		stats += fmt.Sprintf(" · %s tok", fmtTok(u.PromptTokens+u.CompletionTokens))
 	}
 	if m.agent.ContextLimit > 0 {
@@ -3563,16 +3566,41 @@ func (m *model) contextLimitFor(provName, apiID string) int {
 // sessionCost returns the session's cumulative USD spend at the current
 // model's advertised rates; ok is false when the provider's catalog has no
 // pricing for the model, in which case the status line hides the segment.
+// The figure is the whole bill: own requests at this model's rates plus each
+// subagent's spend at ITS model's rates. Any unpriceable component hides the
+// segment rather than showing a number that is knowingly low.
 func (m *model) sessionCost() (float64, bool) {
-	cat, ok := m.catalogs[m.provName]
+	total, ok := m.usageCost(m.agent.Model, m.provName, m.agent.Usage())
 	if !ok {
 		return 0, false
 	}
-	in, out, cacheRead, ok := cat.Pricing(m.agent.Model)
-	if !ok {
+	for label, u := range m.agent.SubUsage() {
+		model, prov, _ := strings.Cut(label, " @ ")
+		c, ok := m.usageCost(model, prov, u)
+		if !ok {
+			return 0, false
+		}
+		total += c
+	}
+	return total, true
+}
+
+// usageCost prices u at model's rates from the provider's catalog. A sub may
+// carry no provider (or one without a loaded catalog); then any catalog that
+// knows the model prices it.
+func (m *model) usageCost(model, prov string, u llm.Usage) (float64, bool) {
+	if cat, ok := m.catalogs[prov]; ok {
+		if in, out, cacheRead, ok := cat.Pricing(model); ok {
+			return llm.SessionCost(u, in, out, cacheRead), true
+		}
 		return 0, false
 	}
-	return llm.SessionCost(m.agent.Usage(), in, out, cacheRead), true
+	for _, cat := range m.catalogs {
+		if in, out, cacheRead, ok := cat.Pricing(model); ok {
+			return llm.SessionCost(u, in, out, cacheRead), true
+		}
+	}
+	return 0, false
 }
 
 // compactThresholdFor converts the config's compactPct preference into the
@@ -3644,8 +3672,14 @@ func (m *model) wireTasks() {
 		// Attribute it to the sub's own route (t.SubModel): a model-overridden
 		// subagent must not be recorded under the parent's model/provider.
 		if t.Status != agent.TaskRunning && t.SubMessages != nil {
-			if _, err := st.SaveSubagentTranscript(sessionID, t.ID, t.SubMessages, t.SubModel, ""); err != nil {
+			id, err := st.SaveSubagentTranscript(sessionID, t.ID, t.SubMessages, t.SubModel, "")
+			if err != nil {
 				config.LogEvent("session.task", "transcript save failed: "+err.Error())
+			} else if id != "" {
+				// The task row carries the sub's own bill (and its nested subs'),
+				// like any session row; the parent's sub_usage is the rollup.
+				u := t.SubUsage
+				_ = st.SetUsage(id, u.PromptTokens, u.Cached(), u.CompletionTokens, t.SubSubUsage)
 			}
 		}
 	}
@@ -4818,9 +4852,10 @@ func (m *model) viewBody() string {
 	if !m.follow {
 		left += fmt.Sprintf(" · ↑ %d%%", int(m.vp.ScrollPercent()*100))
 	}
-	// session token usage, provider-reported: in (cached of it) / out, then
-	// the share of the advertised context window the conversation occupies
-	u := m.agent.Usage()
+	// session token usage, provider-reported and including every subagent's
+	// requests: in (cached of it) / out, then the share of the advertised
+	// context window the conversation occupies
+	u := m.agent.TotalUsage()
 	if u.PromptTokens > 0 || u.CompletionTokens > 0 {
 		left += fmt.Sprintf(" · ⣿ %s in", fmtTok(u.PromptTokens))
 		if c := u.Cached(); c > 0 {
@@ -5005,7 +5040,7 @@ func (m *model) statusView() string {
 	if e := effortLabel(m.agent.Effort); e != "off" {
 		model += " (" + e + ")"
 	}
-	u := m.agent.Usage()
+	u := m.agent.TotalUsage() // whole bill: own requests plus every subagent's
 	spend := fmtUsage(u)
 	if cost, ok := m.sessionCost(); ok {
 		spend += " · " + fmtCost(cost)


### PR DESCRIPTION
## What this is

Implements the cost-reduction plan from `docs/context-cost-plan.md`, derived from a forensic analysis of session `7ec5ba63` (kimi-k3, 48h, 2,096 API calls, 283M input tokens, ≈$210) against opencode's context-management layer. All 7 work items land here with tests.

## Root causes fixed (each verified against the session DB)

1. **Proactive compaction never fired despite `compactPct: 30`.** The trigger ran on `EstimateTokens` (chars/4 + flat 1200/image), which peaked at 296k/1M (28%) while the provider billed 392k+ prompt tokens (37%).
2. **Images undercounted ~7×** — four screenshots cost 4.1k–11.4k real tokens each; whip counted 1.2k. Images also never left context: ~7.1M tokens of input was re-sending old screenshots.
3. **No ingest image normalization** — a 3410×2646 clipboard PNG went in verbatim.
4. **Compaction tail = 6 messages regardless of size**; summary capped at 1024 tokens with 500-char tool-result truncation → small, lossy folds.
5. **No doom-loop guard** — one stuck subagent made 789 calls (516× identical `sleep 280; git status`, incl. a 235-in-a-row streak) burning 85M tokens (~$35) polling git.
6. **Usage double-counted** — subagent spend fanned into the parent's own counter; the session row reported 550M vs 283M provider-truth (~2× inflated cost UI). Now the total still includes subagents, but through a separate per-model ledger so each token is counted exactly once and priced at the right model's rates.

## Changes

**`internal/llm`** (items 2, 3)
- `ContentPart` records image dims at ingest (persisted in session JSON, stripped from the provider wire via a fixed deep-copying `stripAuthored`).
- `PartTokens`: `⌈w/28⌉·⌈h/28⌉` (floor 85, fallback 1200 for undecodable), replacing flat 1200/image.
- `NormalizeImage`: cap 2000×2000, JPEG q80→40 until ≤5MiB (`x/image/draw`); small/corrupt inputs pass through.

**`internal/agent`** (items 1, 4, 5, 6, 7)
- **Real-usage trigger:** `maybeCompact` fires off the provider-reported prompt size (`lastPrompt`, fed by `AddUsage`); chars/4 is the fallback for usage-less providers. Also closes the single-round-turn gap: a final response whose usage crosses the threshold compacts before the turn returns (skipped if the turn already compacted).
- **Budgeted tail:** `min(15k, max(2k, usable×0.25))` walking whole user turns (replaces `compactKeepBack = 6`); summary `MaxTokens` 1024→4096; **incremental summaries** merge the prior fold forward.
- **Image decay:** image parts past the hot window → text placeholder with dims + spilled-file path (recoverable via `@mention`).
- **Doom-loop guard:** 3rd consecutive identical (tool, args) returns a refusal without executing; any different call resets the run; `wait` is exempt.
- **Usage accounting, counted once and complete:** `Agent.usage` is strictly the agent's own requests; a per-model `subUsage` ledger holds every subagent's spend (foreground, background, follow-up, nested, and their compaction calls), fed by a `usageSink` set at sub creation. `TotalUsage()` = own + subs. Persisted as `sessions.sub_usage` (JSON), task rows get their own `usage_*`, and `compactions` gains `model` + `usage`. The TUI shows the total and prices each ledger entry at its own model's rates, hiding the $ figure if any part is unpriceable.

## Verification

`go build ./...` and `go test ./...` pass. New tests: pixel-formula estimator, dims persist/strip round-trip, lazy decode of pre-dims rows, normalization budget/aspect/passthrough, real-usage trigger (compacts at real 400k despite low text estimate), estimate fallback, doom-loop refusal + execution-skip + alternation-reset + wait exemption, image-decay placeholder, background-usage single-count.

**Note:** the two `internal/tui` `TestStartupReport*` failures **pre-date this branch** (verified failing on clean `main` via a worktree) — unrelated to these changes.

## Non-goals (unchanged)

No tokenizer vendoring; the existing 50KB tool-output truncation + spill-to-disk is untouched.

## Review pass (self)

A second read of the branch found two real bugs, fixed in the last commit with tests:

- **`lastPrompt` poisoning.** It was set inside `AddUsage`, which also receives foreground-subagent and compaction-summary usage, so those prompt sizes overwrote the parent's real context size. The pre-fold value also lingered after a fold, so the next round could re-fold the fresh summary. Now set only from the turn loop (`notePrompt`) and reset to 0 in `compact`.
- **Refused doom-loop calls left a stuck TUI row.** The refusal path skipped `OnToolStart`/`OnToolEnd`; the queued row opened on `OnToolCall` never closed. Both events now fire.

Cleanup: JPEG quality ladder was out of order (80, 85, ...); removed dead `NormalizeImagePNG` and the trivial `Dimensions()` accessor; dropped an unreachable base64 fallback in `DecodeDimensions` and widened the header window to 64KB for JPEGs with large ICC profiles; removed a duplicate tail clamp; dropped a no-op `FanIn`.