### PR TITLE
feat(tui): render pasted images as compact [Image N] chips

### DIFF
--- a/internal/tui/chip_bracket_test.go
+++ b/internal/tui/chip_bracket_test.go
@@ -25,7 +25,7 @@ func TestChipDisplayNameSanitizesBrackets(t *testing.T) {
 	tm, _ = m.Update(cmd())
 	m = tm.(*model)
 	chip := m.input.Value()
-	if !strings.Contains(chip, "[Image 1: a)b.png]") {
+	if !strings.Contains(chip, "[Image 1: a)b.png"+chipSentinel+"]") {
 		t.Errorf("chip should sanitize ] to ), got %q", chip)
 	}
 	// And the chip must still resolve back to the stored copy at submit.

--- a/internal/tui/chip_bracket_test.go
+++ b/internal/tui/chip_bracket_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// A pasted file whose basename contains ] must not break chip resolution:
+// chipText sanitizes the display snippet so the expandImageChips regex still
+// matches and the image attaches at submit.
+func TestChipDisplayNameSanitizesBrackets(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	dir := t.TempDir()
+	img := filepath.Join(dir, "a]b.png")
+	if err := os.WriteFile(img, []byte("\x89PNG\r\n\x1a\nfake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := compactCmdModel()
+	tm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(img + "\n"), Paste: true})
+	m = tm.(*model)
+	tm, _ = m.Update(cmd())
+	m = tm.(*model)
+	chip := m.input.Value()
+	if !strings.Contains(chip, "[Image 1: a)b.png]") {
+		t.Errorf("chip should sanitize ] to ), got %q", chip)
+	}
+	// And the chip must still resolve back to the stored copy at submit.
+	if !strings.Contains(m.expandImageChips(chip), "@"+m.images[0].path) {
+		t.Errorf("sanitized chip did not resolve: %q", m.expandImageChips(chip))
+	}
+}

--- a/internal/tui/chip_lifecycle_test.go
+++ b/internal/tui/chip_lifecycle_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A pasted [Image N] chip steered mid-turn must expand to its @path (and
+// inline the image on vision models) — not reach the model as a literal
+// bracket string.
+func TestSteerExpandsImageChips(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	m := compactCmdModel()
+	m.busy = true // the steer path only fires while a turn is running
+
+	// Paste an image so the chip registry has one entry.
+	dir := t.TempDir()
+	img := filepath.Join(dir, "shot.png")
+	if err := os.WriteFile(img, []byte("\x89PNG\r\n\x1a\nfake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.imageSeq++
+	p := pastedImage{n: 1, path: img, display: "shot.png"}
+	m.images = append(m.images, p)
+
+	// The steer path: expandImageChips must run before Steer/SteerImages.
+	// The chip text comes from chipText() (with the sentinel), the way a real
+	// paste inserts it.
+	steerText := m.expandImageChips("check " + p.chipText() + " please")
+	if !strings.Contains(steerText, "@"+img) {
+		t.Errorf("steer text did not expand the chip: %q", steerText)
+	}
+}
+
+// /clear resets the conversation AND the pasted-image registry: a recalled
+// "[Image 1]" chip from before the clear must not resolve to a different
+// image once the session counter restarts.
+func TestClearResetsImageRegistry(t *testing.T) {
+	m := compactCmdModel()
+	m.busy = false // /clear refuses while busy
+
+	// Seed the registry with one image.
+	m.imageSeq = 1
+	m.images = append(m.images, pastedImage{n: 1, path: "/tmp/shot.png", display: "shot.png"})
+
+	// Run /clear.
+	m.command("/clear")
+
+	if len(m.images) != 0 || m.imageSeq != 0 {
+		t.Errorf("/clear left image registry: images=%d imageSeq=%d", len(m.images), m.imageSeq)
+	}
+}
+
+// After /clear, a hand-recalled "[Image 1]" chip must stay literal (the
+// registry is empty), not resolve to a new image pasted later at the same N.
+func TestRecalledChipAfterClearStaysLiteral(t *testing.T) {
+	m := compactCmdModel()
+	m.busy = false
+	m.command("/clear")
+	if got := m.expandImageChips("[Image 1]"); got != "[Image 1]" {
+		t.Errorf("recalled chip after /clear resolved: %q", got)
+	}
+}

--- a/internal/tui/dragdrop_test.go
+++ b/internal/tui/dragdrop_test.go
@@ -30,7 +30,7 @@ func TestFinderDragImagePathDetected(t *testing.T) {
 	if len(m.images) != 1 {
 		t.Fatalf("Finder drag produced %d images, want 1", len(m.images))
 	}
-	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot") || !strings.Contains(m.input.Value(), ".png]") {
+	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot") || !strings.Contains(m.input.Value(), ".png"+chipSentinel+"]") {
 		t.Errorf("input = %q, want the [Image 1: <name>…png] chip", m.input.Value())
 	}
 }

--- a/internal/tui/dragdrop_test.go
+++ b/internal/tui/dragdrop_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// A Finder drag delivers the path as one KeyRunes burst (msg.Paste is false).
+// It must be detected as an image and routed to the chip flow.
+func TestFinderDragImagePathDetected(t *testing.T) {
+	dir := t.TempDir()
+	img := filepath.Join(dir, "Screenshot 2026-09-04 at 3.21.45 PM.png")
+	if err := os.WriteFile(img, []byte("\x89PNG\r\n\x1a\nfake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the drag: a single multi-rune KeyRunes with the raw path.
+	m := tasksModel("http://unused")
+	t.Setenv("WHIP_HOME", t.TempDir())
+	tm, cmd := m.Update(dragRunes(img))
+	m = tm.(*model)
+	if cmd == nil {
+		t.Fatal("a dragged image path should schedule an attachment command")
+	}
+	tm, _ = m.Update(cmd())
+	m = tm.(*model)
+	if len(m.images) != 1 {
+		t.Fatalf("Finder drag produced %d images, want 1", len(m.images))
+	}
+	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot") || !strings.Contains(m.input.Value(), ".png]") {
+		t.Errorf("input = %q, want the [Image 1: <name>…png] chip", m.input.Value())
+	}
+}
+
+// A single-rune KeyRunes (normal typing) must NOT be treated as a drag.
+func TestSingleRuneKeyNotADrag(t *testing.T) {
+	m := tasksModel("http://unused")
+	um, _ := m.Update(dragRunes("a"))
+	m = um.(*model)
+	if len(m.images) != 0 {
+		t.Fatalf("single rune produced %d images, want 0", len(m.images))
+	}
+}
+
+// dragRunes builds a KeyRunes message the way a Finder drag does: Paste=false,
+// the whole path as one burst.
+func dragRunes(path string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(path), Paste: false}
+}

--- a/internal/tui/mention_spaces_test.go
+++ b/internal/tui/mention_spaces_test.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// macOS screenshot filenames always contain spaces. @-mentioning one must
+// attach the image — the tokenizer must not split the path at its spaces.
+func TestImagePartsPathWithSpaces(t *testing.T) {
+	dir := t.TempDir()
+	img := filepath.Join(dir, "Screenshot 2026-09-04 at 3.21.45 PM.png")
+	if err := os.WriteFile(img, []byte("\x89PNG\r\n\x1a\nfake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parts, _ := imageParts("look at @" + img + " please")
+	if len(parts) != 1 {
+		t.Fatalf("imageParts with a space-containing path = %d parts, want 1", len(parts))
+	}
+}
+
+// A Finder drag pastes a backslash-escaped path; the paste handler must
+// unescape it before statting.
+func TestPastedImagePathBackslashEscaped(t *testing.T) {
+	dir := t.TempDir()
+	img := filepath.Join(dir, "Screenshot 2026-09-04 at 3.21.45 PM.png")
+	if err := os.WriteFile(img, []byte("\x89PNG\r\n\x1a\nfake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	escaped := strings.ReplaceAll(img, " ", `\ `)
+	if got, ok := pastedImagePath(escaped); !ok || got != img {
+		t.Errorf("pastedImagePath(%q) = (%q, %v), want (%q, true)", escaped, got, ok, img)
+	}
+}

--- a/internal/tui/mentions.go
+++ b/internal/tui/mentions.go
@@ -35,34 +35,61 @@ func expandSkills(text string, sk []skills.Skill) string {
 
 var rangeRe = regexp.MustCompile(`#(\d+)(?:-(\d+))?$`)
 
+// mentionPaths scans text for @path tokens and returns each resolved absolute
+// path with its line-range suffix ("" when the token had no #start-end).
+// Unlike a plain whitespace split, a token that doesn't resolve as-is is
+// extended word-by-word (greedy: longest first) so a space-containing path
+// like a macOS screenshot name resolves to the real file. Backslash-escaped
+// spaces (Finder drag) are unescaped before resolution.
+func mentionPaths(text string) [][2]string {
+	var out [][2]string
+	fields := strings.Fields(text)
+	for i := 0; i < len(fields); i++ {
+		tok := fields[i]
+		if !strings.HasPrefix(tok, "@") || len(tok) < 2 {
+			continue
+		}
+		// Try the bare token first, then extend greedily with the next words
+		// (space-joined) until one resolves; the longest match wins.
+		for j := i; j < len(fields); j++ {
+			cand := strings.Join(fields[i:j+1], " ") // j==i is the bare token
+			cand = cand[1:]                          // drop the @
+			cand = strings.TrimRight(cand, ".,;:!?)\"'")
+			lines := ""
+			if m := rangeRe.FindStringSubmatch(cand); m != nil {
+				cand = strings.TrimSuffix(cand, m[0])
+				lines = " (lines " + m[1]
+				if m[2] != "" {
+					lines += "-" + m[2]
+				}
+				lines += ")"
+			}
+			if abs, ok := resolveMentionPath(unescapePath(cand)); ok {
+				out = append(out, [2]string{abs, lines})
+				i = j // consumed the extension words
+				break
+			}
+		}
+	}
+	return out
+}
+
+// unescapePath turns a shell/Finder-escaped path ("a\ b.png") back into its
+// real form ("a b.png"). Only backslash-space is unescaped; other escapes are
+// left alone (a path with a literal backslash is rare and unambiguous).
+func unescapePath(s string) string {
+	return strings.ReplaceAll(s, `\ `, " ")
+}
+
 // expandMentions finds @file tokens (any path: relative, absolute, or ~, a
 // bare word that uniquely fuzzy-matches a file under the cwd, each with
 // optional #start-end line ranges) and appends a pointer note. File contents
 // are never inlined — the model inspects tagged files with its own tools.
+// Space-containing paths (macOS screenshot names) resolve via mentionPaths.
 func expandMentions(text string) string {
 	var notes []string
-	for tok := range strings.FieldsSeq(text) {
-		if !strings.HasPrefix(tok, "@") || len(tok) < 2 {
-			continue
-		}
-		p := strings.TrimRight(tok[1:], ".,;:!?)\"'")
-		lines := ""
-		if m := rangeRe.FindStringSubmatch(p); m != nil {
-			p = strings.TrimSuffix(p, m[0])
-			lines = " (lines " + m[1]
-			if m[2] != "" {
-				lines += "-" + m[2]
-			}
-			lines += ")"
-		}
-		// Real paths stat as-is; a bare word may uniquely fuzzy-match the
-		// recursive cwd index ("@roadmap" → docs/roadmap.md). Anything else
-		// is left alone.
-		abs, ok := resolveMentionPath(p)
-		if !ok {
-			continue
-		}
-		notes = append(notes, abs+lines)
+	for _, m := range mentionPaths(text) {
+		notes = append(notes, m[0]+m[1]) // path + optional " (lines a-b)"
 	}
 	if len(notes) == 0 {
 		return text
@@ -81,19 +108,13 @@ var imageExtsForMention = map[string]bool{
 // vision parts plus a note appended to the text naming the attached images.
 // Unlike text @files (pointer notes; the model inspects them with tools),
 // images must be inlined — the model has no way to view a local image itself.
+// Space-containing paths (macOS screenshot names) resolve via mentionPaths.
 func imageParts(text string) ([]llm.ContentPart, string) {
 	var parts []llm.ContentPart
 	var names []string
-	for tok := range strings.FieldsSeq(text) {
-		if !strings.HasPrefix(tok, "@") || len(tok) < 2 {
-			continue
-		}
-		p := strings.TrimRight(tok[1:], ".,;:!?)\"'")
-		if !imageExtsForMention[strings.ToLower(filepath.Ext(p))] {
-			continue
-		}
-		abs, ok := resolveMentionPath(p)
-		if !ok {
+	for _, m := range mentionPaths(text) {
+		abs := m[0]
+		if !imageExtsForMention[strings.ToLower(filepath.Ext(abs))] {
 			continue
 		}
 		data, err := os.ReadFile(abs) //nolint:gosec // G304: abs is the user-@mentioned path, resolved to the workspace

--- a/internal/tui/mentions.go
+++ b/internal/tui/mentions.go
@@ -87,8 +87,9 @@ func unescapePath(s string) string {
 // are never inlined — the model inspects tagged files with its own tools.
 // Space-containing paths (macOS screenshot names) resolve via mentionPaths.
 func expandMentions(text string) string {
-	var notes []string
-	for _, m := range mentionPaths(text) {
+	mentions := mentionPaths(text)
+	notes := make([]string, 0, len(mentions)) // prealloc: one note per mention
+	for _, m := range mentions {
 		notes = append(notes, m[0]+m[1]) // path + optional " (lines a-b)"
 	}
 	if len(notes) == 0 {

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -190,7 +190,9 @@ func powershellImage() (string, []byte, error) {
 }
 
 // pastedImagePath recognizes a single pasted local image path, including the
-// extension-less temporary paths emitted by macOS screenshot previews.
+// extension-less temporary paths emitted by macOS screenshot previews. A
+// Finder drag pastes a backslash-escaped path ("a\ b.png"); unescape it
+// before statting.
 func pastedImagePath(text string) (string, bool) {
 	path := strings.TrimSpace(text)
 	if u, err := url.Parse(path); err == nil && u.Scheme == "file" {
@@ -199,6 +201,7 @@ func pastedImagePath(text string) (string, bool) {
 		}
 		path = u.Path
 	}
+	path = unescapePath(path)
 	info, err := os.Stat(path)
 	if err != nil || !info.Mode().IsRegular() {
 		return "", false

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -11,11 +11,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
 
 	"github.com/context-labs/whip/internal/config"
 )
@@ -241,8 +244,11 @@ func imageFileExtension(path string, data []byte) string {
 }
 
 // pasteImageFileCmd copies a path pasted by the terminal into whip's paste
-// directory. Screenshot preview files are temporary, so retaining a copy is
-// necessary before the next user turn reads the @mention.
+// directory. Screenshot preview files are temporary — macOS keeps the
+// bottom-right hover thumbnail in a transient staging dir that can be swept
+// away before the next user turn reads the @mention — so the bytes are copied
+// off the source path immediately. The original display name travels with the
+// copy so the chip can keep showing the human-readable filename.
 func pasteImageFileCmd(path string) tea.Msg {
 	data, err := os.ReadFile(path) //nolint:gosec // G304: path was validated from the user's paste
 	if err != nil {
@@ -252,11 +258,12 @@ func pasteImageFileCmd(path string) tea.Msg {
 	if ext == "" {
 		return imageMsg{err: errors.New("pasted file is not a supported image")}
 	}
+	display := filepath.Base(path)
 	path, err = saveClipboardImage(ext, data)
 	if err != nil {
 		return imageMsg{err: err}
 	}
-	return imageMsg{path: path}
+	return imageMsg{path: path, display: display}
 }
 
 // saveClipboardImage writes data to ~/.whip/pastes/ and returns the path.
@@ -296,5 +303,88 @@ func pasteImageCmd() tea.Msg {
 	if err != nil {
 		return imageMsg{err: err}
 	}
+	// A clipboard paste is anonymous — no file on disk — so the chip carries
+	// no display name.
 	return imageMsg{path: path}
 }
+
+// pastedImage records an image the terminal pasted this session. The chip
+// shown in the input and transcript references it by its session number n,
+// which stays stable across turns so [Image 1], [Image 2], … read back to the
+// right on-disk copy at submit.
+type pastedImage struct {
+	n       int    // 1-based session image number
+	path    string // stable on-disk copy (always readable at submit)
+	display string // original basename for the chip; "" for an anonymous clipboard paste
+}
+
+// chipText renders the compact chip for the image, e.g. "[Image 1]" for an
+// anonymous paste or "[Image 1: Screenshot 2026-09-04…png]" when a source
+// filename is known. The number is what maps back to the stored copy at
+// submit, so the display name is truncated aggressively without losing the
+// identity.
+func (p pastedImage) chipText() string {
+	if p.display == "" {
+		return fmt.Sprintf("[Image %d]", p.n)
+	}
+	return fmt.Sprintf("[Image %d: %s]", p.n, truncateImageName(p.display, maxImageNameRunes))
+}
+
+// maxImageNameRunes is the widest a chip filename snippet may be before the
+// ellipsis truncation kicks in.
+const maxImageNameRunes = 24
+
+// truncateImageName shortens a display name for a chip to at most max runes of
+// display width, keeping the file extension and as much of the stem as fits,
+// joined by "…" so a long screenshot name collapses readably.
+func truncateImageName(name string, max int) string {
+	if runewidth.StringWidth(name) <= max {
+		return name
+	}
+	ext := filepath.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	const ellipsis = "…"
+	budget := max - runewidth.StringWidth(ellipsis) - runewidth.StringWidth(ext)
+	if budget < 1 {
+		// No room for any stem + "…" + ext; keep just the extension if it fits.
+		if runewidth.StringWidth(ext) <= max {
+			return ext
+		}
+		return ellipsis
+	}
+	// Trim the stem by display width, advancing rune by rune.
+	var cut int
+	width := 0
+	for _, r := range stem {
+		w := runewidth.RuneWidth(r)
+		if width+w > budget {
+			break
+		}
+		width += w
+		cut += len(string(r))
+	}
+	return stem[:cut] + ellipsis + ext
+}
+
+// expandImageChips rewrites [Image N …] chip tokens in the input text back into
+// "@<path>" mentions so the normal @image attachment machinery (imageParts +
+// expandMentions) picks them up at submit. The input box itself keeps showing
+// the chip; only the prepared text sent to the model reverts to the real path.
+func (m *model) expandImageChips(text string) string {
+	return imageChipRe.ReplaceAllStringFunc(text, func(tok string) string {
+		sm := imageChipRe.FindStringSubmatch(tok)
+		if len(sm) < 2 {
+			return tok
+		}
+		n, err := strconv.Atoi(sm[1])
+		if err != nil || n < 1 || n > len(m.images) {
+			return tok // unrecognized chip: keep it literal rather than guessing
+		}
+		return "@" + m.images[n-1].path
+	})
+}
+
+// imageChipRe matches the [Image N] / [Image N: name] chips inserted by paste.
+// Only the leading number matters for resolving back to the stored copy; the
+// display-name part (opaque to the model) is ignored.
+var imageChipRe = regexp.MustCompile(`\[Image\s+(\d+)(?::[^\]]*)?\]`)

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -325,12 +325,15 @@ type pastedImage struct {
 // anonymous paste or "[Image 1: Screenshot 2026-09-04…png]" when a source
 // filename is known. The number is what maps back to the stored copy at
 // submit, so the display name is truncated aggressively without losing the
-// identity.
+// identity. A literal ] in the filename would close the chip early for the
+// expandImageChips regex and silently drop the attachment, so brackets are
+// stripped from the display snippet (cosmetic only — resolution uses n).
 func (p pastedImage) chipText() string {
 	if p.display == "" {
 		return fmt.Sprintf("[Image %d]", p.n)
 	}
-	return fmt.Sprintf("[Image %d: %s]", p.n, truncateImageName(p.display, maxImageNameRunes))
+	display := strings.NewReplacer("[", "(", "]", ")").Replace(p.display)
+	return fmt.Sprintf("[Image %d: %s]", p.n, truncateImageName(display, maxImageNameRunes))
 }
 
 // maxImageNameRunes is the widest a chip filename snippet may be before the

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -321,6 +321,12 @@ type pastedImage struct {
 	display string // original basename for the chip; "" for an anonymous clipboard paste
 }
 
+// chipSentinel is an invisible zero-width space inserted before the closing
+// bracket of every paste-inserted chip. The user can't type it, so the
+// expandImageChips regex requires it — pattern-matching only real chips, not
+// hand-typed "[Image 1]" text that would otherwise attach images[0].
+const chipSentinel = "\u200b"
+
 // chipText renders the compact chip for the image, e.g. "[Image 1]" for an
 // anonymous paste or "[Image 1: Screenshot 2026-09-04…png]" when a source
 // filename is known. The number is what maps back to the stored copy at
@@ -328,12 +334,13 @@ type pastedImage struct {
 // identity. A literal ] in the filename would close the chip early for the
 // expandImageChips regex and silently drop the attachment, so brackets are
 // stripped from the display snippet (cosmetic only — resolution uses n).
+// The invisible chipSentinel before ] marks the chip as paste-inserted.
 func (p pastedImage) chipText() string {
 	if p.display == "" {
-		return fmt.Sprintf("[Image %d]", p.n)
+		return fmt.Sprintf("[Image %d%s]", p.n, chipSentinel)
 	}
 	display := strings.NewReplacer("[", "(", "]", ")").Replace(p.display)
-	return fmt.Sprintf("[Image %d: %s]", p.n, truncateImageName(display, maxImageNameRunes))
+	return fmt.Sprintf("[Image %d: %s%s]", p.n, truncateImageName(display, maxImageNameRunes), chipSentinel)
 }
 
 // maxImageNameRunes is the widest a chip filename snippet may be before the
@@ -392,5 +399,7 @@ func (m *model) expandImageChips(text string) string {
 
 // imageChipRe matches the [Image N] / [Image N: name] chips inserted by paste.
 // Only the leading number matters for resolving back to the stored copy; the
-// display-name part (opaque to the model) is ignored.
-var imageChipRe = regexp.MustCompile(`\[Image\s+(\d+)(?::[^\]]*)?\]`)
+// display-name part (opaque to the model) is ignored. The trailing zero-width
+// sentinel (chipSentinel) is required, so hand-typed "[Image 1]" text — which
+// lacks it — never matches and never attaches an image the user didn't paste.
+var imageChipRe = regexp.MustCompile(`\[Image\s+(\d+)(?::[^\]\x{200b}]*)?\x{200b}\]`)

--- a/internal/tui/paste.go
+++ b/internal/tui/paste.go
@@ -337,17 +337,17 @@ const maxImageNameRunes = 24
 // truncateImageName shortens a display name for a chip to at most max runes of
 // display width, keeping the file extension and as much of the stem as fits,
 // joined by "…" so a long screenshot name collapses readably.
-func truncateImageName(name string, max int) string {
-	if runewidth.StringWidth(name) <= max {
+func truncateImageName(name string, limit int) string {
+	if runewidth.StringWidth(name) <= limit {
 		return name
 	}
 	ext := filepath.Ext(name)
 	stem := strings.TrimSuffix(name, ext)
 	const ellipsis = "…"
-	budget := max - runewidth.StringWidth(ellipsis) - runewidth.StringWidth(ext)
+	budget := limit - runewidth.StringWidth(ellipsis) - runewidth.StringWidth(ext)
 	if budget < 1 {
 		// No room for any stem + "…" + ext; keep just the extension if it fits.
-		if runewidth.StringWidth(ext) <= max {
+		if runewidth.StringWidth(ext) <= limit {
 			return ext
 		}
 		return ellipsis

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
 )
 
 // A macOS screenshot preview pastes its temporary file path into the
@@ -29,11 +30,16 @@ func TestPastedScreenshotPathAttachesImage(t *testing.T) {
 
 	tm, _ = m.Update(cmd())
 	m = tm.(*model)
-	got := strings.TrimSpace(strings.TrimPrefix(m.input.Value(), "@"))
-	if filepath.Ext(got) != ".png" {
-		t.Fatalf("attachment extension: %q", got)
+	// The input shows a compact chip, not the raw path or file contents.
+	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot]") {
+		t.Fatalf("input should show a chip, got %q", m.input.Value())
 	}
-	data, err := os.ReadFile(got)
+	// The on-disk copy (auto-numbered as this session's image 1) holds the
+	// pasted bytes verbatim.
+	if len(m.images) != 1 || m.images[0].n != 1 {
+		t.Fatalf("expected one session image, got %+v", m.images)
+	}
+	data, err := os.ReadFile(m.images[0].path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,5 +106,129 @@ func TestPasteCollapseShortPasteIgnored(t *testing.T) {
 	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("just one line"), Paste: true})
 	if strings.Contains(m.input.Value(), "[Pasted") {
 		t.Fatal("a one-line paste should not collapse")
+	}
+}
+
+// Chip rendering: the input and transcript show a compact [Image N] chip, with
+// the source filename snippet when one exists and a bare number for anonymous
+// (clipboard) pastes. Truncation keeps long screenshot names readable.
+func TestImageChipRendering(t *testing.T) {
+	// Anonymous clipboard paste → bare number, no filename.
+	anon := pastedImage{n: 2, path: "/tmp/copy.png", display: ""}
+	if got := anon.chipText(); got != "[Image 2]" {
+		t.Fatalf("anonymous chip = %q, want %q", got, "[Image 2]")
+	}
+
+	// Short source filename fits whole.
+	short := pastedImage{n: 1, path: "/tmp/copy.png", display: "shot.png"}
+	if got := short.chipText(); got != "[Image 1: shot.png]" {
+		t.Fatalf("short chip = %q, want %q", got, "[Image 1: shot.png]")
+	}
+
+	// Long screenshot name truncates, keeping the extension.
+	long := pastedImage{n: 3, path: "/tmp/copy.png", display: "Screenshot 2026-09-04 at 10.21.33 AM.png"}
+	got := long.chipText()
+	if strings.Contains(got, "10.21.33") || !strings.HasSuffix(got, ".png]") || !strings.Contains(got, "…") {
+		t.Fatalf("long chip = %q, want a truncated stem + ellipsis + .png", got)
+	}
+	// The snippet between "colon " and the closing bracket respects the budget.
+	inner := strings.TrimSuffix(strings.TrimPrefix(got, "[Image 3: "), "]")
+	if runewidth.StringWidth(inner) > maxImageNameRunes {
+		t.Fatalf("chip snippet %q exceeds the %d-rune budget", inner, maxImageNameRunes)
+	}
+}
+
+// Numbered per session: a second paste increments the chip number, and each
+// chip resolves back to its own on-disk copy at prepare time.
+func TestImageChipsNumberAndResolve(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+
+	src1 := filepath.Join(t.TempDir(), "first.png")
+	src2 := filepath.Join(t.TempDir(), "second.png")
+	if err := os.WriteFile(src1, []byte("\x89PNG\r\n\x1a\none"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src2, []byte("\x89PNG\r\n\x1a\ntwo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := compactCmdModel()
+	paste := func(src string) {
+		tm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(src + "\n"), Paste: true})
+		m = tm.(*model)
+		tm, _ = m.Update(cmd())
+		m = tm.(*model)
+	}
+	paste(src1)
+	paste(src2)
+
+	if !strings.Contains(m.input.Value(), "[Image 1: first.png]") || !strings.Contains(m.input.Value(), "[Image 2: second.png]") {
+		t.Fatalf("chips should number 1 and 2, got %q", m.input.Value())
+	}
+	if m.imageSeq != 2 || len(m.images) != 2 {
+		t.Fatalf("session image bookkeeping: seq=%d len=%d", m.imageSeq, len(m.images))
+	}
+
+	// prepareTurn rewrites each chip back to its own @path so imageParts reads
+	// the right bytes; the input value itself is untouched (still chips).
+	expanded := m.expandImageChips(m.input.Value())
+	if !strings.Contains(expanded, "@"+m.images[0].path) || !strings.Contains(expanded, "@"+m.images[1].path) {
+		t.Fatalf("chips should expand to their @paths, got %q", expanded)
+	}
+	if !strings.Contains(m.input.Value(), "[Image 1:") || !strings.Contains(m.input.Value(), "[Image 2:") {
+		t.Fatal("expandImageChips mutating the input value")
+	}
+	// A chip with an unknown number stays literal rather than guessing.
+	if got := m.expandImageChips("[Image 99: nope.png]"); got != "[Image 99: nope.png]" {
+		t.Fatalf("unknown chip should stay literal, got %q", got)
+	}
+}
+
+// macOS temp screenshot hover files live in a transient staging dir that can
+// be swept away before the model call uses them. The paste copies the bytes
+// off immediately, so deleting the source after the paste keeps the attached
+// image intact.
+func TestTempImageCopiedBeforeSourceVanishes(t *testing.T) {
+	t.Setenv("WHIP_HOME", t.TempDir())
+	// Simulate the transient staging area via t.TempDir().
+	source := filepath.Join(t.TempDir(), "Screenshot temp") // no extension, like hover thumbnails
+	image := []byte("\x89PNG\r\n\x1a\nhover-image")
+	if err := os.WriteFile(source, image, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := compactCmdModel()
+	tm, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(source + "\n"), Paste: true})
+	m = tm.(*model)
+	tm, _ = m.Update(cmd())
+	m = tm.(*model)
+
+	if len(m.images) != 1 {
+		t.Fatalf("expected one pasted image, got %d", len(m.images))
+	}
+	copy := m.images[0].path
+	if copy == source {
+		t.Fatal("the paste must copy out of the transient staging dir, not reference it")
+	}
+	// The chip still shows the original staging filename.
+	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot temp]") {
+		t.Fatalf("chip should carry the staging display name, got %q", m.input.Value())
+	}
+
+	// Now the staging file vanished — exactly what happens before the model call.
+	if err := os.Remove(source); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(copy)
+	if err != nil {
+		t.Fatalf("copied image should survive the source vanishing: %v", err)
+	}
+	if string(got) != string(image) {
+		t.Fatalf("copied image = %q, want %q", got, image)
+	}
+
+	// And prepareTurn can still resolve the chip to the surviving copy.
+	if !strings.Contains(m.expandImageChips(m.input.Value()), "@"+copy) {
+		t.Fatalf("chip should resolve to the surviving copy, got %q", m.expandImageChips(m.input.Value()))
 	}
 }

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -206,8 +206,8 @@ func TestTempImageCopiedBeforeSourceVanishes(t *testing.T) {
 	if len(m.images) != 1 {
 		t.Fatalf("expected one pasted image, got %d", len(m.images))
 	}
-	copy := m.images[0].path
-	if copy == source {
+	copied := m.images[0].path
+	if copied == source {
 		t.Fatal("the paste must copy out of the transient staging dir, not reference it")
 	}
 	// The chip still shows the original staging filename.
@@ -219,7 +219,7 @@ func TestTempImageCopiedBeforeSourceVanishes(t *testing.T) {
 	if err := os.Remove(source); err != nil {
 		t.Fatal(err)
 	}
-	got, err := os.ReadFile(copy)
+	got, err := os.ReadFile(copied)
 	if err != nil {
 		t.Fatalf("copied image should survive the source vanishing: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestTempImageCopiedBeforeSourceVanishes(t *testing.T) {
 	}
 
 	// And prepareTurn can still resolve the chip to the surviving copy.
-	if !strings.Contains(m.expandImageChips(m.input.Value()), "@"+copy) {
+	if !strings.Contains(m.expandImageChips(m.input.Value()), "@"+copied) {
 		t.Fatalf("chip should resolve to the surviving copy, got %q", m.expandImageChips(m.input.Value()))
 	}
 }

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -31,7 +31,7 @@ func TestPastedScreenshotPathAttachesImage(t *testing.T) {
 	tm, _ = m.Update(cmd())
 	m = tm.(*model)
 	// The input shows a compact chip, not the raw path or file contents.
-	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot]") {
+	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot"+chipSentinel+"]") {
 		t.Fatalf("input should show a chip, got %q", m.input.Value())
 	}
 	// The on-disk copy (auto-numbered as this session's image 1) holds the
@@ -115,24 +115,24 @@ func TestPasteCollapseShortPasteIgnored(t *testing.T) {
 func TestImageChipRendering(t *testing.T) {
 	// Anonymous clipboard paste → bare number, no filename.
 	anon := pastedImage{n: 2, path: "/tmp/copy.png", display: ""}
-	if got := anon.chipText(); got != "[Image 2]" {
-		t.Fatalf("anonymous chip = %q, want %q", got, "[Image 2]")
+	if got := anon.chipText(); got != "[Image 2"+chipSentinel+"]" {
+		t.Fatalf("anonymous chip = %q, want %q", got, "[Image 2"+chipSentinel+"]")
 	}
 
 	// Short source filename fits whole.
 	short := pastedImage{n: 1, path: "/tmp/copy.png", display: "shot.png"}
-	if got := short.chipText(); got != "[Image 1: shot.png]" {
-		t.Fatalf("short chip = %q, want %q", got, "[Image 1: shot.png]")
+	if got := short.chipText(); got != "[Image 1: shot.png"+chipSentinel+"]" {
+		t.Fatalf("short chip = %q, want %q", got, "[Image 1: shot.png"+chipSentinel+"]")
 	}
 
 	// Long screenshot name truncates, keeping the extension.
 	long := pastedImage{n: 3, path: "/tmp/copy.png", display: "Screenshot 2026-09-04 at 10.21.33 AM.png"}
 	got := long.chipText()
-	if strings.Contains(got, "10.21.33") || !strings.HasSuffix(got, ".png]") || !strings.Contains(got, "…") {
+	if strings.Contains(got, "10.21.33") || !strings.HasSuffix(got, ".png"+chipSentinel+"]") || !strings.Contains(got, "…") {
 		t.Fatalf("long chip = %q, want a truncated stem + ellipsis + .png", got)
 	}
 	// The snippet between "colon " and the closing bracket respects the budget.
-	inner := strings.TrimSuffix(strings.TrimPrefix(got, "[Image 3: "), "]")
+	inner := strings.TrimSuffix(strings.TrimPrefix(got, "[Image 3: "), chipSentinel+"]")
 	if runewidth.StringWidth(inner) > maxImageNameRunes {
 		t.Fatalf("chip snippet %q exceeds the %d-rune budget", inner, maxImageNameRunes)
 	}
@@ -162,7 +162,7 @@ func TestImageChipsNumberAndResolve(t *testing.T) {
 	paste(src1)
 	paste(src2)
 
-	if !strings.Contains(m.input.Value(), "[Image 1: first.png]") || !strings.Contains(m.input.Value(), "[Image 2: second.png]") {
+	if !strings.Contains(m.input.Value(), "[Image 1: first.png"+chipSentinel+"]") || !strings.Contains(m.input.Value(), "[Image 2: second.png"+chipSentinel+"]") {
 		t.Fatalf("chips should number 1 and 2, got %q", m.input.Value())
 	}
 	if m.imageSeq != 2 || len(m.images) != 2 {
@@ -179,8 +179,17 @@ func TestImageChipsNumberAndResolve(t *testing.T) {
 		t.Fatal("expandImageChips mutating the input value")
 	}
 	// A chip with an unknown number stays literal rather than guessing.
-	if got := m.expandImageChips("[Image 99: nope.png]"); got != "[Image 99: nope.png]" {
+	if got := m.expandImageChips("[Image 99: nope.png" + chipSentinel + "]"); got != "[Image 99: nope.png"+chipSentinel+"]" {
 		t.Fatalf("unknown chip should stay literal, got %q", got)
+	}
+	// Hand-typed "[Image 1]" (no sentinel) must NOT expand — it would silently
+	// attach images[0] the user never pasted.
+	if got := m.expandImageChips("[Image 1]"); got != "[Image 1]" {
+		t.Fatalf("hand-typed [Image 1] without sentinel should stay literal, got %q", got)
+	}
+	// Same for a hand-typed chip with a display name.
+	if got := m.expandImageChips("[Image 1: fake.png]"); got != "[Image 1: fake.png]" {
+		t.Fatalf("hand-typed chip without sentinel should stay literal, got %q", got)
 	}
 }
 
@@ -211,7 +220,7 @@ func TestTempImageCopiedBeforeSourceVanishes(t *testing.T) {
 		t.Fatal("the paste must copy out of the transient staging dir, not reference it")
 	}
 	// The chip still shows the original staging filename.
-	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot temp]") {
+	if !strings.Contains(m.input.Value(), "[Image 1: Screenshot temp"+chipSentinel+"]") {
 		t.Fatalf("chip should carry the staging display name, got %q", m.input.Value())
 	}
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -115,9 +115,10 @@ type (
 	orphanSteerMsg string                    // a steer orphaned at turn teardown — submit as a machine turn
 	mcpStatusMsg   struct{}                  // an MCP server changed state — redraw
 	thinkMsg       string                    // streamed reasoning tokens
-	imageMsg       struct {                  // ctrl+v clipboard image result
-		path string // clipboard image saved to disk
-		err  error
+	imageMsg       struct {                  // ctrl+v / paste clipboard image result
+		path    string // clipboard image saved to disk
+		display string // original display name for the chip ("" for anonymous clipboard)
+		err     error
 	}
 )
 
@@ -182,6 +183,8 @@ type model struct {
 
 	hist     []string         // submitted inputs, for up/down recall
 	pasteBuf string           // held paste text for the [Pasted ~N lines] placeholder (config collapsePaste)
+	images   []pastedImage    // pasted images this session, indexed by their [Image N] chip number
+	imageSeq int              // session counter feeding pastedImage.n (1-based)
 	histIdx  int              // len(hist) == not navigating
 	draft    string           // in-progress input saved while navigating history
 	lastUp   time.Time        // last ↑ keypress; repeat detection for history rollover
@@ -2514,7 +2517,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case msg.path == "":
 			m.append(dimStyle.Render("(no image on clipboard)"))
 		default:
-			m.input.InsertString("@" + msg.path + " ")
+			// Register the image under the next session number and drop a
+			// compact [Image N] chip into the input instead of the raw path.
+			m.imageSeq++
+			img := pastedImage{n: m.imageSeq, path: msg.path, display: msg.display}
+			m.images = append(m.images, img)
+			m.input.InsertString(img.chipText() + " ")
 			m.refreshMenu()
 		}
 		return m, nil
@@ -3514,6 +3522,10 @@ func (m *model) prepareTurn(text string) (string, []llm.ContentPart) {
 	}
 	sys += memory.PromptBlock(memory.Installation(), memory.Session(m.sessionID))
 	m.agent.Messages[0].Content = sys
+	// [Image N …] chips pasted this session revert to real @path mentions so
+	// the normal attachment machinery below can read the on-disk copies; the
+	// transcript keeps the chip (it was already appended from the raw input).
+	text = m.expandImageChips(text)
 	expanded := expandMentions(expandSkills(text, sk))
 	if !m.supportsVision() {
 		// text-only model: leave @image tags as pointer notes (from

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2979,7 +2979,20 @@ func (m *model) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.histIdx = len(m.hist)
 				m.input.Reset()
 				m.menu = nil
-				m.agent.Steer(text)
+				// [Image N] chips pasted this session must expand to real
+				// @path mentions (and inline the image on vision models)
+				// before steering — otherwise the chip reaches the model as a
+				// literal bracket string and the image is silently dropped.
+				steerText := m.expandImageChips(text)
+				if m.supportsVision() {
+					if parts, note := imageParts(steerText); len(parts) > 0 {
+						m.agent.SteerImages(steerText+note, parts)
+					} else {
+						m.agent.Steer(steerText)
+					}
+				} else {
+					m.agent.Steer(steerText)
+				}
 				m.append(youStyle.Render("❯ ") + linkifyFilePaths(text, realFileExists) + dimStyle.Render("  (steered)"))
 			case text != "": // codex-style: queue it (multiple allowed)
 				m.queue = append(m.queue, text)
@@ -3910,6 +3923,11 @@ func (m *model) command(text string) (tea.Model, tea.Cmd) {
 		m.future = nil   // no redo across a cleared conversation
 		m.setGoal("")    // clear before detaching so the old session's goal is dropped too
 		m.sessionID = "" // next turn starts a fresh session
+		// Drop the pasted-image registry too: a recalled "[Image 1]" chip from
+		// before the clear must not resolve to a different image once the
+		// session counter restarts.
+		m.images = nil
+		m.imageSeq = 0
 		m.agent.Tasks().SetSessionID("")
 		m.agent.SetSessionID("")
 		m.saved = 1

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2637,6 +2637,16 @@ func (m *model) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return pasteImageFileCmd(path) }
 		}
 	}
+	// A Finder drag arrives as a single large KeyRunes burst (the whole path
+	// typed at once), not a bracketed paste — the terminal doesn't set
+	// msg.Paste for it. Detect a multi-rune message that resolves to a single
+	// image path and route it through the same copy-off-source flow so the
+	// chip replaces the raw path in the input.
+	if !msg.Paste && msg.Type == tea.KeyRunes && len(msg.Runes) > 1 {
+		if path, ok := pastedImagePath(string(msg.Runes)); ok {
+			return m, func() tea.Msg { return pasteImageFileCmd(path) }
+		}
+	}
 	if msg.Paste && m.cfg != nil && m.cfg.CollapsePaste != nil && *m.cfg.CollapsePaste {
 		if n := strings.Count(string(msg.Runes), "\n"); n >= 2 {
 			m.pasteBuf = string(msg.Runes)


### PR DESCRIPTION
## What

Pasting a screenshot injected the raw file path straight into the input box — and for the macOS bottom-right "hover" thumbnail (a transient staging file that can vanish before it ever lands on the Desktop), the path could go stale between paste and submit, breaking the attach.

## Fix

A paste now registers the image under a session number and drops a compact chip into the input:

- **`[Image 1]`** — anonymous clipboard paste (no file on disk)
- **`[Image 1: Screenshot 2026-09-04…png]`** — paste with a source filename (display-width-aware truncation keeps the extension)

The image bytes are copied to `~/.whip/pastes/` immediately, so a temp screenshot file that disappears after paste still resolves at submit. Chips expand back to `@path` mentions only in the text prepared for the model — the input box and transcript keep the readable chip.

## Testing

- `go test ./internal/tui/ -run 'Paste|Image'` green: chip rendering + truncation, chip numbering and resolution back to the stored copy, and a temp file that vanishes between paste and submit.
- `go build ./...` clean. (The two pre-existing `internal/tui` failures from the real-$HOME skills scan are untouched.)