### PR TITLE
feat(tools): question tool with selectable options modal

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,6 +17,7 @@ flowchart TB
         WRITE["write<br/>create/overwrite"]
         EDIT["edit<br/>exact-string replacement"]
         SUGGEST["suggest<br/>file completions"]
+        QUESTION["question<br/>selectable options modal,<br/>main agent only"]
     end
 
     subgraph agents["agents & planning — internal/agent"]
@@ -63,6 +64,16 @@ Runs through `internal/tools/bashrun` so the agent can:
   command after 15s of no input.
 - **suggest next steps** — the schema nudges the model toward batching
   independent calls in one turn, which the loop then runs in parallel.
+
+## question
+
+The model asks the user to pick from 2-6 options when a decision is theirs
+(opencode's `question` tool, one question per call). The TUI shows a modal:
+numbered rows with dim descriptions, a "type your own answer" row, `multiple`
+for checkbox selection. Same hand-off as the permission gate: the tool
+goroutine blocks on `tools.Ask` until the UI answers; esc dismisses and the
+model is told so. Registered for the main agent only — subagents are told not
+to ask, and the MCP server has no user.
 
 ## Subagents (`subagent`)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -283,7 +283,7 @@ func New(client *llm.Client, model string, maxTokens int, systemPrompt string) *
 		MaxTokens: maxTokens,
 		Messages:  []llm.Message{{Role: "system", Content: systemPrompt}},
 	}
-	a.Tools = tools.All()
+	a.Tools = append(tools.All(), tools.QuestionTool())
 	if !a.BrowserDisabled {
 		a.Tools = append(a.Tools, tools.BrowserExec())
 	}

--- a/internal/tools/question.go
+++ b/internal/tools/question.go
@@ -1,0 +1,56 @@
+// The question tool: the model pauses the turn and asks the user to pick from
+// a short list of options (or type their own answer). Same shape as
+// opencode's question tool, cut to one question per call. The TUI installs
+// Ask; without it (whip run, tests) the tool tells the model no one is there.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/context-labs/whip/internal/llm"
+)
+
+// AskOption is one selectable answer.
+type AskOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// AskRequest is one question for the user.
+type AskRequest struct {
+	Question string      `json:"question"`
+	Options  []AskOption `json:"options"`
+	Multiple bool        `json:"multiple"`
+}
+
+// Ask is the installed UI hook. It returns the chosen labels (or the typed
+// custom answer) and ok=false when the user dismissed the question. Nil =
+// no interactive user.
+var Ask func(AskRequest) (answers []string, ok bool)
+
+// QuestionTool is registered for the main agent only — subagents are told not
+// to ask questions and the MCP server has no user to ask.
+func QuestionTool() Tool {
+	return Tool{
+		Def: llm.NewTool("question",
+			"Ask the user to choose between options when a decision is genuinely theirs: ambiguous instructions, a preference, or a fork in implementation. The user sees a selectable list; a \"type your own answer\" row is always added, so never include an \"Other\" option. If you recommend an option, put it first and end its label with \"(Recommended)\". Answers come back as the chosen labels.",
+			`{"type":"object","properties":{"question":{"type":"string","description":"The complete question"},"options":{"type":"array","minItems":2,"maxItems":6,"items":{"type":"object","properties":{"label":{"type":"string","description":"Display text, 1-5 words"},"description":{"type":"string","description":"One line explaining the choice"}},"required":["label"]}},"multiple":{"type":"boolean","description":"Allow selecting more than one option"}},"required":["question","options"]}`),
+		Run: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var a AskRequest
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", err
+			}
+			if Ask == nil {
+				return "", errors.New("no interactive user to ask; make a reasonable assumption and continue")
+			}
+			answers, ok := Ask(a)
+			if !ok {
+				return "", errors.New("the user dismissed the question")
+			}
+			return "User answered \"" + a.Question + "\": " + strings.Join(answers, ", "), nil
+		},
+	}
+}

--- a/internal/tools/question.go
+++ b/internal/tools/question.go
@@ -27,9 +27,9 @@ type AskRequest struct {
 }
 
 // Ask is the installed UI hook. It returns the chosen labels (or the typed
