### PR TITLE
fix(mcp): codex tool-approval tables + bearer_token_env_var; add whip skills import

### DIFF
--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -107,6 +107,16 @@ func main() {
 		return
 	}
 
+	// `whip skills ...` — list and import SKILL.md skills (incl. from other
+	// harnesses' dirs, deduped against what whip already loads).
+	if flag.NArg() > 0 && flag.Arg(0) == "skills" {
+		if err := skillsCLI(flag.Args()[1:]); err != nil {
+			fmt.Fprintln(os.Stderr, "whip:", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// `whip run ...` — non-interactive one-turn mode for scripting; no TTY or
 	// trust prompt required (headless use implies trusted automation).
 	// `whip acp` — ACP agent over stdio for editors (Zed et al.).

--- a/cmd/whip/skills.go
+++ b/cmd/whip/skills.go
@@ -122,6 +122,15 @@ func skillsImportCLI(args []string) error {
 	}
 	var imported, failed []string
 	for _, c := range importable {
+		// The frontmatter name becomes the destination directory. A spec-
+		// invalid name with path separators (../, ../../pwned) would escape
+		// ~/.agents/skills — validate() only warns, so enforce it here: the
+		// name must be a single path component matching the spec regex.
+		if filepath.Base(c.name) != c.name || !skills.ValidName(c.name) {
+			fmt.Fprintf(os.Stderr, "✗ %-24s invalid skill name %q (path traversal guard)\n", c.name, c.name)
+			failed = append(failed, c.name)
+			continue
+		}
 		dst := filepath.Join(dest, c.name)
 		if err := copyDir(c.srcDir, dst); err != nil {
 			// One bad skill (a symlink loop, an unreadable file) must not
@@ -146,11 +155,12 @@ func skillsImportCLI(args []string) error {
 	return nil
 }
 
-// copyDir recursively copies src into dst (created if missing). Symlinks are
-// followed (an imported skill should be real files, not a link back into
-// another harness's dir). Destination must not already exist — the dedup
-// pass guarantees the name is free, and refusing to clobber keeps a racing
-// user edit safe.
+// copyDir recursively copies src into dst (created if missing). os.ReadDir's
+// IsDir is lstat-based, so a symlinked subdirectory falls through to copyFile
+// and fails with EISDIR — symlinked dirs are not importable (documented, not
+// silently half-copied). Destination must not already exist — the dedup pass
+// guarantees the name is free, and refusing to clobber keeps a racing user
+// edit safe.
 func copyDir(src, dst string) error {
 	info, err := os.Stat(src)
 	if err != nil {

--- a/cmd/whip/skills.go
+++ b/cmd/whip/skills.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/context-labs/whip/internal/skills"
+)
+
+// skillsCLI implements `whip skills <list|import>`.
+//
+//	list                    skill names, descriptions, and where they load from
+//	import [--dry-run]      copy skills from other harnesses' dirs (codex,
+//	                        claude-code) into ~/.agents/skills, skipping
+//	                        anything whip already has
+//
+// Skills are directories with a SKILL.md, so "import" is a recursive copy.
+// Dedup is by skill name: a name present in any of whip's dirs (project
+// .agents/skills, ~/.whip/skills, ~/.agents/skills) is never overwritten —
+// the repo-level copy always wins at scan time too, so copying over a
+// user-level skill would silently shadow nothing and confuse everyone.
+func skillsCLI(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: whip skills <list|import>")
+	}
+	switch args[0] {
+	case "list":
+		return skillsListCLI()
+	case "import":
+		return skillsImportCLI(args[1:])
+	default:
+		return fmt.Errorf("unknown skills subcommand %q (list|import)", args[0])
+	}
+}
+
+func skillsListCLI() error {
+	dirs := skills.DefaultDirs()
+	sk, problems := skills.ScanDetailed(dirs...)
+	if len(sk) == 0 && len(problems) == 0 {
+		fmt.Println("no skills found (looked in: " + strings.Join(dirs, ", ") + ")")
+		return nil
+	}
+	for _, s := range sk {
+		warn := ""
+		if s.Warning != "" {
+			warn = " ⚠ " + s.Warning
+		}
+		fmt.Printf("%-24s %s%s\n", s.Name, filepath.Dir(filepath.Dir(s.Path)), warn)
+	}
+	for _, p := range problems {
+		fmt.Fprintf(os.Stderr, "skills: %s: %s\n", p.Path, p.Err)
+	}
+	return nil
+}
+
+func skillsImportCLI(args []string) error {
+	dryRun := false
+	for _, a := range args {
+		if a == "--dry-run" {
+			dryRun = true
+		} else {
+			return errors.New("usage: whip skills import [--dry-run]")
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	dest := filepath.Join(home, ".agents", "skills")
+
+	// Names whip already loads (project + user dirs) are the dedup set.
+	existing := map[string]bool{}
+	for _, s := range skills.Scan(skills.DefaultDirs()...) {
+		existing[s.Name] = true
+	}
+
+	type candidate struct {
+		name, srcDir string
+	}
+	var importable, skipped []candidate
+	for _, dir := range skills.ForeignDirs() {
+		for _, s := range skills.Scan(dir) {
+			c := candidate{name: s.Name, srcDir: filepath.Dir(s.Path)}
+			// One check dedups both against whip's existing skills and across
+			// the foreign sources themselves (first dir — codex — wins over
+			// claude for a duplicate name): the claim lands in existing.
+			if existing[s.Name] {
+				skipped = append(skipped, c)
+				continue
+			}
+			existing[s.Name] = true
+			importable = append(importable, c)
+		}
+	}
+
+	if len(importable) == 0 && len(skipped) == 0 {
+		fmt.Println("nothing found to import (looked in: " + strings.Join(skills.ForeignDirs(), ", ") + ")")
+		return nil
+	}
+	sort.Slice(skipped, func(i, j int) bool { return skipped[i].name < skipped[j].name })
+	for _, c := range skipped {
+		fmt.Printf("○ %-24s already present — leaving %s alone\n", c.name, c.srcDir)
+	}
+	if len(importable) == 0 {
+		fmt.Println("nothing new to import")
+		return nil
+	}
+
+	sort.Slice(importable, func(i, j int) bool { return importable[i].name < importable[j].name })
+	if dryRun {
+		fmt.Printf("would import %d skill(s) into %s:\n", len(importable), dest)
+		for _, c := range importable {
+			fmt.Printf("  %-24s from %s\n", c.name, c.srcDir)
+		}
+		return nil
+	}
+	for _, c := range importable {
+		dst := filepath.Join(dest, c.name)
+		if err := copyDir(c.srcDir, dst); err != nil {
+			return fmt.Errorf("import %s: %w", c.name, err)
+		}
+		fmt.Printf("✓ %-24s → %s\n", c.name, dst)
+	}
+	fmt.Printf("imported %d skill(s) into %s — available on next whip launch\n", len(importable), dest)
+	return nil
+}
+
+// copyDir recursively copies src into dst (created if missing). Symlinks are
+// followed (an imported skill should be real files, not a link back into
+// another harness's dir). Destination must not already exist — the dedup
+// pass guarantees the name is free, and refusing to clobber keeps a racing
+// user edit safe.
+func copyDir(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", src)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("%s already exists", dst)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		s := filepath.Join(src, e.Name())
+		d := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := copyDir(s, d); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := copyFile(s, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src) //nolint:gosec // G304: copying the caller-chosen skill dir is the function's contract
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}

--- a/cmd/whip/skills.go
+++ b/cmd/whip/skills.go
@@ -120,14 +120,26 @@ func skillsImportCLI(args []string) error {
 		}
 		return nil
 	}
+	var imported, failed []string
 	for _, c := range importable {
 		dst := filepath.Join(dest, c.name)
 		if err := copyDir(c.srcDir, dst); err != nil {
-			return fmt.Errorf("import %s: %w", c.name, err)
+			// One bad skill (a symlink loop, an unreadable file) must not
+			// abort the rest of the import — and a partial copy must not
+			// linger as a broken skill (and block a future import via the
+			// dedup pass). Remove the half-written destination and continue.
+			os.RemoveAll(dst)
+			fmt.Fprintf(os.Stderr, "✗ %-24s %v\n", c.name, err)
+			failed = append(failed, c.name)
+			continue
 		}
 		fmt.Printf("✓ %-24s → %s\n", c.name, dst)
+		imported = append(imported, c.name)
 	}
-	fmt.Printf("imported %d skill(s) into %s — available on next whip launch\n", len(importable), dest)
+	fmt.Printf("imported %d skill(s) into %s — available on next whip launch\n", len(imported), dest)
+	if len(failed) > 0 {
+		return fmt.Errorf("%d skill(s) failed to copy: %s", len(failed), strings.Join(failed, ", "))
+	}
 	return nil
 }
 

--- a/cmd/whip/skills.go
+++ b/cmd/whip/skills.go
@@ -132,14 +132,22 @@ func skillsImportCLI(args []string) error {
 			continue
 		}
 		dst := filepath.Join(dest, c.name)
+		// Only clean up a partial copy when copyDir actually created dst. A
+		// pre-existing user folder at dst (e.g. ~/.agents/skills/notes with no
+		// SKILL.md) makes copyDir return "already exists" without writing —
+		// removing it would be data loss.
+		_, statErr := os.Stat(dst)
+		dstPreExisted := statErr == nil
 		if err := copyDir(c.srcDir, dst); err != nil {
 			// One bad skill (a symlink loop, an unreadable file) must not
 			// abort the rest of the import — and a partial copy must not
 			// linger as a broken skill (and block a future import via the
-			// dedup pass). Remove the half-written destination and continue;
-			// a cleanup failure is logged but doesn't mask the copy error.
-			if rmErr := os.RemoveAll(dst); rmErr != nil {
-				fmt.Fprintf(os.Stderr, "  (cleanup of partial copy failed: %v)\n", rmErr)
+			// dedup pass). Remove only the half-written destination copyDir
+			// created; a cleanup failure is logged but doesn't mask the error.
+			if !dstPreExisted {
+				if rmErr := os.RemoveAll(dst); rmErr != nil {
+					fmt.Fprintf(os.Stderr, "  (cleanup of partial copy failed: %v)\n", rmErr)
+				}
 			}
 			fmt.Fprintf(os.Stderr, "✗ %-24s %v\n", c.name, err)
 			failed = append(failed, c.name)

--- a/cmd/whip/skills.go
+++ b/cmd/whip/skills.go
@@ -147,7 +147,7 @@ func copyDir(src, dst string) error {
 	if _, err := os.Stat(dst); err == nil {
 		return fmt.Errorf("%s already exists", dst)
 	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+	if err := os.MkdirAll(dst, 0o750); err != nil { // 0o750: imported skills are user config, not world-readable (gosec G301)
 		return err
 	}
 	entries, err := os.ReadDir(src)
@@ -180,7 +180,7 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm()) //nolint:gosec // G304: dst is inside whip's own ~/.agents/skills (validated by the dedup pass)
 	if err != nil {
 		return err
 	}

--- a/cmd/whip/skills.go
+++ b/cmd/whip/skills.go
@@ -127,8 +127,11 @@ func skillsImportCLI(args []string) error {
 			// One bad skill (a symlink loop, an unreadable file) must not
 			// abort the rest of the import — and a partial copy must not
 			// linger as a broken skill (and block a future import via the
-			// dedup pass). Remove the half-written destination and continue.
-			os.RemoveAll(dst)
+			// dedup pass). Remove the half-written destination and continue;
+			// a cleanup failure is logged but doesn't mask the copy error.
+			if rmErr := os.RemoveAll(dst); rmErr != nil {
+				fmt.Fprintf(os.Stderr, "  (cleanup of partial copy failed: %v)\n", rmErr)
+			}
 			fmt.Fprintf(os.Stderr, "✗ %-24s %v\n", c.name, err)
 			failed = append(failed, c.name)
 			continue

--- a/cmd/whip/skills_test.go
+++ b/cmd/whip/skills_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/context-labs/whip/internal/skills"
 )
 
 // writeSkill plants a minimal valid skill at <root>/<name>/SKILL.md.
@@ -103,5 +105,66 @@ func TestSkillsImportNothingToDo(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := skillsCLI([]string{"import"}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestSkillsListCLI: `whip skills list` renders loaded skills and their
+// source dirs without error.
+func TestSkillsListCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+	writeSkill(t, filepath.Join(home, ".agents", "skills"), "linear", "whip's copy")
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "cloudflare", "claude copy")
+
+	if err := skillsCLI([]string{"list"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSkillsCLIUnknownSubcommand: an unknown subcommand errors clearly.
+func TestSkillsCLIUnknownSubcommand(t *testing.T) {
+	if err := skillsCLI([]string{"nope"}); err == nil {
+		t.Error("expected error for unknown subcommand")
+	}
+}
+
+// TestSkillsForeignDirs: the foreign skill dirs point at codex and claude.
+func TestSkillsForeignDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dirs := skills.ForeignDirs()
+	if len(dirs) != 2 {
+		t.Fatalf("got %d foreign dirs, want 2", len(dirs))
+	}
+	if !strings.HasSuffix(dirs[0], ".codex/skills") {
+		t.Errorf("first foreign dir = %q, want codex", dirs[0])
+	}
+	if !strings.HasSuffix(dirs[1], ".claude/skills") {
+		t.Errorf("second foreign dir = %q, want claude", dirs[1])
+	}
+}
+
+// TestCopyDirErrorPaths: copyDir fails on a non-directory source and a
+// destination that already exists.
+func TestCopyDirErrorPaths(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := copyDir(src, filepath.Join(t.TempDir(), "dst")); err == nil {
+		t.Error("copyDir of a non-directory should fail")
+	}
+	dst := filepath.Join(t.TempDir(), "exists")
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyDir(t.TempDir(), dst); err == nil {
+		t.Error("copyDir to an existing destination should fail")
+	}
+}
+
+// TestCopyFileErrorPaths: copyFile fails on a missing source.
+func TestCopyFileErrorPaths(t *testing.T) {
+	if err := copyFile(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "dst")); err == nil {
+		t.Error("copyFile of a missing source should fail")
 	}
 }

--- a/cmd/whip/skills_test.go
+++ b/cmd/whip/skills_test.go
@@ -108,6 +108,63 @@ func TestSkillsImportNothingToDo(t *testing.T) {
 	}
 }
 
+// TestSkillsImportContinuesPastFailure: one unreadable skill must not abort
+// the rest of the import — the good skill lands, the error names only the
+// failed one.
+func TestSkillsImportContinuesPastFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	// A good skill and a bad one (unreadable SKILL.md) in claude's dir.
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "good", "fine")
+	badDir := filepath.Join(home, ".claude", "skills", "bad")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	badFile := filepath.Join(badDir, "SKILL.md")
+	if err := os.WriteFile(badFile, []byte("---\nname: bad\ndescription: x\n---\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A subdirectory with an unreadable file inside the otherwise-parseable
+	// skill: Scan succeeds, copyFile fails.
+	sub := filepath.Join(badDir, "refs")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := filepath.Join(sub, "secret.md")
+	if err := os.WriteFile(unreadable, []byte("x"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(unreadable, 0o600) }) // let TempDir clean up
+	if _, err := os.Open(unreadable); err == nil {
+		t.Skip("running with permission to read 0o000 files (root)")
+	}
+
+	err := skillsCLI([]string{"import"})
+	if err == nil {
+		t.Fatal("import should report the failed skill")
+	}
+	if !strings.Contains(err.Error(), "bad") {
+		t.Errorf("error should name the failed skill, got %v", err)
+	}
+	// The good skill still imported.
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "good", "SKILL.md")); err != nil {
+		t.Errorf("good skill not imported despite the failure: %v", err)
+	}
+	// The bad skill must not linger as a half-copied dir.
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "bad")); err == nil {
+		// copyDir creates the dest dir before failing — that's fine as long as
+		// it's empty (no partial SKILL.md shipped).
+		entries, _ := os.ReadDir(filepath.Join(home, ".agents", "skills", "bad"))
+		for _, e := range entries {
+			if e.Name() == "SKILL.md" {
+				t.Error("partial import: bad skill's SKILL.md copied despite the failure")
+			}
+		}
+	}
+}
+
 // TestSkillsListCLI: `whip skills list` renders loaded skills and their
 // source dirs without error.
 func TestSkillsListCLI(t *testing.T) {

--- a/cmd/whip/skills_test.go
+++ b/cmd/whip/skills_test.go
@@ -225,3 +225,39 @@ func TestCopyFileErrorPaths(t *testing.T) {
 		t.Error("copyFile of a missing source should fail")
 	}
 }
+
+// TestSkillsImportPathTraversal: a skill whose frontmatter name contains path
+// separators (../, ../../pwned) must be rejected — the name becomes the
+// destination directory, and without the guard it escapes ~/.agents/skills.
+func TestSkillsImportPathTraversal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	// Plant a malicious skill with a traversal name in claude's dir.
+	malDir := filepath.Join(home, ".claude", "skills", "pwn")
+	if err := os.MkdirAll(malDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(malDir, "SKILL.md"), []byte("---\nname: ../../pwned\ndescription: x\n---\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// And a good one to prove the import continues past the rejected name.
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "good", "fine")
+
+	err := skillsCLI([]string{"import"})
+	if err == nil {
+		t.Fatal("import should reject the traversal name")
+	}
+	if !strings.Contains(err.Error(), "../../pwned") {
+		t.Errorf("error should name the rejected skill, got %v", err)
+	}
+	// The traversal destination must not exist (no escape from ~/.agents/skills).
+	if _, err := os.Stat(filepath.Join(home, "pwned")); !os.IsNotExist(err) {
+		t.Errorf("path traversal succeeded: %v", err)
+	}
+	// The good skill still imported.
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "good", "SKILL.md")); err != nil {
+		t.Errorf("good skill not imported despite the traversal rejection: %v", err)
+	}
+}

--- a/cmd/whip/skills_test.go
+++ b/cmd/whip/skills_test.go
@@ -226,6 +226,42 @@ func TestCopyFileErrorPaths(t *testing.T) {
 	}
 }
 
+// TestSkillsImportKeepsPreExistingDirOnConflict: when a foreign skill name
+// collides with a pre-existing non-skill directory in ~/.agents/skills (no
+// SKILL.md, so the dedup pass never registered it), the import must report
+// the conflict and leave the user's folder untouched — not delete it.
+func TestSkillsImportKeepsPreExistingDirOnConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+
+	// A pre-existing user folder with no SKILL.md (invisible to the scan, so
+	// the dedup set misses it) that shares a name with a foreign skill.
+	userDir := filepath.Join(home, ".agents", "skills", "notes")
+	if err := os.MkdirAll(userDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	userFile := filepath.Join(userDir, "keep-me.txt")
+	if err := os.WriteFile(userFile, []byte("precious"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The foreign skill named "notes" that would collide.
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "notes", "claude copy")
+
+	err := skillsCLI([]string{"import"})
+	if err == nil {
+		t.Fatal("import should report the destination conflict")
+	}
+	// The user's folder and its contents must survive.
+	if _, err := os.Stat(userFile); err != nil {
+		t.Errorf("pre-existing user folder was deleted or modified: %v", err)
+	}
+	data, _ := os.ReadFile(userFile)
+	if string(data) != "precious" {
+		t.Errorf("user file contents changed: %q", data)
+	}
+}
+
 // TestSkillsImportPathTraversal: a skill whose frontmatter name contains path
 // separators (../, ../../pwned) must be rejected — the name becomes the
 // destination directory, and without the guard it escapes ~/.agents/skills.

--- a/cmd/whip/skills_test.go
+++ b/cmd/whip/skills_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkill plants a minimal valid skill at <root>/<name>/SKILL.md.
+func writeSkill(t *testing.T, root, name, desc string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: " + name + "\ndescription: " + desc + "\n---\n\n# " + name + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSkillsImportDedup pins the core contract: a skill name whip already
+// loads (project or user dir) is never overwritten, a name duplicated across
+// the foreign sources imports once (codex wins over claude), and a genuinely
+// new skill copies into ~/.agents/skills with its contents intact.
+func TestSkillsImportDedup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	// whip already has "linear" at user level.
+	writeSkill(t, filepath.Join(home, ".agents", "skills"), "linear", "whip's copy")
+	// codex has "linear" (dup) and "codex-only" (new).
+	writeSkill(t, filepath.Join(home, ".codex", "skills"), "linear", "codex copy")
+	writeSkill(t, filepath.Join(home, ".codex", "skills"), "codex-only", "only in codex")
+	// claude has "linear" (dup), "shared" (dup of codex), and "cloudflare" (new).
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "linear", "claude copy")
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "codex-only", "claude's codex-only")
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "cloudflare", "only in claude")
+
+	if err := skillsCLI([]string{"import"}); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(home, ".agents", "skills")
+
+	// The dedup'd name keeps whip's original copy.
+	body, err := os.ReadFile(filepath.Join(dest, "linear", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "whip's copy") {
+		t.Errorf("linear was overwritten: %q", body)
+	}
+	// Both new skills arrived.
+	for _, name := range []string{"codex-only", "cloudflare"} {
+		if _, err := os.Stat(filepath.Join(dest, name, "SKILL.md")); err != nil {
+			t.Errorf("%s not imported: %v", name, err)
+		}
+	}
+	// The cross-source dup came from codex (first source), not claude.
+	body, err = os.ReadFile(filepath.Join(dest, "codex-only", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "only in codex") {
+		t.Errorf("codex-only should be codex's copy, got %q", body)
+	}
+	// A second run imports nothing — the command is idempotent.
+	if err := skillsCLI([]string{"import"}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Errorf("dest has %d skills after re-import, want 3", len(entries))
+	}
+}
+
+// TestSkillsImportDryRun: --dry-run writes nothing.
+func TestSkillsImportDryRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "cloudflare", "cf")
+
+	if err := skillsCLI([]string{"import", "--dry-run"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills")); !os.IsNotExist(err) {
+		t.Errorf("--dry-run created the dest dir: %v", err)
+	}
+}
+
+// TestSkillsImportNothingToDo: no foreign skills at all is a clean no-op.
+func TestSkillsImportNothingToDo(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(t.TempDir())
+	if err := skillsCLI([]string{"import"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,7 +135,17 @@ each server's tools automatically. CLI: `whip mcp list|add|remove|import`
 `whip mcp test <name>` to doctor one server (status, timing, tool names,
 stderr tail; non-zero exit — validate a `.mcp.json` in CI). `whip mcp
 serve` runs whip's own tools (read/bash/edit/write) as an MCP server for
-other harnesses.
+other harnesses. Codex configs with `http_headers` and
+`bearer_token_env_var` import correctly (the env var resolves to an
+`Authorization` header at load), and codex's `[mcp_servers.X.tools.*]`
+per-tool approval tables are skipped — they're codex's config, not servers.
+
+`whip skills list` shows loaded skills and where they come from;
+`whip skills import [--dry-run]` copies skills from other harnesses'
+user dirs (`~/.codex/skills`, `~/.claude/skills`) into `~/.agents/skills`,
+deduped by name against everything whip already loads — an existing
+skill is never overwritten, and a name duplicated across codex/claude
+imports once.
 
 ## Browser — drive your real, logged-in Chrome
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -890,6 +890,13 @@ catalog in the Agent Skills spec format (`<skill><name>/<description>/<location>
 XML-escaped). The model reads a SKILL.md with its own read tool when relevant.
 Skills re-index every turn, so new ones load without restarting.
 
+CLI: `whip skills list` (names, sources, warnings) and `whip skills import
+[--dry-run]` — copies skills from other harnesses' user dirs
+(`~/.codex/skills`, `~/.claude/skills` — `skills.ForeignDirs`) into
+`~/.agents/skills`, deduped by name against what whip already loads and
+across the sources (codex wins on a dup). Never overwrites an existing
+skill. Tests: `cmd/whip/skills_test.go`.
+
 **Spec compliance** (agentskills.io, matching pi's `core/skills.ts`): name
 validated (≤64 chars, lowercase a-z/0-9/hyphens, no leading/trailing/double
 hyphens), description ≤1024 chars (a *validity* ceiling, not a prompt budget),

--- a/internal/mcp/codextoml.go
+++ b/internal/mcp/codextoml.go
@@ -53,9 +53,17 @@ func ParseCodex(data []byte) (map[string]ServerConfig, error) {
 		// "foo.env" isn't dropped.
 		if idx := strings.LastIndex(name, "."); idx > 0 {
 			sub := name[idx+1:]
-			if (sub == "env" || sub == "environment" || sub == "headers") && hasKeys["mcp_servers."+name[:idx]] {
+			if (sub == "env" || sub == "environment" || sub == "headers" || sub == "http_headers" || sub == "env_http_headers") && hasKeys["mcp_servers."+name[:idx]] {
 				continue
 			}
+		}
+		// Codex nests per-tool approval config under [mcp_servers.NAME.tools.TOOL]
+		// — that is a tool table, not a server, and never has command/url.
+		// Treating it as a server used to surface a bogus "neither command nor
+		// url set" entry named "incident_io.tools.ask_telemetry". Skip any
+		// sub-table whose parent is a server table and isn't a fold-in (above).
+		if idx := strings.Index(name, "."); idx > 0 && hasKeys["mcp_servers."+name[:idx]] {
+			continue
 		}
 		c := ServerConfig{}
 		var args []string // folded into Command after the key loop

--- a/internal/mcp/codextoml_test.go
+++ b/internal/mcp/codextoml_test.go
@@ -136,6 +136,88 @@ func TestParseCodexTypeErrors(t *testing.T) {
 	}
 }
 
+// TestParseCodexToolApprovalTables: [mcp_servers.x.tools.y] is codex per-tool
+// approval config, not a server. It must not produce a bogus server entry
+// named "x.tools.y" (regression: incident_io.tools.ask_telemetry showed up in
+// the startup report as a failed server with neither command nor url).
+func TestParseCodexToolApprovalTables(t *testing.T) {
+	cfgs, err := ParseCodex([]byte(`
+[mcp_servers.incident_io]
+url = "https://mcp.incident.io/mcp"
+
+[mcp_servers.incident_io.tools.ask_telemetry]
+approval_mode = "approve"
+
+[mcp_servers.inf-memory]
+url = "http://office/api/mcp"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("got %d servers %v, want 2", len(cfgs), keys(cfgs))
+	}
+	if cfgs["incident_io"].URL != "https://mcp.incident.io/mcp" {
+		t.Errorf("incident_io url = %q", cfgs["incident_io"].URL)
+	}
+	for name := range cfgs {
+		if strings.Contains(name, ".") {
+			t.Errorf("bogus sub-table server leaked into configs: %q", name)
+		}
+	}
+}
+
+// TestParseCodexServerNamedTools: a server genuinely named "x.tools" must
+// still load — the sub-table skip is keyed on the parent being a server.
+func TestParseCodexServerNamedTools(t *testing.T) {
+	cfgs, err := ParseCodex([]byte("[mcp_servers.x.tools]\ncommand = \"srv\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cfgs["x.tools"].Command, []string{"srv"}) {
+		t.Errorf("x.tools command = %v", cfgs["x.tools"].Command)
+	}
+}
+
+// TestParseCodexHTTPHeadersAndBearer: codex's http_headers inline table lands
+// as literal header values, and bearer_token_env_var lands as a lazy $VAR
+// reference (resolved at connect, never baked or persisted). A literal
+// http_headers Authorization beats the env-ref on collision.
+func TestParseCodexHTTPHeadersAndBearer(t *testing.T) {
+	cfgs, err := ParseCodex([]byte(`
+[mcp_servers.a]
+url = "https://a.example/mcp"
+http_headers = { "X-Team" = "eng" }
+bearer_token_env_var = "WHIP_TEST_TOKEN"
+
+[mcp_servers.b]
+url = "https://b.example/mcp"
+headers = { "Authorization" = "Bearer explicit" }
+bearer_token_env_var = "WHIP_TEST_TOKEN"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The bearer var is stored as a lazy reference, not resolved at parse time.
+	if got := cfgs["a"].Headers["Authorization"]; got != "Bearer $WHIP_TEST_TOKEN" {
+		t.Errorf("a Authorization = %q, want the lazy $VAR reference", got)
+	}
+	if got := cfgs["a"].Headers["X-Team"]; got != "eng" {
+		t.Errorf("a X-Team = %q", got)
+	}
+	if got := cfgs["b"].Headers["Authorization"]; got != "Bearer explicit" {
+		t.Errorf("b Authorization = %q, explicit literal header must win", got)
+	}
+}
+
+func keys(m map[string]ServerConfig) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestLoadCodex(t *testing.T) {
 	// An unset path is the "no codex config" signal in the discovery flow.
 	if _, err := LoadCodex(""); !errors.Is(err, os.ErrNotExist) {

--- a/internal/mcp/realconfig_smoke_test.go
+++ b/internal/mcp/realconfig_smoke_test.go
@@ -1,0 +1,34 @@
+package mcp
+
+import (
+	"os"
+	"testing"
+)
+
+// Smoke test against a real codex config when one exists — skipped in CI.
+// Reproduces the two startup-report failures from a francesco-shaped config:
+// a bogus "incident_io.tools.ask_telemetry" server, and an Unauthorized
+// incident_io with no way to express auth.
+func TestRealCodexConfigSmoke(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	path := home + "/.codex/config.toml"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("no codex config:", err)
+	}
+	cfgs, err := ParseCodex(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name := range cfgs {
+		if name == "incident_io.tools.ask_telemetry" {
+			t.Errorf("tool approval table leaked as server %q", name)
+		}
+	}
+	if _, ok := cfgs["incident_io"]; ok {
+		t.Logf("incident_io: url=%q headers=%v note=%q", cfgs["incident_io"].URL, cfgs["incident_io"].Headers, cfgs["incident_io"].Note)
+	}
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -47,6 +47,20 @@ func DefaultDirs() []string {
 	return dirs
 }
 
+// ForeignDirs returns other harnesses' user-level skill locations that an
+// import can pull from — codex (~/.codex/skills) and claude-code
+// (~/.claude/skills). Missing directories are skipped by the scan.
+func ForeignDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".codex", "skills"),
+		filepath.Join(home, ".claude", "skills"),
+	}
+}
+
 // Scan reads <dir>/<skill>/SKILL.md for each dir, skipping anything
 // unreadable. Loaded-but-degraded skills carry a Warning (e.g. description
 // truncated); anything that fails to parse is silently skipped (a SKILL.md

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -291,6 +291,14 @@ const (
 
 var specNameRe = regexp.MustCompile(`^[a-z0-9-]+$`)
 
+// ValidName reports whether name matches the spec's name charset (lowercase
+// a-z, 0-9, hyphens only). Callers that turn a skill name into a filesystem
+// path (e.g. `whip skills import`) must gate on this — validate() only warns,
+// and a name with separators is a path-traversal primitive.
+func ValidName(name string) bool {
+	return specNameRe.MatchString(name)
+}
+
 // validate checks a loaded skill against the Agent Skills spec. Returns a
 // warning string ("" when spec-clean). Skills with warnings still load —
 // portability problems degrade, never disappear (pi does the same).


### PR DESCRIPTION
## What

Three startup-report failures on a real codex config, plus a missing import path for skills.

### Codex TOML parser fixes

1. **`[mcp_servers.X.tools.Y]` leaked as a bogus server.** Codex per-tool approval tables were parsed as a server named `incident_io.tools.ask_telemetry` with no `command`/`url`, surfacing as a failed `✗ incident_io.tools.ask_telemetry: neither command nor url set` line at startup. Now any sub-table of a server that isn't an env/headers fold-in is skipped; a server genuinely named `x.tools` still loads (the parent must be a server table for the skip).

2. **No way to express codex auth → `Unauthorized`.** `http_headers` (inline table) and `bearer_token_env_var` are now honored; the env var resolves to an `Authorization: Bearer` header at load (explicit header wins, missing var becomes a visible Note instead of a silent 401). This was mcp-polish item 10.

### `whip skills import`

`whip skills list` shows loaded skills + sources. `whip skills import [--dry-run]` copies skills from other harnesses' user dirs (`~/.codex/skills`, `~/.claude/skills`) into `~/.agents/skills`, **deduped by name** against everything whip already loads and across the sources (codex wins a codex/claude dup). Never overwrites an existing skill. The original ask was "import all my skills from other places with dedup across codex and claude" — there was no command for it.

## Testing

- `go test ./internal/mcp/ ./internal/skills/ ./cmd/whip/ ./internal/config/` all green.
- New `TestRealCodexConfigSmoke` runs against the actual `~/.codex/config.toml` and proves both fixes (the bogus `incident_io.tools.ask_telemetry` server is gone; `bearer_token_env_var` → `Authorization: Bearer` header verified with a test token).
- Ran `whip skills import` for real: dedup'd 5 claude skills already in `~/.agents/skills`, copied the 1 new one, idempotent on re-run.

Docs: README.md + features.md updated. The two pre-existing failures in `internal/tui`/`internal/browser` (skills test scans real $HOME, browser test conflicts with a live Chrome on :9222) are untouched by this change.