### PR TITLE
fix(tui,config): loupe follow-ups from #106 — scrolled dock click math, +N-more hitbox, kitty push on /ui toggle, settle race, template defaults

### DIFF
--- a/internal/agent/background.go
+++ b/internal/agent/background.go
@@ -403,8 +403,12 @@ func (a *Agent) launchBackground(t *BackgroundTask) {
 			status, text = TaskError, err.Error()
 		}
 		// Snapshot the transcript BEFORE settle: settle fires OnRecord (which
-		// persists SubMessages), so it must be populated first.
+		// persists SubMessages), so it must be populated first. Under the
+		// registry lock: List copies *t under it, and the dock calls List on
+		// every Update, so an unlocked write here is a live data race.
+		a.bg.mu.Lock()
 		t.SubMessages = t.sub.MessagesSnapshot()
+		a.bg.mu.Unlock()
 		a.bg.settle(id, status, text)
 		// subscribers stop here; late events after settle go nowhere (Subscribe
 		// rejects non-running tasks, and settled state is visible via List/Get)

--- a/internal/agent/parallel_test.go
+++ b/internal/agent/parallel_test.go
@@ -428,7 +428,7 @@ func TestBackgroundTaskSubscriberSeesToolEvents(t *testing.T) {
 
 	var mu sync.Mutex
 	var seq []string
-	_, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{
+	replay, _, ok := ag.Tasks().SubscribeWithJournal(task.ID, Events{
 		OnText:      func(s string) { mu.Lock(); seq = append(seq, "text:"+s); mu.Unlock() },
 		OnToolStart: func(_, n, _ string) { mu.Lock(); seq = append(seq, "start:"+n); mu.Unlock() },
 		OnToolEnd:   func(_, n, r string) { mu.Lock(); seq = append(seq, "end:"+n+":"+r); mu.Unlock() },
@@ -436,6 +436,21 @@ func TestBackgroundTaskSubscriberSeesToolEvents(t *testing.T) {
 	if !ok {
 		t.Fatal("SubscribeWithJournal on a running task should report live")
 	}
+	// A subscriber sees the stream as journal replay + live events: whatever
+	// fired before the subscription attached is in replay (the sub may have
+	// already run its tool by now on a loaded CI box), the rest arrives live.
+	mu.Lock()
+	for _, e := range replay {
+		switch e.Kind {
+		case 0:
+			seq = append(seq, "text:"+e.S)
+		case 1:
+			seq = append(seq, "start:"+e.S)
+		case 2:
+			seq = append(seq, "end:"+e.S+":"+e.S2)
+		}
+	}
+	mu.Unlock()
 	select {
 	case <-task.Done:
 	case <-time.After(5 * time.Second):

--- a/internal/config/secret.go
+++ b/internal/config/secret.go
@@ -40,7 +40,7 @@ func ResolveSecret(v string) (string, error) {
 			if val := os.Getenv(key); val != "" {
 				return val, nil
 			}
-			return os.Expand(def, os.Getenv), nil
+			return ExpandTemplate(def) // the default may reference vars; unset ones error, never silently empty
 		}
 		if key, def, found := strings.Cut(name, "-"); found {
 			if !isEnvName(key) {
@@ -49,7 +49,7 @@ func ResolveSecret(v string) (string, error) {
 			if _, ok := os.LookupEnv(key); ok {
 				return os.Getenv(key), nil
 			}
-			return os.Expand(def, os.Getenv), nil
+			return ExpandTemplate(def) // the default may reference vars; unset ones error, never silently empty
 		}
 		if val := os.Getenv(name); val != "" {
 			return val, nil

--- a/internal/config/secret_test.go
+++ b/internal/config/secret_test.go
@@ -256,3 +256,22 @@ func TestResolveHeader(t *testing.T) {
 		t.Errorf("literal = %q, %v", got, err)
 	}
 }
+
+// A whole-ref default that itself references an unset variable must error,
+// not resolve to "" — the empty value would spawn KEY= (env) or send an empty
+// header, the masking bug lazy resolution exists to remove.
+func TestResolveSecretDefaultUnsetInnerVarErrors(t *testing.T) {
+	t.Setenv("WHIP_OUTER_UNSET", "")
+	os.Unsetenv("WHIP_OUTER_UNSET")
+	os.Unsetenv("WHIP_INNER_UNSET")
+	for _, v := range []string{"${WHIP_OUTER_UNSET:-$WHIP_INNER_UNSET}", "${WHIP_OUTER_UNSET-$WHIP_INNER_UNSET}"} {
+		if got, err := ResolveSecret(v); err == nil {
+			t.Errorf("ResolveSecret(%q) = %q, want error for the unset inner var", v, got)
+		}
+	}
+	// a resolvable inner var still expands
+	t.Setenv("WHIP_INNER_SET", "inner")
+	if got, err := ResolveSecret("${WHIP_OUTER_UNSET:-$WHIP_INNER_SET}"); err != nil || got != "inner" {
+		t.Errorf("default with a set inner var = %q, %v; want inner", got, err)
+	}
+}

--- a/internal/tui/opencode.go
+++ b/internal/tui/opencode.go
@@ -1136,10 +1136,19 @@ func (m *model) setUIMode(mode string) tea.Cmd {
 	}
 	m.refreshVP()
 	m.append(dimStyle.Render("◐ ui mode: " + uiModeLabel(mode)))
+	// The kitty keyboard stack is per-screen, so the push whip made at startup
+	// does not follow the alt-screen switch: re-push AFTER the switch lands
+	// (terminalInitMsg, the same path Init uses) or shift+enter silently dies
+	// for the rest of the session. Entering the alt screen from inline first
+	// pops the main screen's entry so the stack stays balanced for the pop
+	// Run does on exit; leaving it re-pushes on main for that same pop.
 	if mode == opencodeMode {
-		return tea.EnterAltScreen
+		if tuiRunning {
+			disableKeyboardEnhancement(os.Stdout)
+		}
+		return tea.Sequence(tea.EnterAltScreen, func() tea.Msg { return terminalInitMsg{} })
 	}
-	return tea.ExitAltScreen
+	return tea.Sequence(tea.ExitAltScreen, func() tea.Msg { return terminalInitMsg{} })
 }
 
 // uiModeLabel is the display name for a UI mode value.

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -216,6 +216,7 @@ func (m *model) tasksDock() string {
 	hi = max(hi, min(lo+1, len(tasks))) // always show at least the selected task
 
 	m.dockOffsets = m.dockOffsets[:0]
+	m.dockLo = lo
 	offset := 0
 	for i := lo; i < hi; i++ {
 		t := tasks[i]
@@ -252,6 +253,7 @@ func (m *model) tasksDock() string {
 			}
 		}
 	}
+	m.dockTaskRows = offset
 	if more := len(tasks) - hi; more > 0 {
 		rows = append(rows, dimStyle.Render(fmt.Sprintf("   … +%d more (ctrl+t to browse)", more)))
 	}

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -1028,3 +1028,46 @@ func TestDockTaskExpandContent(t *testing.T) {
 		t.Fatalf("unknown id expands to nothing, got %q", got)
 	}
 }
+
+// With the dock scrolled (selection past the visible window), dockOffsets are
+// window-relative: a click must map through the window base to the displayed
+// task, not to the newest one. And the trailing "+N more" counter row is not
+// a task — clicking it must not move the selection.
+func TestDockClickMapsThroughScrollWindow(t *testing.T) {
+	srv := sseTextServer(t, "ok")
+	defer srv.Close()
+	m := tasksModel(srv.URL)
+	for i := range 8 {
+		tk := m.agent.StartBackground(fmt.Sprintf("probe-%d", i), "p", agent.SubModel{})
+		defer m.agent.Tasks().Cancel(tk.ID)
+	}
+	m.tasksFocus = true
+	m.taskSel = 6 // scrolls the window so lo > 0
+	m.layout()
+	if m.dockLo == 0 {
+		t.Fatalf("test setup: selection 6 should scroll the window, dockLo=%d", m.dockLo)
+	}
+	lo := m.dockLo
+	top := m.dockTop()
+
+	click := func(y int) {
+		tm, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 5, Y: y})
+		m = tm.(*model)
+	}
+	// the top visible row is task lo, not task 0
+	click(top)
+	if m.taskSel != lo {
+		t.Fatalf("clicking the top visible row should select task %d (window base), got %d", lo, m.taskSel)
+	}
+	// the "+N more" row sits right after the task rows: a click there is inert
+	m.layout()
+	before := m.taskSel
+	dock := stripAll(m.tasksDock())
+	if !strings.Contains(dock, "more") {
+		t.Fatalf("test setup: dock should show the +N more counter, got %q", dock)
+	}
+	click(m.dockTop() + m.dockTaskRows)
+	if m.taskSel != before {
+		t.Fatalf("clicking the +N more row must not change the selection: %d → %d", before, m.taskSel)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -253,7 +253,9 @@ type model struct {
 	taskSel      int       // selected row in the dock (index into newest-first tasks)
 	taskExpanded bool      // selected dock row renders its recent activity inline (space/click toggles)
 	dockSkip     int       // non-task rows at the dock's top (focused hint) — click math skips them
-	dockOffsets  []int     // screen-row offset of each task row within the strip (expanded rows shift rows below)
+	dockOffsets  []int     // screen-row offset of each VISIBLE task row within the strip (expanded rows shift rows below)
+	dockLo       int       // index (into newest-first tasks) of the first visible dock row: dockOffsets[i] is task dockLo+i
+	dockTaskRows int       // strip rows occupied by task rows (incl. expansion); rows at/after this are the "+N more" counter
 	taskVP       *taskView // open per-task detail view; nil when on the main thread
 	dockRows     int       // rendered dock height; layout() maintains it for click math
 
@@ -2031,15 +2033,18 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	switch msg := msg.(type) {
 	case terminalInitMsg:
-		// Alt screen is up by now (Init commands run after the renderer
-		// starts), so these stick: the kitty keyboard-enhancement push goes on
-		// the alt screen's fresh kitty stack (per-screen), and the mouse
-		// enables survive because they're written after ?1049h cleared them.
+		// The screen switch (?1049h from Init or a runtime /ui toggle, ?1049l
+		// from a toggle back) has landed by now, so these stick: the kitty
+		// keyboard-enhancement push goes on the CURRENT screen's stack
+		// (per-screen), and the mouse enables survive because they're written
+		// after the switch cleared them.
 		enableKeyboardEnhancement(os.Stdout)
 		if m.mouseOn {
-			// all-motion tracking (?1003, a superset of ?1002) so passive mouse
-			// moves drive opencode's hover highlight on message cards
-			fmt.Fprint(os.Stdout, "\x1b[?1003h")
+			if m.uiMode == opencodeMode {
+				// all-motion tracking (?1003, a superset of ?1002) so passive
+				// mouse moves drive opencode's hover highlight on message cards
+				fmt.Fprint(os.Stdout, "\x1b[?1003h")
+			}
 			enableClickWheelMouse(os.Stdout)
 		}
 		return m, nil
@@ -2221,11 +2226,18 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
 					if m.tasksFocus && len(m.dockOffsets) > 0 {
 						row := msg.Y - top
-						// find the last task row whose offset is at/above the click
+						if row >= m.dockTaskRows {
+							// the trailing "… +N more" counter is not a task:
+							// don't let a click on it select the last visible row
+							return m, nil
+						}
+						// find the last visible task row whose offset is at/above
+						// the click; offsets are window-relative, so add the
+						// window base to get the absolute task index
 						sel := m.taskSel
 						for i, off := range m.dockOffsets {
 							if off <= row {
-								sel = i
+								sel = m.dockLo + i
 							}
 						}
 						m.taskSel = min(sel, n-1)


### PR DESCRIPTION
Follow-up to #106, which merged before these review fixes landed on its branch. Addresses the open loupe findings there (three inline comments + two concerns in the last review):

- **Dock click math dropped the scroll window** (🔴). `dockOffsets` are window-relative; the click now maps through the window base (`dockLo`) so a scrolled dock selects the displayed task, not the newest. Pinned by `TestDockClickMapsThroughScrollWindow`.
- **`… +N more` counter row was clickable** (🟡). `tasksDock` records `dockTaskRows`; clicks at or past it are inert.
- **Runtime `/ui` toggle lost the kitty keyboard push** (🟡). `setUIMode` returns `tea.Sequence(Enter/ExitAltScreen, terminalInitMsg)` so the push and mouse enables re-apply after the screen switch lands, on the current screen's stack. Entering the alt screen from inline pops the main-screen entry first so Run's exit pop stays balanced; leaving re-pushes on main. `terminalInitMsg` only arms `?1003h` in opencode mode.
- **Settle-path data race** (🟡). `SubMessages` is now snapshotted under the registry lock; `List` copies `*t` under it on every dock redraw.
- **Whole-ref defaults with an unset inner var resolved to empty** (🟡). `ResolveSecret`'s `${A:-$B}` / `${A-$B}` branches now go through `ExpandTemplate`, so an unset `$B` errors instead of spawning `KEY=` or sending an empty header. Pinned by `TestResolveSecretDefaultUnsetInnerVarErrors`.

Not changed: the tmux extended-keys restore concern is moot — the branch deliberately never restores it (see `tmuxEnableExtendedKeys`). `go test ./internal/config` passes here with both real and isolated `HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)