### PR TITLE
fix(tui): wrap question title and option descriptions

### DIFF
--- a/internal/tui/question.go
+++ b/internal/tui/question.go
@@ -176,7 +176,8 @@ func (m *model) askView() string {
 	if d.req.Multiple {
 		title += " (select all that apply)"
 	}
-	b.WriteString(youStyle.Render("? " + title))
+	w := max(m.width, 8)
+	b.WriteString(youStyle.Render(wrap("? "+title, w)))
 	for i, o := range d.req.Options {
 		mark := ""
 		if d.req.Multiple {
@@ -192,7 +193,7 @@ func (m *model) askView() string {
 			b.WriteString("\n  " + row)
 		}
 		if o.Description != "" {
-			b.WriteString("\n" + dimStyle.Render("     "+o.Description))
+			b.WriteString("\n" + dimStyle.Render("     "+strings.ReplaceAll(wrap(o.Description, w-5), "\n", "\n     ")))
 		}
 	}
 	custom := strconv.Itoa(len(d.req.Options)+1) + ". type your own answer"


### PR DESCRIPTION
The question modal rendered the title as one unbroken line, so long questions were clipped at the terminal edge (see `askView` in `internal/tui/question.go`). Option descriptions had the same latent issue.

Fix: wrap title and descriptions to `m.width` using the existing `wrap` helper. Height accounting already goes through `askView`, so layout picks up the extra lines.

Question tests pass. The two `TestStartupReport*` failures in the package are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)