-// custom answer) and ok=false when the user dismissed the question. Nil =
-// no interactive user.
-var Ask func(AskRequest) (answers []string, ok bool)
+// custom answer) and ok=false when the user dismissed the question or ctx was
+// cancelled. Nil = no interactive user.
+var Ask func(ctx context.Context, req AskRequest) (answers []string, ok bool)
 
 // QuestionTool is registered for the main agent only — subagents are told not
 // to ask questions and the MCP server has no user to ask.
@@ -46,7 +46,7 @@ func QuestionTool() Tool {
 			if Ask == nil {
 				return "", errors.New("no interactive user to ask; make a reasonable assumption and continue")
 			}
-			answers, ok := Ask(a)
+			answers, ok := Ask(ctx, a)
 			if !ok {
 				return "", errors.New("the user dismissed the question")
 			}

--- a/internal/tui/permission.go
+++ b/internal/tui/permission.go
@@ -114,11 +114,8 @@ func (m *model) permKey(msg tea.KeyMsg) bool {
 			if len(d.rejectIn) > 0 {
 				d.rejectIn = d.rejectIn[:len(d.rejectIn)-1]
 			}
-		case tea.KeyRunes, tea.KeySpace:
+		case tea.KeyRunes, tea.KeySpace: // KeySpace arrives with Runes == " "
 			d.rejectIn += string(msg.Runes)
-			if msg.Type == tea.KeySpace {
-				d.rejectIn += " "
-			}
 		}
 		return true
 	}

--- a/internal/tui/question.go
+++ b/internal/tui/question.go
@@ -60,7 +60,7 @@ func (m *model) askKey(msg tea.KeyMsg) bool {
 		d.reply <- a
 		m.askDialog = nil
 	}
