### PR TITLE
chore(loupe): bump whip to v0.5.5 (prompt caching)

### DIFF
--- a/.github/workflows/whip--loupe-chat.yml
+++ b/.github/workflows/whip--loupe-chat.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
-  WHIP_VERSION: "v0.5.4"
+  WHIP_VERSION: "v0.5.5"
 
 jobs:
   chat:

--- a/.github/workflows/whip--loupe-review.yml
+++ b/.github/workflows/whip--loupe-review.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   INFISICAL_IDENTITY_ID: "46f034e9-14e7-49ad-b3f7-f0d8ad8a989f" # Github-Ci
-  WHIP_VERSION: "v0.5.4"
+  WHIP_VERSION: "v0.5.5"
 
 jobs:
   loupe:


### PR DESCRIPTION
Bumps the loupe workflows to whip **v0.5.5**, which stamps a prompt_cache_key so runs cache their prefix (input tokens were fully uncached before). Pure cost reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)