### PR TITLE
feat(run): stamp prompt_cache_key so headless runs cache their prefix

### DIFF
--- a/cmd/whip/cachekey_test.go
+++ b/cmd/whip/cachekey_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestResolveCacheKey(t *testing.T) {
+	if got := resolveCacheKey("repo/reviewer", "sess"); got != "repo/reviewer" {
+		t.Fatalf("explicit key must win, got %q", got)
+	}
+	if got := resolveCacheKey("", "sess"); got != "sess" {
+		t.Fatalf("session id is the fallback, got %q", got)
+	}
+	got := resolveCacheKey("", "")
+	if len(got) < 5 || got[:4] != "run-" {
+		t.Fatalf("no session/key must yield a per-run key, got %q", got)
+	}
+	if resolveCacheKey("", "") == got {
+		t.Fatal("per-run keys must differ between runs")
+	}
+}

--- a/cmd/whip/run.go
+++ b/cmd/whip/run.go
@@ -9,6 +9,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -27,6 +29,27 @@ import (
 	"github.com/context-labs/whip/internal/tui"
 )
 
+// resolveCacheKey picks the prompt_cache_key for a run: an explicit -cache-key
+// wins; otherwise the session id (stable per resumable session); otherwise a
+// fresh per-run key so a one-off (-no-session) run still caches its own turns.
+func resolveCacheKey(explicit, sessionID string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if sessionID != "" {
+		return sessionID
+	}
+	return "run-" + randHex(8)
+}
+
+func randHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "run"
+	}
+	return hex.EncodeToString(b)
+}
+
 func runCLI(args []string) error {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	format := fs.String("format", "text", "output format: text (stream the reply) or json (newline-delimited event stream)")
@@ -39,6 +62,7 @@ func runCLI(args []string) error {
 	timeoutFlag := fs.Duration("timeout", 0, "wall-clock cap on the whole run (e.g. 30s, 5m); 0 = no timeout")
 	quietFlag := fs.Bool("quiet", false, "suppress the stderr tool/session notes (clean stdout for -format json piping)")
 	noSessionFlag := fs.Bool("no-session", false, "run without persisting a session (one-off jobs don't clutter whip sessions)")
+	cacheKeyFlag := fs.String("cache-key", "", "prompt_cache_key for provider prefix caching; defaults to the session id, else a per-run key. Pass a STABLE value (e.g. repo/reviewer) to reuse the cached system prefix across runs.")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: whip run [--format text|json] [-m model] [-p provider] [-resume id] [-system text | -system-file path] [-max-turns N] [-timeout dur] [-quiet] [-no-session] \"prompt\"")
 		fs.PrintDefaults()
@@ -150,6 +174,12 @@ func runCLI(args []string) error {
 			}
 		}
 	}
+
+	// Prompt-cache key: stamped as prompt_cache_key so the provider caches the
+	// message prefix across turns (and across runs when the caller passes a
+	// stable key). -no-session left this empty, so headless runs never cached
+	// their own turns — a per-run fallback fixes that; subagents scope under it.
+	ag.Client.CacheKey = resolveCacheKey(*cacheKeyFlag, sessionID)
 
 	// ctrl+c cancels the turn; -timeout caps the whole run.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -340,9 +340,15 @@ func (a *Agent) RegisterBackground(description, prompt string, o SubModel) *Back
 	sub := a.newSub(o)
 	// Scope the subagent's prompt-cache key to the task so its shorter,
 	// churning context never disturbs the parent's cached prefix (and two
-	// concurrent subagents don't collide on the session key).
-	if sid := a.SessionIDValue(); sid != "" {
-		sub.Client.CacheKey = sid + "/" + id
+	// concurrent subagents don't collide on the key). Prefer the session id;
+	// fall back to the parent's cache key so subagents still cache on a
+	// -no-session run (where the session id is empty).
+	scope := a.SessionIDValue()
+	if scope == "" && a.Client != nil {
+		scope = a.Client.CacheKey
+	}
+	if scope != "" {
+		sub.Client.CacheKey = scope + "/" + id
 	}
 	t := &BackgroundTask{
 		ID: id, Description: description, Prompt: prompt,


### PR DESCRIPTION
## Why
Profiling loupe's inference showed **`cachedInputTokens = 0`** on ~250k-input agentic turns — every turn re-sent the full growing prefix at **full input price** (~10× the cached rate). Root cause: `whip run` never sets the client cache key. With `-no-session` the session id is empty → `prompt_cache_key` omitted → the provider caches nothing.

## What
- `resolveCacheKey`: explicit **`-cache-key`** wins → else the session id → else a fresh **per-run** key. A per-run key alone enables **within-run** turn-over-turn caching (turns 2…N reuse the cached prefix); a stable `-cache-key` (e.g. `repo/reviewer`) also caches the **system prefix across runs**.
- Background subagents fall back to the parent's cache key when there's no session, so they cache too (scoped per task so concurrent subagents don't collide).

Pure cost win — no behavior change beyond enabling caching. `go build`/`vet`/`test` green.