-	submit := func() {
+	submit := func() bool {
 		var out []string
 		for i, o := range d.req.Options {
 			if d.picked[i] {
@@ -71,9 +71,10 @@ func (m *model) askKey(msg tea.KeyMsg) bool {
 			out = append(out, c)
 		}
 		if len(out) == 0 {
-			return // nothing chosen yet
+			return false // nothing chosen yet
 		}
 		answer(askAnswer{answers: out, ok: true})
+		return true
 	}
 	choose := func(i int) {
 		if i == n { // custom row
@@ -91,10 +92,10 @@ func (m *model) askKey(msg tea.KeyMsg) bool {
 		switch msg.Type {
 		case tea.KeyEnter:
 			d.editing = false
-			if !d.req.Multiple {
-				if c := strings.TrimSpace(d.custom); c != "" {
-					answer(askAnswer{answers: []string{c}, ok: true})
-				}
+			if d.req.Multiple {
+				submit() // custom text and/or toggles; no-op when both empty
+			} else if c := strings.TrimSpace(d.custom); c != "" {
+				answer(askAnswer{answers: []string{c}, ok: true})
 			}
 		case tea.KeyEsc:
 			d.editing = false
@@ -102,11 +103,8 @@ func (m *model) askKey(msg tea.KeyMsg) bool {
 			if len(d.custom) > 0 {
 				d.custom = d.custom[:len(d.custom)-1]
 			}
-		case tea.KeyRunes, tea.KeySpace:
+		case tea.KeyRunes, tea.KeySpace: // KeySpace arrives with Runes == " "
 			d.custom += string(msg.Runes)
-			if msg.Type == tea.KeySpace {
-				d.custom += " "
-			}
 		}
 		return true
 	}
@@ -117,7 +115,7 @@ func (m *model) askKey(msg tea.KeyMsg) bool {
 		d.sel = (d.sel + 1) % rows
 	case tea.KeyEnter:
 		if d.req.Multiple && d.sel != n {
-			submit()
+			submit() // on the custom row enter edits; enter while editing submits
 			return true
 		}
 		choose(d.sel)

--- a/internal/tui/question.go
+++ b/internal/tui/question.go
@@ -1,8 +1,10 @@
 package tui
 
 import (
+	"context"
 	"strconv"
 	"strings"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -35,16 +37,33 @@ type askDialog struct {
 	custom  string
 }
 
+// askClose drops the dialog for a request whose tool call was cancelled.
+type askClose struct{ reply chan askAnswer }
+
 // installAskHook wires tools.Ask to the modal. Called once at startup.
+// One question at a time: parallel question calls in one tool batch queue on
+// the mutex instead of overwriting each other's dialog. ctx cancel (ctrl+c,
+// esc interrupt) releases the tool goroutine and closes the dialog.
 func (m *model) installAskHook() {
-	tools.Ask = func(req tools.AskRequest) ([]string, bool) {
+	var mu sync.Mutex
+	tools.Ask = func(ctx context.Context, req tools.AskRequest) ([]string, bool) {
 		if m.prog == nil {
 			return nil, false // headless: no one to ask
 		}
+		mu.Lock()
+		defer mu.Unlock()
+		if ctx.Err() != nil {
+			return nil, false
+		}
 		reply := make(chan askAnswer, 1)
 		m.prog.Send(askRequest{req: req, reply: reply}) //nolint:uilock // background: the calling tool goroutine, which blocks on reply — never the event loop
-		ans := <-reply
-		return ans.answers, ans.ok
+		select {
+		case ans := <-reply:
+			return ans.answers, ans.ok
+		case <-ctx.Done():
+			m.prog.Send(askClose{reply: reply}) //nolint:uilock // background: same tool goroutine
+			return nil, false
+		}
 	}
 }
 
@@ -123,6 +142,11 @@ func (m *model) askKey(msg tea.KeyMsg) bool {
 		choose(d.sel)
 	case tea.KeyEsc:
 		answer(askAnswer{ok: false})
+	case tea.KeyCtrlC:
+		answer(askAnswer{ok: false})
+		if m.busy && m.cancel != nil {
+			m.cancel() // interrupt the turn, not just the question
+		}
 	case tea.KeyRunes:
 		s := string(msg.Runes)
 		switch s {

--- a/internal/tui/question.go
+++ b/internal/tui/question.go
@@ -1,0 +1,193 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/context-labs/whip/internal/tools"
+)
+
+// Question prompts: the model's `question` tool pauses the turn and a modal
+// lists the options (opencode-style: numbered rows, dim description, a
+// "type your own answer" row). ↑/↓ or j/k move, 1-9 jump, enter picks, space
+// toggles in multi-select, esc dismisses. Same goroutine hand-off as the
+// permission gate: the tool goroutine blocks on reply until the UI answers.
+
+type askRequest struct {
+	req   tools.AskRequest
+	reply chan askAnswer
+}
+
+type askAnswer struct {
+	answers []string
+	ok      bool
+}
+
+// askDialog is the UI-thread modal state while a question is open.
+type askDialog struct {
+	req     tools.AskRequest
+	reply   chan askAnswer
+	sel     int          // row index; len(options) is the custom row
+	picked  map[int]bool // multi-select toggles
+	editing bool         // typing the custom answer
+	custom  string
+}
+
+// installAskHook wires tools.Ask to the modal. Called once at startup.
+func (m *model) installAskHook() {
+	tools.Ask = func(req tools.AskRequest) ([]string, bool) {
+		if m.prog == nil {
+			return nil, false // headless: no one to ask
+		}
+		reply := make(chan askAnswer, 1)
+		m.prog.Send(askRequest{req: req, reply: reply}) //nolint:uilock // background: the calling tool goroutine, which blocks on reply — never the event loop
+		ans := <-reply
+		return ans.answers, ans.ok
+	}
+}
+
+// askKey handles keys while the dialog is open. Returns (handled).
+func (m *model) askKey(msg tea.KeyMsg) bool {
+	d := m.askDialog
+	if d == nil {
+		return false
+	}
+	n := len(d.req.Options)
+	rows := n + 1 // + custom row
+	answer := func(a askAnswer) {
+		d.reply <- a
+		m.askDialog = nil
+	}
+	submit := func() {
+		var out []string
+		for i, o := range d.req.Options {
+			if d.picked[i] {
+				out = append(out, o.Label)
+			}
+		}
+		if c := strings.TrimSpace(d.custom); c != "" {
+			out = append(out, c)
+		}
+		if len(out) == 0 {
+			return // nothing chosen yet
+		}
+		answer(askAnswer{answers: out, ok: true})
+	}
+	choose := func(i int) {
+		if i == n { // custom row
+			d.editing = true
+			return
+		}
+		if d.req.Multiple {
+			d.picked[i] = !d.picked[i]
+			return
+		}
+		answer(askAnswer{answers: []string{d.req.Options[i].Label}, ok: true})
+	}
+
+	if d.editing {
+		switch msg.Type {
+		case tea.KeyEnter:
+			d.editing = false
+			if !d.req.Multiple {
+				if c := strings.TrimSpace(d.custom); c != "" {
+					answer(askAnswer{answers: []string{c}, ok: true})
+				}
+			}
+		case tea.KeyEsc:
+			d.editing = false
+		case tea.KeyBackspace:
+			if len(d.custom) > 0 {
+				d.custom = d.custom[:len(d.custom)-1]
+			}
+		case tea.KeyRunes, tea.KeySpace:
+			d.custom += string(msg.Runes)
+			if msg.Type == tea.KeySpace {
+				d.custom += " "
+			}
+		}
+		return true
+	}
+	switch msg.Type {
+	case tea.KeyUp:
+		d.sel = (d.sel + rows - 1) % rows
+	case tea.KeyDown, tea.KeyTab:
+		d.sel = (d.sel + 1) % rows
+	case tea.KeyEnter:
+		if d.req.Multiple && d.sel != n {
+			submit()
+			return true
+		}
+		choose(d.sel)
+	case tea.KeySpace:
+		choose(d.sel)
+	case tea.KeyEsc:
+		answer(askAnswer{ok: false})
+	case tea.KeyRunes:
+		s := string(msg.Runes)
+		switch s {
+		case "k":
+			d.sel = (d.sel + rows - 1) % rows
+		case "j":
+			d.sel = (d.sel + 1) % rows
+		default:
+			if i, err := strconv.Atoi(s); err == nil && i >= 1 && i <= rows {
+				d.sel = i - 1
+				choose(d.sel)
+			}
+		}
+	}
+	return true
+}
+
+// askView renders the modal: the question, numbered options with dim
+// descriptions, and the custom-answer row.
+func (m *model) askView() string {
+	d := m.askDialog
+	if d == nil {
+		return ""
+	}
+	var b strings.Builder
+	title := d.req.Question
+	if d.req.Multiple {
+		title += " (select all that apply)"
+	}
+	b.WriteString(youStyle.Render("? " + title))
+	for i, o := range d.req.Options {
+		mark := ""
+		if d.req.Multiple {
+			mark = "[ ] "
+			if d.picked[i] {
+				mark = "[✓] "
+			}
+		}
+		row := strconv.Itoa(i+1) + ". " + mark + o.Label
+		if i == d.sel && !d.editing {
+			b.WriteString("\n" + youStyle.Render(glyphUser+row))
+		} else {
+			b.WriteString("\n  " + row)
+		}
+		if o.Description != "" {
+			b.WriteString("\n" + dimStyle.Render("     "+o.Description))
+		}
+	}
+	custom := strconv.Itoa(len(d.req.Options)+1) + ". type your own answer"
+	switch {
+	case d.editing:
+		b.WriteString("\n" + youStyle.Render(glyphUser+custom+": ") + d.custom + "█")
+		b.WriteString(dimStyle.Render("\n  enter confirms · esc back"))
+		return b.String()
+	case d.sel == len(d.req.Options):
+		b.WriteString("\n" + youStyle.Render(glyphUser+custom))
+	default:
+		b.WriteString("\n  " + custom)
+	}
+	hint := "  ↑/↓ or 1-9 select · enter picks · esc dismisses"
+	if d.req.Multiple {
+		hint = "  ↑/↓ or 1-9 toggle · enter submits · esc dismisses"
+	}
+	b.WriteString("\n" + dimStyle.Render(hint))
+	return b.String()
+}

--- a/internal/tui/question_test.go
+++ b/internal/tui/question_test.go
@@ -54,6 +54,19 @@ func TestQuestionCustomAndMulti(t *testing.T) {
 		t.Fatalf("multi: got %+v", got)
 	}
 
+	// multi + custom row: enter edits, type, enter submits (was an edit loop)
+	m, reply = newAskModel(true)
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")})
+	m.askKey(tea.KeyMsg{Type: tea.KeyUp}) // wraps to the custom row
+	m.askKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("my")})
+	m.askKey(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("own")})
+	m.askKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := <-reply; !got.ok || len(got.answers) != 2 || got.answers[1] != "my own" {
+		t.Fatalf("multi custom: got %+v", got)
+	}
+
 	// esc dismisses
 	m, reply = newAskModel(false)
 	m.askKey(tea.KeyMsg{Type: tea.KeyEsc})

--- a/internal/tui/question_test.go
+++ b/internal/tui/question_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/context-labs/whip/internal/tools"
+)
+
+func newAskModel(multiple bool) (*model, chan askAnswer) {
+	m := compactCmdModel()
+	reply := make(chan askAnswer, 1)
+	m.askDialog = &askDialog{
+		req: tools.AskRequest{
+			Question: "Which planner?",
+			Options:  []tools.AskOption{{Label: "fable (Recommended)", Description: "default"}, {Label: "opus"}, {Label: "gpt-5.6-sol"}},
+			Multiple: multiple,
+		},
+		reply: reply, picked: map[int]bool{},
+	}
+	return m, reply
+}
+
+func TestQuestionNumberPicks(t *testing.T) {
+	m, reply := newAskModel(false)
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("3")})
+	got := <-reply
+	if !got.ok || len(got.answers) != 1 || got.answers[0] != "gpt-5.6-sol" {
+		t.Fatalf("got %+v", got)
+	}
+	if m.askDialog != nil {
+		t.Fatal("dialog should close after a pick")
+	}
+}
+
+func TestQuestionCustomAndMulti(t *testing.T) {
+	// custom row: arrow to the last row, enter, type, enter
+	m, reply := newAskModel(false)
+	m.askKey(tea.KeyMsg{Type: tea.KeyUp}) // wraps to the custom row
+	m.askKey(tea.KeyMsg{Type: tea.KeyEnter})
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("grok")})
+	m.askKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := <-reply; !got.ok || got.answers[0] != "grok" {
+		t.Fatalf("custom: got %+v", got)
+	}
+
+	// multi: toggle 1 and 2, enter submits both
+	m, reply = newAskModel(true)
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")})
+	m.askKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")})
+	m.askKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := <-reply; !got.ok || len(got.answers) != 2 {
+		t.Fatalf("multi: got %+v", got)
+	}
+
+	// esc dismisses
+	m, reply = newAskModel(false)
+	m.askKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if got := <-reply; got.ok {
+		t.Fatalf("esc: got %+v", got)
+	}
+}

--- a/internal/tui/question_test.go
+++ b/internal/tui/question_test.go
@@ -74,3 +74,14 @@ func TestQuestionCustomAndMulti(t *testing.T) {
 		t.Fatalf("esc: got %+v", got)
 	}
 }
+
+// ctrl+c dismisses the question and interrupts the turn.
+func TestQuestionCtrlCInterrupts(t *testing.T) {
+	m, reply := newAskModel(false)
+	cancelled := false
+	m.busy, m.cancel = true, func() { cancelled = true }
+	m.askKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if got := <-reply; got.ok || !cancelled || m.askDialog != nil {
+		t.Fatalf("got %+v cancelled=%v", got, cancelled)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -246,6 +246,7 @@ type model struct {
 
 	perms      permRules   // saved allow-always rules
 	permDialog *permDialog // open permission modal; the turn is paused on it
+	askDialog  *askDialog  // open question modal; the turn is paused on it
 
 	tasksFocus bool      // the tasks dock owns ↑/↓/enter (never esc); typing or ↑ past the top returns to the input
 	taskSel    int       // selected row in the dock (index into newest-first tasks)
@@ -430,6 +431,7 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 	// Permission prompts are opt-in (--cautious); without it tools run free.
 	if cautious {
 		m.installPermGate()
+		m.installAskHook()
 	}
 	if dir, derr := config.Dir(); derr == nil {
 		if st, serr := session.Open(dir + "/sessions.db"); serr == nil {
@@ -1733,6 +1735,9 @@ func (m *model) layout() {
 	if m.iactive != nil {
 		chrome += lipgloss.Height(m.interactiveView()) + 1
 	}
+	if m.askDialog != nil {
+		chrome += lipgloss.Height(m.askView()) + 1
+	}
 	if m.permDialog != nil {
 		chrome += lipgloss.Height(m.permView()) + 1 // viewBody emits "\n"+permView(); unbudgeted it clips the alt-screen frame and shifts mouse rows
 	}
@@ -1897,6 +1902,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case permRequest:
 		m.permDialog = &permDialog{req: msg.req, reply: msg.reply}
+		return m, nil
+
+	case askRequest:
+		m.askDialog = &askDialog{req: msg.req, reply: msg.reply, picked: map[int]bool{}}
 		return m, nil
 
 	case selScrollTick:
@@ -2542,6 +2551,10 @@ func (m *model) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// a single esc to the child (many prompts use esc to cancel).
 	if m.iactive != nil {
 		return m.iactiveKey(msg)
+	}
+	if m.askDialog != nil {
+		m.askKey(msg)
+		return m, nil
 	}
 	if m.permDialog != nil {
 		m.permKey(msg)
@@ -4444,6 +4457,9 @@ func (m *model) viewBody() string {
 	}
 	if m.permDialog != nil {
 		b.WriteString("\n" + m.permView() + "\n")
+	}
+	if m.askDialog != nil {
+		b.WriteString("\n" + m.askView() + "\n")
 	}
 	if m.busy && m.uiMode != opencodeMode { // opencode mode: the status bar carries the spinner + esc hint
 		hint := " thinking… (enter queues · /theme /mouse /effort run now · esc interrupts · ctrl+c ctrl+c interrupts)"

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -428,10 +428,10 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 	// computer-use: the per-app consent prompt — installed once, here, where
 	// the model exists (buildAgent is package-level and has no m).
 	tools.ComputerApprover = m.computerConsent
+	m.installAskHook() // the question tool always needs a user; nil Ask = tool errors
 	// Permission prompts are opt-in (--cautious); without it tools run free.
 	if cautious {
 		m.installPermGate()
-		m.installAskHook()
 	}
 	if dir, derr := config.Dir(); derr == nil {
 		if st, serr := session.Open(dir + "/sessions.db"); serr == nil {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1908,6 +1908,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.askDialog = &askDialog{req: msg.req, reply: msg.reply, picked: map[int]bool{}}
 		return m, nil
 
+	case askClose:
+		if m.askDialog != nil && m.askDialog.reply == msg.reply {
+			m.askDialog = nil
+		}
+		return m, nil
+
 	case selScrollTick:
 		// drag parked past the viewport edge: keep scrolling + extending the
 		// selection until the drag ends or the viewport hits its limit


### PR DESCRIPTION
## Summary
- New `question` tool: the model asks the user to pick from 2-6 options (label + description, optional `multiple`), or type their own answer. Mirrors opencode's question tool, cut to one question per call.
- TUI modal in `internal/tui/question.go`: numbered rows, dim descriptions, arrows/j/k/1-9, enter picks, space toggles in multi mode, esc dismisses (model is told).
- Wired like the permission gate: `tools.Ask` hook, channel hand-off, tool goroutine blocks until the UI answers.
- Registered for the main agent only; subagents and the MCP server keep the plain tool set.

## Test plan
- [x] `go test ./internal/tui -run Question` (number pick, custom answer, multi, esc)
- [x] build, vet, golangci-lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)