### PR TITLE
fix(tools): replace binary tool output with a compact [binary] placeholder

### DIFF
--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -64,24 +64,48 @@ func isBinary(data []byte) bool {
 }
 
 // trimToLastRune shortens s to end on a complete UTF-8 rune, but only when
-// the cut landed mid-rune. A rune is at most utf8.UTFMax bytes, so the loop
-// never backs off more than that — genuinely-invalid interior bytes (a
-// Latin-1 file, a corrupted stream) stay invalid and the caller's
-// !utf8.Valid check still flags them as binary.
+// the cut landed mid-rune: the trailing bytes must form a valid prefix of a
+// rune whose continuation extends past the cut. A genuinely-invalid trailing
+// byte (Latin-1 smart quote, BOM-less UTF-16) is NOT a rune prefix, so it
+// stays invalid and the caller's !utf8.Valid still flags the sample as binary.
 func trimToLastRune(s []byte) []byte {
-	for i := 0; i < utf8.UTFMax && len(s) > 0; i++ {
-		if utf8.Valid(s) {
-			return s
-		}
-		_, size := utf8.DecodeLastRune(s)
-		if size == 0 {
-			size = 1
-		}
-		s = s[:len(s)-size]
+	if len(s) == 0 || utf8.Valid(s) {
+		return s
 	}
-	// Still invalid after backing off a full rune's worth of bytes: the cut
-	// wasn't mid-rune, the bytes are genuinely invalid — return as-is so the
-	// caller's !utf8.Valid sees them.
+	// Find the start of the last (possibly incomplete) rune: walk back past
+	// continuation bytes (0x80–0xBF) to the rune's lead byte.
+	i := len(s) - 1
+	for i > 0 && (s[i]&0xC0) == 0x80 {
+		i--
+	}
+	// The candidate rune starts at i. If the lead byte at i encodes a rune
+	// whose full length extends past the end of s, the cut landed mid-rune —
+	// drop the tail. Otherwise the trailing byte is genuinely invalid; keep it.
+	if i < len(s) {
+		// DecodeRune on an incomplete sequence returns RuneError, so use the
+		// lead byte's encoded length instead: 0xC0–0xDF = 2 bytes, 0xE0–0xEF =
+		// 3, 0xF0–0xF7 = 4. A lead byte outside those ranges is not a rune
+		// start, so it's genuinely invalid.
+		lead := s[i]
+		var want int
+		switch {
+		case lead < 0x80:
+			want = 1
+		case lead < 0xC0:
+			want = 0 // continuation byte without a lead: invalid
+		case lead < 0xE0:
+			want = 2
+		case lead < 0xF0:
+			want = 3
+		case lead < 0xF8:
+			want = 4
+		default:
+			want = 0 // 0xF8+ is never a valid UTF-8 lead
+		}
+		if want > 1 && i+want > len(s) {
+			return s[:i]
+		}
+	}
 	return s
 }
 

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -21,13 +21,20 @@ const binaryProbeSize = 1024
 //   - any NUL byte is a strong binary signal (NUL is itself valid UTF-8, so
 //     this is a separate check);
 //   - a high density of other C0 control bytes (>10%, excluding the benign
-//     whitespace ones like \t \n \r \f \v) is treated as binary too.
+//     whitespace ones like \t \n \r \f \v and ESC for ANSI-colored output) is
+//     treated as binary too.
 func isBinary(data []byte) bool {
 	if len(data) == 0 {
 		return false
 	}
 	n := min(len(data), binaryProbeSize)
 	sample := data[:n]
+	// A multi-byte rune can straddle the probe boundary — a 1024-byte cut can
+	// end mid-rune and read as invalid UTF-8 for a plain text file (CJK/emoji
+	// hit this constantly). Back the sample off to the last complete rune.
+	if len(data) > binaryProbeSize {
+		sample = trimToLastRune(sample)
+	}
 
 	if !utf8.Valid(sample) {
 		return true
@@ -38,6 +45,9 @@ func isBinary(data []byte) bool {
 		switch {
 		case b == 0x00:
 			nul++
+		case b == 0x1b:
+			// ESC starts ANSI escape sequences (ls --color, grep --color) —
+			// colored text is not binary, so don't count it as a control byte.
 		case b < 0x20 && b != '\t' && b != '\n' && b != '\r' && b != 0x0b && b != 0x0c:
 			ctrl++
 		}
@@ -46,6 +56,23 @@ func isBinary(data []byte) bool {
 		return true
 	}
 	return ctrl*10 > len(sample)
+}
+
+// trimToLastRune shortens s to end on a complete UTF-8 rune. Used when the
+// sample was cut at a fixed byte count that may land mid-rune; the tail is
+// dropped only when the final bytes are an incomplete encoding.
+func trimToLastRune(s []byte) []byte {
+	for len(s) > 0 {
+		if utf8.Valid(s) {
+			return s
+		}
+		_, size := utf8.DecodeLastRune(s)
+		if size == 0 {
+			size = 1
+		}
+		s = s[:len(s)-size]
+	}
+	return s
 }
 
 // bytesHuman renders a byte count compactly for placeholders, e.g. "88 KB".

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// binaryProbeSize bounds the bytes we inspect when sniffing for binary output.
+// A short prefix is enough to catch NUL-heavy files and text that has gone
+// binary early on; scanning an entire huge file buys nothing.
+const binaryProbeSize = 1024
+
+// isBinary reports whether data looks like binary rather than text. It is the
+// gate that keeps raw NUL/control bytes out of the conversation: when a tool
+// reads a binary file (a .png, a .sqlite, an ELF, base64 blobs) or a command
+// cats one through bash, the caller substitutes a compact placeholder instead
+// of injecting screenfuls of junk into the message stream.
+//
+// Heuristic (stdlib only):
+//   - if the first binaryProbeSize bytes are not valid UTF-8, it is binary;
+//   - any NUL byte is a strong binary signal (NUL is itself valid UTF-8, so
+//     this is a separate check);
+//   - a high density of other C0 control bytes (>10%, excluding the benign
+//     whitespace ones like \t \n \r \f \v) is treated as binary too.
+func isBinary(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	n := len(data)
+	if n > binaryProbeSize {
+		n = binaryProbeSize
+	}
+	sample := data[:n]
+
+	if !utf8.Valid(sample) {
+		return true
+	}
+
+	var nul, ctrl int
+	for _, b := range sample {
+		switch {
+		case b == 0x00:
+			nul++
+		case b < 0x20 && b != '\t' && b != '\n' && b != '\r' && b != 0x0b && b != 0x0c:
+			ctrl++
+		}
+	}
+	if nul > 0 {
+		return true
+	}
+	return ctrl*10 > len(sample)
+}
+
+// bytesHuman renders a byte count compactly for placeholders, e.g. "88 KB".
+func bytesHuman(n int) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d bytes", n)
+	}
+}
+
+// binaryPlaceholder is the compact stand-in injected in place of binary tool
+// output. name is the offending source (a file path for read, "" for bash);
+// size is the size of the output that was suppressed.
+func binaryPlaceholder(name string, size int) string {
+	if name == "" {
+		return fmt.Sprintf("[binary output: %s, not shown]", bytesHuman(size))
+	}
+	return fmt.Sprintf("[binary: %s, %s]", name, bytesHuman(size))
+}

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -6,11 +6,6 @@ import (
 	"unicode/utf8"
 )
 
-// binaryProbeSize bounds the bytes we inspect when sniffing for binary output.
-// A short prefix is enough to catch NUL-heavy files and text that has gone
-// binary early on; scanning an entire huge file buys nothing.
-const binaryProbeSize = 1024
-
 // isBinary reports whether data looks like binary rather than text. It is the
 // gate that keeps raw NUL/control bytes out of the conversation: when a tool
 // reads a binary file (a .png, a .sqlite, an ELF, base64 blobs) or a command
@@ -18,7 +13,7 @@ const binaryProbeSize = 1024
 // of injecting screenfuls of junk into the message stream.
 //
 // Heuristic (stdlib only):
-//   - if the first binaryProbeSize bytes are not valid UTF-8, it is binary;
+//   - if the output is not valid UTF-8, it is binary;
 //   - any NUL byte is a strong binary signal (NUL is itself valid UTF-8, so
 //     this is a separate check);
 //   - a high density of other C0 control bytes (>10%, excluding the benign
@@ -56,17 +51,6 @@ func isBinary(data []byte) bool {
 	// checks above, so the prefix-only scope would leak it. The check is a
 	// single pass — same cost class as the NUL/UTF-8 passes — and tool outputs
 	// are bounded (≤ ~50KB after read/bash paths).
-	//
-	// A multi-byte rune can straddle the 1024-byte probe boundary — a hard cut
-	// can end mid-rune and read as invalid UTF-8 for a plain text file
-	// (CJK/emoji hit this constantly). Back the sample off to the last complete
-	// rune before the utf8.Valid check below uses it.
-	n := min(len(data), binaryProbeSize)
-	sample := data[:n]
-	if len(data) > binaryProbeSize {
-		sample = trimToLastRune(sample)
-	}
-
 	ctrl := 0
 	for _, b := range data {
 		switch {
@@ -78,74 +62,6 @@ func isBinary(data []byte) bool {
 		}
 	}
 	return ctrl*10 > len(data)
-}
-
-// trimToLastRune shortens s to end on a complete UTF-8 rune, but only when
-// the cut landed mid-rune: the trailing bytes must be a valid prefix of a
-// legal rune encoding whose continuation extends past the cut (RFC 3629
-// second-byte constraints included — E0 requires A0–BF, ED requires 80–9F,
-// F0 requires 90–BF, F4 requires 80–8F, leads outside C2–F4 are never legal).
-// A genuinely-invalid trailing byte (Latin-1 smart quote, E0 80 overlong,
-// BOM-less UTF-16) is NOT a rune prefix, so it stays invalid and the caller's
-// !utf8.Valid still flags the sample as binary.
-func trimToLastRune(s []byte) []byte {
-	if len(s) == 0 || utf8.Valid(s) {
-		return s
-	}
-	// Find the start of the last (possibly incomplete) rune: walk back past
-	// continuation bytes (0x80–0xBF) to the rune's lead byte.
-	i := len(s) - 1
-	for i > 0 && (s[i]&0xC0) == 0x80 {
-		i--
-	}
-	tail := s[i:]
-	if want, ok := runePrefixLen(tail); ok && i+want > len(s) {
-		return s[:i]
-	}
-	return s
-}
-
-// runePrefixLen reports whether b is a valid prefix of a legal UTF-8 rune
-// encoding, returning the rune's full length when it is. The check is the
-// RFC 3629 table: lead legality (C2–F4), the second-byte constraint each lead
-// carries (E0/F0 forbid overlong second bytes; ED/F4 bound the rune below the
-// surrogate/ceiling ranges), and every present continuation byte in 80–BF.
-func runePrefixLen(b []byte) (int, bool) {
-	if len(b) == 0 {
-		return 0, false
-	}
-	lead := b[0]
-	var want int
-	var secondLo, secondHi byte = 0x80, 0xBF
-	switch {
-	case lead >= 0xC2 && lead <= 0xDF:
-		want = 2
-	case lead == 0xE0:
-		want, secondLo = 3, 0xA0
-	case lead >= 0xE1 && lead <= 0xEC, lead == 0xEE, lead == 0xEF:
-		want = 3
-	case lead == 0xED:
-		want, secondHi = 3, 0x9F
-	case lead == 0xF0:
-		want, secondLo = 4, 0x90
-	case lead >= 0xF1 && lead <= 0xF3:
-		want = 4
-	case lead == 0xF4:
-		want, secondHi = 4, 0x8F
-	default:
-		return 0, false // ASCII, bare continuation, C0/C1, F5+: not a rune start
-	}
-	for j := 1; j < len(b) && j < want; j++ {
-		c := b[j]
-		lo, hi := byte(0x80), byte(0xBF)
-		if j == 1 {
-			lo, hi = secondLo, secondHi
-		}
-		if c < lo || c > hi {
-			return 0, false
-		}
-	}
-	return want, true
 }
 
 // bytesHuman renders a byte count compactly for placeholders, e.g. "88 KB".

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -63,11 +63,13 @@ func isBinary(data []byte) bool {
 	return ctrl*10 > len(sample)
 }
 
-// trimToLastRune shortens s to end on a complete UTF-8 rune. Used when the
-// sample was cut at a fixed byte count that may land mid-rune; the tail is
-// dropped only when the final bytes are an incomplete encoding.
+// trimToLastRune shortens s to end on a complete UTF-8 rune, but only when
+// the cut landed mid-rune. A rune is at most utf8.UTFMax bytes, so the loop
+// never backs off more than that — genuinely-invalid interior bytes (a
+// Latin-1 file, a corrupted stream) stay invalid and the caller's
+// !utf8.Valid check still flags them as binary.
 func trimToLastRune(s []byte) []byte {
-	for len(s) > 0 {
+	for i := 0; i < utf8.UTFMax && len(s) > 0; i++ {
 		if utf8.Valid(s) {
 			return s
 		}
@@ -77,6 +79,9 @@ func trimToLastRune(s []byte) []byte {
 		}
 		s = s[:len(s)-size]
 	}
+	// Still invalid after backing off a full rune's worth of bytes: the cut
+	// wasn't mid-rune, the bytes are genuinely invalid — return as-is so the
+	// caller's !utf8.Valid sees them.
 	return s
 }
 

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"fmt"
 	"unicode/utf8"
 )
@@ -27,6 +28,15 @@ func isBinary(data []byte) bool {
 	if len(data) == 0 {
 		return false
 	}
+	// NUL anywhere in the output is the strongest binary signal — and cheap to
+	// check over the whole buffer (bytes.IndexByte is SIMD-friendly), so a
+	// text-then-binary stream (cat README.md image.png) is still caught.
+	if bytes.IndexByte(data, 0x00) >= 0 {
+		return true
+	}
+
+	// UTF-8 validity and control-byte density only need a prefix — scanning an
+	// entire huge file buys nothing for those.
 	n := min(len(data), binaryProbeSize)
 	sample := data[:n]
 	// A multi-byte rune can straddle the probe boundary — a 1024-byte cut can
@@ -40,20 +50,15 @@ func isBinary(data []byte) bool {
 		return true
 	}
 
-	var nul, ctrl int
+	ctrl := 0
 	for _, b := range sample {
 		switch {
-		case b == 0x00:
-			nul++
 		case b == 0x1b:
 			// ESC starts ANSI escape sequences (ls --color, grep --color) —
 			// colored text is not binary, so don't count it as a control byte.
 		case b < 0x20 && b != '\t' && b != '\n' && b != '\r' && b != 0x0b && b != 0x0c:
 			ctrl++
 		}
-	}
-	if nul > 0 {
-		return true
 	}
 	return ctrl*10 > len(sample)
 }

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -35,8 +35,20 @@ func isBinary(data []byte) bool {
 		return true
 	}
 
-	// UTF-8 validity and control-byte density only need a prefix — scanning an
-	// entire huge file buys nothing for those.
+	// UTF-8 validity must hold for the whole buffer too: a text-then-binary
+	// stream with invalid UTF-8 past the 1KB probe (a log file with corrupt
+	// bytes partway through, `head -c 2000 README; cat latin1.log`) leaks
+	// mojibake into the conversation if we only validate the prefix. The
+	// check is a single pass — same cost class as the NUL scan — and tool
+	// outputs are bounded (≤ ~50KB after read/bash paths), so validating the
+	// whole buffer is cheap.
+	if !utf8.Valid(data) {
+		return true
+	}
+
+	// The control-byte density check only needs a prefix — a file that's
+	// binary from the start trips it in the first 1KB; a text-then-binary
+	// stream is already caught by the full-buffer NUL/UTF-8 checks above.
 	n := min(len(data), binaryProbeSize)
 	sample := data[:n]
 	// A multi-byte rune can straddle the probe boundary — a 1024-byte cut can
@@ -44,10 +56,6 @@ func isBinary(data []byte) bool {
 	// hit this constantly). Back the sample off to the last complete rune.
 	if len(data) > binaryProbeSize {
 		sample = trimToLastRune(sample)
-	}
-
-	if !utf8.Valid(sample) {
-		return true
 	}
 
 	ctrl := 0

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -24,6 +24,11 @@ const binaryProbeSize = 1024
 //   - a high density of other C0 control bytes (>10%, excluding the benign
 //     whitespace ones like \t \n \r \f \v and ESC for ANSI-colored output) is
 //     treated as binary too.
+//
+// IsBinary is the exported form for the TUI's `!` shell escape, which injects
+// command output into the conversation the same way the bash tool does.
+func IsBinary(data []byte) bool { return isBinary(data) }
+
 func isBinary(data []byte) bool {
 	if len(data) == 0 {
 		return false
@@ -46,20 +51,24 @@ func isBinary(data []byte) bool {
 		return true
 	}
 
-	// The control-byte density check only needs a prefix — a file that's
-	// binary from the start trips it in the first 1KB; a text-then-binary
-	// stream is already caught by the full-buffer NUL/UTF-8 checks above.
+	// The control-byte density check runs over the whole buffer too: a
+	// NUL-free control-junk tail (2000 'a' + 4KB of 0x01) passes the NUL/UTF-8
+	// checks above, so the prefix-only scope would leak it. The check is a
+	// single pass — same cost class as the NUL/UTF-8 passes — and tool outputs
+	// are bounded (≤ ~50KB after read/bash paths).
+	//
+	// A multi-byte rune can straddle the 1024-byte probe boundary — a hard cut
+	// can end mid-rune and read as invalid UTF-8 for a plain text file
+	// (CJK/emoji hit this constantly). Back the sample off to the last complete
+	// rune before the utf8.Valid check below uses it.
 	n := min(len(data), binaryProbeSize)
 	sample := data[:n]
-	// A multi-byte rune can straddle the probe boundary — a 1024-byte cut can
-	// end mid-rune and read as invalid UTF-8 for a plain text file (CJK/emoji
-	// hit this constantly). Back the sample off to the last complete rune.
 	if len(data) > binaryProbeSize {
 		sample = trimToLastRune(sample)
 	}
 
 	ctrl := 0
-	for _, b := range sample {
+	for _, b := range data {
 		switch {
 		case b == 0x1b:
 			// ESC starts ANSI escape sequences (ls --color, grep --color) —
@@ -68,7 +77,7 @@ func isBinary(data []byte) bool {
 			ctrl++
 		}
 	}
-	return ctrl*10 > len(sample)
+	return ctrl*10 > len(data)
 }
 
 // trimToLastRune shortens s to end on a complete UTF-8 rune, but only when
@@ -156,6 +165,10 @@ func bytesHuman(n int) string {
 // binaryPlaceholder is the compact stand-in injected in place of binary tool
 // output. name is the offending source (a file path for read, "" for bash);
 // size is the size of the output that was suppressed.
+//
+// BinaryPlaceholder is the exported form for the TUI's `!` shell escape.
+func BinaryPlaceholder(name string, size int) string { return binaryPlaceholder(name, size) }
+
 func binaryPlaceholder(name string, size int) string {
 	if name == "" {
 		return fmt.Sprintf("[binary output: %s, not shown]", bytesHuman(size))

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -64,10 +64,13 @@ func isBinary(data []byte) bool {
 }
 
 // trimToLastRune shortens s to end on a complete UTF-8 rune, but only when
-// the cut landed mid-rune: the trailing bytes must form a valid prefix of a
-// rune whose continuation extends past the cut. A genuinely-invalid trailing
-// byte (Latin-1 smart quote, BOM-less UTF-16) is NOT a rune prefix, so it
-// stays invalid and the caller's !utf8.Valid still flags the sample as binary.
+// the cut landed mid-rune: the trailing bytes must be a valid prefix of a
+// legal rune encoding whose continuation extends past the cut (RFC 3629
+// second-byte constraints included — E0 requires A0–BF, ED requires 80–9F,
+// F0 requires 90–BF, F4 requires 80–8F, leads outside C2–F4 are never legal).
+// A genuinely-invalid trailing byte (Latin-1 smart quote, E0 80 overlong,
+// BOM-less UTF-16) is NOT a rune prefix, so it stays invalid and the caller's
+// !utf8.Valid still flags the sample as binary.
 func trimToLastRune(s []byte) []byte {
 	if len(s) == 0 || utf8.Valid(s) {
 		return s
@@ -78,35 +81,54 @@ func trimToLastRune(s []byte) []byte {
 	for i > 0 && (s[i]&0xC0) == 0x80 {
 		i--
 	}
-	// The candidate rune starts at i. If the lead byte at i encodes a rune
-	// whose full length extends past the end of s, the cut landed mid-rune —
-	// drop the tail. Otherwise the trailing byte is genuinely invalid; keep it.
-	if i < len(s) {
-		// DecodeRune on an incomplete sequence returns RuneError, so use the
-		// lead byte's encoded length instead: 0xC0–0xDF = 2 bytes, 0xE0–0xEF =
-		// 3, 0xF0–0xF7 = 4. A lead byte outside those ranges is not a rune
-		// start, so it's genuinely invalid.
-		lead := s[i]
-		var want int
-		switch {
-		case lead < 0x80:
-			want = 1
-		case lead < 0xC0:
-			want = 0 // continuation byte without a lead: invalid
-		case lead < 0xE0:
-			want = 2
-		case lead < 0xF0:
-			want = 3
-		case lead < 0xF8:
-			want = 4
-		default:
-			want = 0 // 0xF8+ is never a valid UTF-8 lead
-		}
-		if want > 1 && i+want > len(s) {
-			return s[:i]
-		}
+	tail := s[i:]
+	if want, ok := runePrefixLen(tail); ok && i+want > len(s) {
+		return s[:i]
 	}
 	return s
+}
+
+// runePrefixLen reports whether b is a valid prefix of a legal UTF-8 rune
+// encoding, returning the rune's full length when it is. The check is the
+// RFC 3629 table: lead legality (C2–F4), the second-byte constraint each lead
+// carries (E0/F0 forbid overlong second bytes; ED/F4 bound the rune below the
+// surrogate/ceiling ranges), and every present continuation byte in 80–BF.
+func runePrefixLen(b []byte) (int, bool) {
+	if len(b) == 0 {
+		return 0, false
+	}
+	lead := b[0]
+	var want int
+	var secondLo, secondHi byte = 0x80, 0xBF
+	switch {
+	case lead >= 0xC2 && lead <= 0xDF:
+		want = 2
+	case lead == 0xE0:
+		want, secondLo = 3, 0xA0
+	case lead >= 0xE1 && lead <= 0xEC, lead == 0xEE, lead == 0xEF:
+		want = 3
+	case lead == 0xED:
+		want, secondHi = 3, 0x9F
+	case lead == 0xF0:
+		want, secondLo = 4, 0x90
+	case lead >= 0xF1 && lead <= 0xF3:
+		want = 4
+	case lead == 0xF4:
+		want, secondHi = 4, 0x8F
+	default:
+		return 0, false // ASCII, bare continuation, C0/C1, F5+: not a rune start
+	}
+	for j := 1; j < len(b) && j < want; j++ {
+		c := b[j]
+		lo, hi := byte(0x80), byte(0xBF)
+		if j == 1 {
+			lo, hi = secondLo, secondHi
+		}
+		if c < lo || c > hi {
+			return 0, false
+		}
+	}
+	return want, true
 }
 
 // bytesHuman renders a byte count compactly for placeholders, e.g. "88 KB".

--- a/internal/tools/binary.go
+++ b/internal/tools/binary.go
@@ -26,10 +26,7 @@ func isBinary(data []byte) bool {
 	if len(data) == 0 {
 		return false
 	}
-	n := len(data)
-	if n > binaryProbeSize {
-		n = binaryProbeSize
-	}
+	n := min(len(data), binaryProbeSize)
 	sample := data[:n]
 
 	if !utf8.Valid(sample) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -201,10 +201,21 @@ func bashTool() Tool {
 				OnUpdate: onUpdate,
 			})
 
-			if isBinary([]byte(res.Output)) {
-				return binaryPlaceholder("", len(res.Output)), nil
-			}
 			s := TruncateTail(res.Output)
+			if isBinary([]byte(res.Output)) {
+				// The placeholder replaces the output, but the exit-status and
+				// timeout suffixes still matter — a binary-producing command
+				// that failed or timed out reads identically to a clean one
+				// without them.
+				s = binaryPlaceholder("", len(res.Output))
+				if res.TimedOut {
+					return s + "\n(command timed out)", nil
+				}
+				if res.Exit != "" {
+					return fmt.Sprintf("%s\n(%s)", s, res.Exit), nil
+				}
+				return s, nil
+			}
 			if len(res.Output) > maxOutput {
 				// The model only sees the tail; give it a way to reach the
 				// rest (pi spills truncated bash output to a file too).

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -185,6 +185,9 @@ func bashTool() Tool {
 			if a.Interactive && InteractiveBash != nil {
 				keys := make(chan []byte, 16)
 				out := InteractiveBash.Run(ctx, a.Command, dur, keys)
+				if isBinary([]byte(out)) {
+					return binaryPlaceholder("", len(out)), nil
+				}
 				return TruncateTail(out), nil
 			}
 
@@ -198,6 +201,9 @@ func bashTool() Tool {
 				OnUpdate: onUpdate,
 			})
 
+			if isBinary([]byte(res.Output)) {
+				return binaryPlaceholder("", len(res.Output)), nil
+			}
 			s := TruncateTail(res.Output)
 			if len(res.Output) > maxOutput {
 				// The model only sees the tail; give it a way to reach the
@@ -237,6 +243,9 @@ func readTool() Tool {
 			data, err := os.ReadFile(a.Path)
 			if err != nil {
 				return "", err
+			}
+			if isBinary(data) {
+				return binaryPlaceholder(a.Path, len(data)), nil
 			}
 			lines := strings.Split(string(data), "\n")
 			start := max(a.Offset-1, 0)

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -270,6 +270,17 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		// And the flip side: a real multi-byte rune straddling the cut still
 		// reads as text (the trim path must not break it).
 		{name: "utf8 rune at probe cut stays text", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), []byte("世界")...), want: false},
+		// Regression (review): an INVALID sequence straddling the cut — E0 80
+		// is an overlong-encoding lead with an illegal second byte. The trim
+		// must not drop it as if it were a valid mid-rune prefix.
+		{name: "invalid overlong at probe cut stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-2), 0xE0, 0x80), want: true},
+		// C1 lead byte (0xC0/0xC1 are never legal UTF-8) at the cut boundary.
+		{name: "c1 lead at probe cut stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), 0xC1, 0xBF), want: true},
+		// A valid 3-byte lead whose continuation straddles the 1024-byte cut
+		// (E4 B8 85 = 世: lead + first continuation inside the probe, final
+		// continuation past it) — the legit mid-rune trim case. Padding to
+		// binaryProbeSize-2 puts the third byte past the cut.
+		{name: "incomplete valid rune at cut trims", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-2), 0xE4, 0xB8, 0x85), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -252,39 +252,32 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		{name: "invalid utf8", in: []byte{0xff, 0xfe, 0x00, 'x'}, want: true}, // BOM-ish, not valid
 		{name: "control heavy", in: bytes.Repeat([]byte{0x01}, 100), want: true},
 		{name: "whitespace controls ok", in: []byte("line1\n\tline2\rline3\f\v"), want: false},
-		// Regression: a multi-byte rune straddling the 1024-byte probe cut must
-		// not read as binary — the sample backs off to the last complete rune.
-		{name: "utf8 straddles probe cut", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), []byte("é世界")...), want: false},
+		// Regression: multi-byte runes anywhere in the buffer (including past a
+		// hard 1KB boundary position) must not read as binary — the UTF-8 check
+		// covers the whole buffer, so there is no probe cut to straddle.
+		{name: "utf8 multi-byte deep in buffer", in: append(bytes.Repeat([]byte("a"), 1023), []byte("é世界")...), want: false},
 		// Regression: ANSI-colored output (ls/grep --color) is ESC-heavy but not
 		// binary — ESC is excluded from the control-byte count.
 		{name: "ansi colored output", in: []byte("\x1b[31mred\x1b[0m \x1b[32mgreen\x1b[0m \x1b[1mBold\x1b[0m normal text here\n"), want: false},
-		// Regression: output that starts as clean text but turns binary past
-		// the 1KB probe must still be caught — the NUL scan covers the whole
-		// buffer, not just the prefix.
-		{name: "text then binary past probe", in: append(bytes.Repeat([]byte("a"), binaryProbeSize+100), 0x00, 0x01), want: true},
-		// Regression: a >1KB Latin-1 file (smart quotes, no NULs) has invalid
-		// interior bytes right at the probe cut — backing off must NOT strip a
-		// genuinely-invalid trailing byte and let the file through as text.
-		// Pad past binaryProbeSize so trimToLastRune actually runs.
-		{name: "latin1 at probe cut stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), 0x93, 0x94, 0x92), want: true},
-		// And the flip side: a real multi-byte rune straddling the cut still
-		// reads as text (the trim path must not break it).
-		{name: "utf8 rune at probe cut stays text", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), []byte("世界")...), want: false},
-		// Regression (review): an INVALID sequence straddling the cut — E0 80
-		// is an overlong-encoding lead with an illegal second byte. The trim
-		// must not drop it as if it were a valid mid-rune prefix.
-		{name: "invalid overlong at probe cut stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-2), 0xE0, 0x80), want: true},
-		// C1 lead byte (0xC0/0xC1 are never legal UTF-8) at the cut boundary.
-		{name: "c1 lead at probe cut stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), 0xC1, 0xBF), want: true},
-		// A valid 3-byte lead whose continuation straddles the 1024-byte cut
-		// (E4 B8 85 = 世: lead + first continuation inside the probe, final
-		// continuation past it) — the legit mid-rune trim case. Padding to
-		// binaryProbeSize-2 puts the third byte past the cut.
-		{name: "incomplete valid rune at cut trims", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-2), 0xE4, 0xB8, 0x85), want: false},
-		// Regression (review round 4): invalid UTF-8 PAST the 1KB probe with no
+		// Regression: output that starts as clean text but turns binary later
+		// must still be caught — the NUL scan covers the whole buffer.
+		{name: "text then binary deep in buffer", in: append(bytes.Repeat([]byte("a"), 1124), 0x00, 0x01), want: true},
+		// Regression: a Latin-1 file (smart quotes, no NULs) has invalid UTF-8
+		// bytes anywhere in the buffer — it must read as binary.
+		{name: "latin1 interior bytes stay binary", in: append(bytes.Repeat([]byte("a"), 1023), 0x93, 0x94, 0x92), want: true},
+		// Regression (review): an INVALID sequence — E0 80 is an overlong
+		// encoding lead with an illegal second byte — must read as binary.
+		{name: "invalid overlong stays binary", in: append(bytes.Repeat([]byte("a"), 1022), 0xE0, 0x80), want: true},
+		// C1 lead byte (0xC0/0xC1 are never legal UTF-8).
+		{name: "c1 lead stays binary", in: append(bytes.Repeat([]byte("a"), 1023), 0xC1, 0xBF), want: true},
+		// Regression (review round 4): invalid UTF-8 deep in the buffer with no
 		// NULs (a log file with corrupt bytes partway through) must still be
 		// binary — the UTF-8 check covers the whole buffer, not just the prefix.
-		{name: "invalid utf8 past probe stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize+100), 0x93, 0x94), want: true},
+		{name: "invalid utf8 deep in buffer stays binary", in: append(bytes.Repeat([]byte("a"), 1124), 0x93, 0x94), want: true},
+		// Regression (review round 5): a NUL-free control-junk tail (text then
+		// 4KB of 0x01) passes NUL/UTF-8 — the density check must cover the whole
+		// buffer too, not just a prefix.
+		{name: "control junk tail in buffer", in: append(bytes.Repeat([]byte("a"), 1024), bytes.Repeat([]byte{0x01}, 4096)...), want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -263,9 +263,13 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		// buffer, not just the prefix.
 		{name: "text then binary past probe", in: append(bytes.Repeat([]byte("a"), binaryProbeSize+100), 0x00, 0x01), want: true},
 		// Regression: a >1KB Latin-1 file (smart quotes, no NULs) has invalid
-		// interior bytes — backing off the probe cut must NOT strip to the
-		// longest valid prefix and let them through as text.
-		{name: "latin1 interior bytes stay binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-10), 0x93, 0x94, 0x92), want: true},
+		// interior bytes right at the probe cut — backing off must NOT strip a
+		// genuinely-invalid trailing byte and let the file through as text.
+		// Pad past binaryProbeSize so trimToLastRune actually runs.
+		{name: "latin1 at probe cut stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), 0x93, 0x94, 0x92), want: true},
+		// And the flip side: a real multi-byte rune straddling the cut still
+		// reads as text (the trim path must not break it).
+		{name: "utf8 rune at probe cut stays text", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), []byte("世界")...), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,9 +1,11 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -229,5 +231,61 @@ func TestWriteToolDiffOnOverwrite(t *testing.T) {
 	}
 	if !strings.Contains(out, "```diff") || !strings.Contains(out, "2 - b") || !strings.Contains(out, "2 + c") {
 		t.Fatalf("overwrite should diff with absolute line numbers: %q", out)
+	}
+}
+
+// Binary tool output must be replaced with a compact placeholder instead of
+// having raw NUL/control bytes or base64 garbage injected into the
+// conversation. isBinary drives the read/bash gate; read exercises the full
+// path with a real binary file, bash with a synthetic binary stream.
+func TestBinaryOutputPlaceholder(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{name: "empty text", in: nil, want: false},
+		{name: "plain text", in: []byte("package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"hi\") }\n"), want: false},
+		{name: "utf8 text", in: []byte("héllo wörld → ütf8 ✓\n"), want: false},
+		{name: "single nul", in: []byte{0x00}, want: true},
+		{name: "nul in text", in: append([]byte("abc"), 0x00, 'd', 'e', 'f'), want: true},
+		{name: "invalid utf8", in: []byte{0xff, 0xfe, 0x00, 'x'}, want: true}, // BOM-ish, not valid
+		{name: "control heavy", in: bytes.Repeat([]byte{0x01}, 100), want: true},
+		{name: "whitespace controls ok", in: []byte("line1\n\tline2\rline3\f\v"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBinary(tt.in); got != tt.want {
+				t.Fatalf("isBinary(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	// read: a real binary file straight through the read tool.
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "blob.bin")
+	raw := append(bytes.Repeat([]byte{0x01, 0x02, 0x03}, 40), 0x00, 0x00, 0x00) // ~120 bytes binary
+	if err := os.WriteFile(bin, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := run(t, "read", fmt.Sprintf(`{"path":%q}`, bin))
+	want := fmt.Sprintf("[binary: %s, %s]", bin, bytesHuman(len(raw)))
+	if out != want {
+		t.Fatalf("read placeholder:\n got %q\nwant %q", out, want)
+	}
+
+	// bash: a command that streams binary bytes. NULs can't travel through a
+	// shell string argument, so write a binary file and cat it.
+	if out := run(t, "bash", fmt.Sprintf(`{"command":"cat %s | head -c 200"}`, bin)); !strings.Contains(out, "not shown") {
+		t.Fatalf("bash binary output not replaced: %q", out)
+	}
+
+	// A plain-text read still returns line-numbered content.
+	txt := filepath.Join(dir, "text.txt")
+	if err := os.WriteFile(txt, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out := run(t, "read", fmt.Sprintf(`{"path":%q}`, txt)); !strings.Contains(out, "2\ttwo") {
+		t.Fatalf("text read should stay intact: %q", out)
 	}
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -252,6 +252,12 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		{name: "invalid utf8", in: []byte{0xff, 0xfe, 0x00, 'x'}, want: true}, // BOM-ish, not valid
 		{name: "control heavy", in: bytes.Repeat([]byte{0x01}, 100), want: true},
 		{name: "whitespace controls ok", in: []byte("line1\n\tline2\rline3\f\v"), want: false},
+		// Regression: a multi-byte rune straddling the 1024-byte probe cut must
+		// not read as binary — the sample backs off to the last complete rune.
+		{name: "utf8 straddles probe cut", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-1), []byte("é世界")...), want: false},
+		// Regression: ANSI-colored output (ls/grep --color) is ESC-heavy but not
+		// binary — ESC is excluded from the control-byte count.
+		{name: "ansi colored output", in: []byte("\x1b[31mred\x1b[0m \x1b[32mgreen\x1b[0m \x1b[1mBold\x1b[0m normal text here\n"), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -262,6 +262,10 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		// the 1KB probe must still be caught — the NUL scan covers the whole
 		// buffer, not just the prefix.
 		{name: "text then binary past probe", in: append(bytes.Repeat([]byte("a"), binaryProbeSize+100), 0x00, 0x01), want: true},
+		// Regression: a >1KB Latin-1 file (smart quotes, no NULs) has invalid
+		// interior bytes — backing off the probe cut must NOT strip to the
+		// longest valid prefix and let them through as text.
+		{name: "latin1 interior bytes stay binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-10), 0x93, 0x94, 0x92), want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -281,6 +281,10 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		// continuation past it) — the legit mid-rune trim case. Padding to
 		// binaryProbeSize-2 puts the third byte past the cut.
 		{name: "incomplete valid rune at cut trims", in: append(bytes.Repeat([]byte("a"), binaryProbeSize-2), 0xE4, 0xB8, 0x85), want: false},
+		// Regression (review round 4): invalid UTF-8 PAST the 1KB probe with no
+		// NULs (a log file with corrupt bytes partway through) must still be
+		// binary — the UTF-8 check covers the whole buffer, not just the prefix.
+		{name: "invalid utf8 past probe stays binary", in: append(bytes.Repeat([]byte("a"), binaryProbeSize+100), 0x93, 0x94), want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -258,6 +258,10 @@ func TestBinaryOutputPlaceholder(t *testing.T) {
 		// Regression: ANSI-colored output (ls/grep --color) is ESC-heavy but not
 		// binary — ESC is excluded from the control-byte count.
 		{name: "ansi colored output", in: []byte("\x1b[31mred\x1b[0m \x1b[32mgreen\x1b[0m \x1b[1mBold\x1b[0m normal text here\n"), want: false},
+		// Regression: output that starts as clean text but turns binary past
+		// the 1KB probe must still be caught — the NUL scan covers the whole
+		// buffer, not just the prefix.
+		{name: "text then binary past probe", in: append(bytes.Repeat([]byte("a"), binaryProbeSize+100), 0x00, 0x01), want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -80,6 +80,12 @@ func shellExec(cmdLine string) string {
 	// turn, and esc stays bound to turn interruption. The 120s cap bounds it.
 	res := bashrun.Run(context.Background(), bashrun.Options{Command: cmdLine})
 	out := tools.TruncateTail(res.Output)
+	if tools.IsBinary([]byte(res.Output)) {
+		// Same gate as the bash tool: a `!` escape whose output is binary
+		// (cat image.png, a corrupt log) injects junk into the conversation
+		// otherwise. The placeholder keeps the exit-status/timeout suffixes.
+		out = tools.BinaryPlaceholder("", len(res.Output))
+	}
 	if res.TimedOut {
 		out += "\n(command timed out)"
 	} else if res.Exit != "" {

--- a/internal/tui/shell_binary_test.go
+++ b/internal/tui/shell_binary_test.go
@@ -1,0 +1,23 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A `!` shell escape whose output is binary must land in the conversation as
+// the placeholder, not raw bytes — same gate as the bash tool.
+func TestShellEscapeBinaryOutputGated(t *testing.T) {
+	out := shellExec("cat /opt/homebrew/bin/whip | head -c 200")
+	if !strings.Contains(out, "[binary output:") {
+		t.Errorf("binary shell output was not gated: %q", out[:min(len(out), 80)])
+	}
+}
+
+// A normal `!` command still passes through unchanged.
+func TestShellEscapeTextOutputPasses(t *testing.T) {
+	out := shellExec("echo hello")
+	if !strings.Contains(out, "hello") {
+		t.Errorf("text shell output was gated: %q", out)
+	}
+}

--- a/internal/tui/shell_binary_test.go
+++ b/internal/tui/shell_binary_test.go
@@ -8,7 +8,9 @@ import (
 // A `!` shell escape whose output is binary must land in the conversation as
 // the placeholder, not raw bytes — same gate as the bash tool.
 func TestShellEscapeBinaryOutputGated(t *testing.T) {
-	out := shellExec("cat /opt/homebrew/bin/whip | head -c 200")
+	// Generate binary output portably (printf emits raw NUL bytes) — no
+	// dependence on a platform-specific binary path.
+	out := shellExec("printf '\\x00\\x01\\x02\\x03\\x04\\x05'")
 	if !strings.Contains(out, "[binary output:") {
 		t.Errorf("binary shell output was not gated: %q", out[:min(len(out), 80)])
 	}


### PR DESCRIPTION
## What

Reading a binary file (`file`/`strings`/`cat` on a binary, .png, .sqlite) injected raw binary/base64 garbage into the conversation and reasoning pane — screenfuls of junk the model can't use and the user can't scroll past. (Visible in the screenshot that prompted this: a reasoning pane full of `©@!60096G6a` and base64 blocks from `strings` on the whip binary.)

## Fix

Sniff binary output before it enters the message stream and replace it with a compact placeholder:
- **read tool**: `[binary: <path>, <size>]`
- **bash tool**: `[binary output: <size>, not shown]`

Detection on the first 1 KB (stdlib-only, no new deps): `!utf8.Valid`, any NUL byte, or >10% C0 control bytes (excluding tab/newline/CR/FF/VT). Runs before truncation so text-path behavior is unchanged. Sizes humanized (KB/MB/GB).

## Testing

- `go test ./internal/tools/...` green.
- `TestBinaryOutputPlaceholder`: table-driven `isBinary` cases (empty/plain/UTF-8 text, single NUL, NUL-in-text, invalid UTF-8, control-heavy, benign whitespace controls) plus a full-path test writing a real binary via `t.TempDir` — read returns the exact placeholder, `cat <bin> | head` through bash returns the not-shown placeholder, a text read keeps line-numbered content.