### PR TITLE
fix(tui): small-terminal scrolling — cap the live area, don't yank scroll on stream

### DIFF
--- a/internal/tui/scroll_thinking_test.go
+++ b/internal/tui/scroll_thinking_test.go
@@ -65,7 +65,7 @@ func TestThinkingAndResponseScrollFullyOnSmallTerminal(t *testing.T) {
 		if m.vp.AtBottom() {
 			break
 		}
-		m.vp.LineDown(1)
+		m.vp.ScrollDown(1)
 	}
 	var missing []string
 	for i := range 10 {
@@ -123,7 +123,7 @@ func TestFrameHeightDuringLongInflightResponse(t *testing.T) {
 			m = um.(*model)
 		}
 		// An in-flight response with embedded newlines that never flushed.
-		m.current = "answer\nanswer\nanswer\nanswer\nanswer\nanswer\nanswer\nanswer"
+		m.current = "answer one\nanswer two\nanswer three\nanswer four\nanswer five\nanswer six\nanswer seven\nanswer eight"
 		m.layout()
 		return m
 	}

--- a/internal/tui/scroll_thinking_test.go
+++ b/internal/tui/scroll_thinking_test.go
@@ -1,0 +1,225 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Reproduction for the small-terminal scroll bug: reasoning streams, then a
+// response longer than the screen streams. On a small terminal the user sees
+// the response cut off at the top with reasoning traces above it, and
+// scrolling up goes "straight to the reasoning" — the response content is
+// only visible again after enlarging the terminal.
+//
+// What MUST hold instead: every completed reasoning line and every response
+// line is reachable by scrolling the transcript viewport, and the rendered
+// frame never exceeds the terminal height (overflow pushes the top rows into
+// terminal scrollback, which is the "cut off at the top" symptom).
+func TestThinkingAndResponseScrollFullyOnSmallTerminal(t *testing.T) {
+	m := compactCmdModel()
+	m.showThinking = true
+	m.busy = true               // streaming turn in flight: the spinner rows are live chrome
+	m.Update(mkWinSize(80, 12)) // small terminal
+
+	// Stream reasoning: thinkMsg accumulates; complete lines flush to blocks.
+	for range 15 {
+		um, _ := m.Update(thinkMsg("reasoning trace line about the plan\n"))
+		m = um.(*model)
+	}
+	// Stream the response: complete lines append as assistant blocks.
+	for i := range 10 {
+		um, _ := m.Update(textMsg("response line " + string(rune('a'+i)) + " of the actual answer\n"))
+		m = um.(*model)
+	}
+	// End the turn: partial lines flush, busy clears (chrome back to base).
+	m.flushThink()
+	m.flushCurrent()
+	m.busy = false
+	m.layout()
+
+	// 1. The frame must never be taller than the terminal — overflow pushes
+	//    top rows into terminal scrollback, which is exactly the "cut off at
+	//    the top" the user sees.
+	if h := lipgloss.Height(m.View()); h > m.height {
+		t.Errorf("frame height %d exceeds terminal height %d — top rows scrolled off-screen", h, m.height)
+	}
+
+	// 2. Every response line must be reachable by scrolling: scroll to the
+	//    very top and walk down; every "response line x" must appear in some
+	//    viewport position.
+	m.vp.GotoTop()
+	seen := map[string]bool{}
+	for i := range 10 {
+		seen[string(rune('a'+i))] = false
+	}
+	for {
+		v := m.viewportView()
+		for i := range 10 {
+			if strings.Contains(v, "response line "+string(rune('a'+i))) {
+				seen[string(rune('a'+i))] = true
+			}
+		}
+		if m.vp.AtBottom() {
+			break
+		}
+		m.vp.LineDown(1)
+	}
+	var missing []string
+	for i := range 10 {
+		k := string(rune('a' + i))
+		if !seen[k] {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("response lines never visible at any scroll position: %v", missing)
+	}
+}
+
+// The streaming phase must hold the same invariants: with curThink/current
+// live below the viewport, the frame still fits and prior reasoning stays
+// scrollable.
+func TestFrameFitsWhileReasoningStreams(t *testing.T) {
+	m := compactCmdModel()
+	m.showThinking = true
+	m.busy = true
+	m.Update(mkWinSize(80, 12))
+
+	for range 30 {
+		um, _ := m.Update(thinkMsg("a long reasoning trace line that keeps coming\n"))
+		m = um.(*model)
+	}
+	um, _ := m.Update(textMsg("the response begins"))
+	m = um.(*model)
+	m.layout()
+
+	if h := lipgloss.Height(m.View()); h > m.height {
+		t.Errorf("streaming frame height %d exceeds terminal height %d", h, m.height)
+	}
+
+	// Scrolled up, the earliest reasoning blocks must be reachable.
+	m.vp.GotoTop()
+	top := m.viewportView()
+	if !strings.Contains(top, "reasoning trace") {
+		t.Errorf("top of transcript doesn't show reasoning:\n%s", top)
+	}
+}
+
+// A long in-flight response chunk must never render a frame taller than the
+// terminal (overflow pushes the transcript's top into scrollback — the "cut
+// off at the top" symptom). The live area is capped to its tail so the
+// transcript keeps a usable window.
+func TestFrameHeightDuringLongInflightResponse(t *testing.T) {
+	newStreamingModel := func(height int) *model {
+		m := compactCmdModel()
+		m.showThinking = true
+		m.busy = true
+		m.Update(mkWinSize(80, height))
+		for i := range 5 {
+			um, _ := m.Update(thinkMsg("thinking " + string(rune('0'+i)) + "\n"))
+			m = um.(*model)
+		}
+		// An in-flight response with embedded newlines that never flushed.
+		m.current = "answer\nanswer\nanswer\nanswer\nanswer\nanswer\nanswer\nanswer"
+		m.layout()
+		return m
+	}
+
+	// Realistic small terminal: the transcript floor holds — the live area is
+	// what gets trimmed, never the transcript below minTranscriptRows.
+	t.Run("small terminal keeps the transcript floor", func(t *testing.T) {
+		m := newStreamingModel(20)
+		if h := lipgloss.Height(m.View()); h > m.height {
+			t.Errorf("frame %d rows > terminal %d rows:\n%s", h, m.height, m.View())
+		}
+		if m.vp.Height < minTranscriptRows {
+			t.Errorf("vp.Height=%d < minTranscriptRows=%d — the live area ate the transcript floor", m.vp.Height, minTranscriptRows)
+		}
+		// And the live area still shows its growing tail.
+		if cv := m.currentViewCapped(); !strings.Contains(cv, "answer") {
+			t.Errorf("live area lost its tail entirely: %q", cv)
+		}
+	})
+
+	// Degenerate tiny terminal: a 5-row floor is mathematically impossible, so
+	// the invariant is the frame fits and the split stays fair (live area never
+	// takes more than the transcript gets).
+	t.Run("tiny terminal fits with a fair split", func(t *testing.T) {
+		m := newStreamingModel(12)
+		if h := lipgloss.Height(m.View()); h > m.height {
+			t.Errorf("frame %d rows > terminal %d rows:\n%s", h, m.height, m.View())
+		}
+		live := lipgloss.Height(m.currentViewCapped())
+		if live > m.vp.Height {
+			t.Errorf("live area %d rows > transcript %d rows on a %d-row terminal", live, m.vp.Height, m.height)
+		}
+	})
+}
+
+// While the user is scrolled up reading reasoning, streamed response lines
+// must not yank them to the bottom: follow is only re-engaged by scrolling
+// back down, never by new content arriving.
+func TestScrollPositionStableWhileResponseStreams(t *testing.T) {
+	m := compactCmdModel()
+	m.showThinking = true
+	m.busy = true
+	m.Update(mkWinSize(80, 12))
+
+	for i := range 10 {
+		um, _ := m.Update(thinkMsg("reasoning line " + string(rune('0'+i)) + "\n"))
+		m = um.(*model)
+	}
+	m.layout()
+	m.vp.GotoTop()
+	m.follow = false
+	before := m.viewportView()
+	if !strings.Contains(before, "reasoning line 0") {
+		t.Fatalf("setup: top should show first reasoning line:\n%s", before)
+	}
+
+	// Response streams below the viewport.
+	um, _ := m.Update(textMsg("response begins\n"))
+	m = um.(*model)
+	m.layout()
+
+	after := m.viewportView()
+	if m.follow {
+		t.Error("streamed response re-engaged follow mode while scrolled up")
+	}
+	if !strings.Contains(after, "reasoning line 0") {
+		t.Errorf("response streaming shifted the scrolled view:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// PgUp through a thinking+response transcript must move through ALL content,
+// not jump past the response to the reasoning.
+func TestPgUpMovesThroughWholeTranscript(t *testing.T) {
+	m := compactCmdModel()
+	m.showThinking = true
+	m.Update(mkWinSize(80, 12))
+
+	for range 8 {
+		um, _ := m.Update(thinkMsg("thinking block line\n"))
+		m = um.(*model)
+	}
+	for i := range 20 {
+		um, _ := m.Update(textMsg("answer part " + string(rune('a'+i)) + "\n"))
+		m = um.(*model)
+	}
+	m.flushThink()
+	m.flushCurrent()
+	m.layout()
+	m.vp.GotoBottom()
+
+	// PgUp once: the visible window should still contain answer content
+	// (the lines just above the fold), not skip straight to thinking.
+	um, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = um.(*model)
+	v := m.viewportView()
+	if !strings.Contains(v, "answer part") {
+		t.Errorf("after one PgUp the answer is gone — jumped straight past it:\n%s", v)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1314,8 +1314,14 @@ func (m *model) appendAssistantBlock(s string) {
 }
 
 func (m *model) appendRaw(kind blockKind, text string) {
+	// Only stay pinned to the bottom if we were already following. A user who
+	// scrolled up to read reasoning must not be yanked to the bottom by every
+	// streamed line that lands — follow is re-engaged by scrolling back down
+	// (m.follow = m.vp.AtBottom()), not by new content arriving.
+	if m.vp.AtBottom() {
+		m.follow = true
+	}
 	m.blocks = append(m.blocks, block{kind: kind, text: text})
-	m.follow = true
 	m.refreshVP()
 }
 
@@ -1721,12 +1727,11 @@ func (m *model) layout() {
 	if m.busy && m.uiMode != opencodeMode {
 		chrome += 2 // blank line above the spinner + the spinner line itself (opencode mode: status bar spinner instead)
 	}
-	if m.current != "" {
-		chrome += lipgloss.Height(m.currentView()) + 1 // + its blank separator
-	}
-	if m.curThink != "" {
-		chrome += lipgloss.Height(m.thinkView()) + 1
-	}
+	// The in-flight response/reasoning renders below the viewport and are
+	// unbounded — a long chunk would budget every terminal row into chrome,
+	// collapse the transcript to 1 row, and push its top into scrollback (the
+	// "cut off at the top, reasoning above it" bug). Their height is budgeted
+	// below at m.streamCap(), AFTER fixed chrome is known.
 	if m.uiMode == opencodeMode && m.busy && !m.thinkStart.IsZero() {
 		chrome += 2 // the live "+ Thinking…" line + its blank separator (must match viewBody)
 	}
@@ -1767,6 +1772,15 @@ func (m *model) layout() {
 		}
 		chrome += m.dockRows // the blank above the input is already in the base
 	}
+	// Now budget the in-flight streaming area at its cap: fixed chrome + the
+	// capped live rows + the transcript floor must equal the terminal height,
+	// so the frame fits and the transcript keeps a scrollable window. A 0 cap
+	// drops the live area (and its separator) entirely.
+	if m.current != "" || m.curThink != "" {
+		if cap := m.streamCap(chrome); cap > 0 {
+			chrome += cap + 1 // + the blank separator above it
+		}
+	}
 	// Floor the viewport width too: a degenerate m.width (1–4 cols) would set
 	// the viewport to 1 col and re-slice the transcript into a one-char strip,
 	// regardless of the render floor in refreshVP.
@@ -1775,6 +1789,22 @@ func (m *model) layout() {
 		m.vp.Width, m.vp.Height = w, h
 		m.refreshVP()
 	}
+}
+
+// streamCap returns how many rows the in-flight streaming area (response
+// and/or live reasoning) may occupy: what fixed chrome leaves after reserving
+// up to minTranscriptRows for the transcript. The transcript floor wins over
+// the live area — a squeezed terminal trims the live view to its tail (where
+// new tokens land) instead of pushing the transcript off-screen. The floor
+// itself scales down on terminals too short to afford it, and 0 means the
+// live area is dropped entirely (base chrome alone already fills the frame).
+func (m *model) streamCap(fixedChrome int) int {
+	avail := m.height - fixedChrome - 1 // the blank separator above the live area
+	if avail < 2 {
+		return 0
+	}
+	floor := min(minTranscriptRows, avail-1)
+	return avail - floor
 }
 
 // dockTop returns the screen row of the first TASK row in the dock: the dock
@@ -4295,6 +4325,88 @@ func (m *model) currentView() string {
 	return wrap(s, m.width) // streamed mid-flight: plain text; markdown renders on flush
 }
 
+// minTranscriptRows is the smallest window the transcript viewport keeps while
+// a response/reasoning streams below it. Without a floor, a long in-flight
+// chunk budgets every terminal row into chrome, collapses the viewport to 1
+// row, and the over-tall frame pushes the transcript's top into scrollback —
+// the "response cut off at the top, reasoning traces above it" bug.
+const minTranscriptRows = 5
+
+// streamTail keeps the last n rows of s (the growing edge of a streaming
+// render); s is returned unchanged when it already fits.
+func streamTail(s string, n int) string {
+	if n < 1 {
+		n = 1
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// fixedChrome mirrors layout()'s chrome count MINUS the streaming area, so
+// the capped views render to the exact height layout budgets. Keep in sync
+// with layout: any always-on row it adds must land here too.
+func (m *model) fixedChrome() int {
+	chrome := 6 + m.input.Height()
+	if m.uiMode == opencodeMode {
+		chrome++
+	}
+	if m.iactive != nil {
+		chrome -= m.input.Height()
+	}
+	if m.busy && m.uiMode != opencodeMode {
+		chrome += 2
+	}
+	if m.uiMode == opencodeMode && m.busy && !m.thinkStart.IsZero() {
+		chrome += 2
+	}
+	if m.iactive != nil {
+		chrome += lipgloss.Height(m.interactiveView()) + 1
+	}
+	if m.permDialog != nil {
+		chrome += lipgloss.Height(m.permView()) + 1
+	}
+	if m.menu != nil && m.uiMode != opencodeMode {
+		chrome += lipgloss.Height(m.menuView()) + 1
+	}
+	if len(m.queue) > 0 {
+		chrome += len(m.queue) + 1
+	}
+	if m.rew != nil {
+		chrome += lipgloss.Height(m.rewindView()) + 1
+	}
+	if m.quit1 {
+		chrome++
+	}
+	if m.escClr || (m.esc1 && m.rew == nil && m.namePrompt == nil) {
+		chrome++
+	}
+	return chrome + m.dockRows
+}
+
+// currentViewCapped is currentView trimmed to streamCap; layout budgets this
+// exact height so the frame fits the terminal. The tail is kept because
+// that's where new tokens land. A 0 cap means the terminal is too short to
+// show any of it — return "" so the caller drops the area (and its separator).
+func (m *model) currentViewCapped() string {
+	cap := m.streamCap(m.fixedChrome())
+	if cap == 0 {
+		return ""
+	}
+	return streamTail(m.currentView(), cap)
+}
+
+// thinkViewCapped is thinkView trimmed the same way for the live reasoning line.
+func (m *model) thinkViewCapped() string {
+	cap := m.streamCap(m.fixedChrome())
+	if cap == 0 {
+		return ""
+	}
+	return streamTail(m.thinkView(), cap)
+}
+
 // View renders the frame and tracks WHERE it sits on the screen. Mouse events
 // arrive in absolute screen coordinates, so every click/drag mapping needs the
 // view's top row. The inline view starts bottom-anchored (Run moves the cursor
@@ -4428,16 +4540,21 @@ func (m *model) viewBody() string {
 		b.WriteString(dimStyle.Render(tips) + "\n\n")
 	}
 	b.WriteString(m.viewportView() + "\n") // selection highlight paints inside
-	if m.curThink != "" {
-		b.WriteString("\n" + m.thinkView() + "\n")
+	// Live streaming area: render only when the capped view is non-empty (a 0
+	// cap on a degenerate short terminal drops the area AND its separator, so
+	// layout's chrome count and this paint stay in sync). curThink and current
+	// are never live simultaneously (thinkMsg flushes current first, textMsg
+	// flushes curThink first), so each can safely claim the whole streamCap.
+	if cv := m.thinkViewCapped(); m.curThink != "" && cv != "" {
+		b.WriteString("\n" + cv + "\n")
 	}
 	if m.uiMode == opencodeMode && m.busy && !m.thinkStart.IsZero() {
 		// reasoning is streaming: opencode shows a transient "Thinking" line
 		// where the collapsed "+ Thought: {dur}" will land on flush
 		b.WriteString("\n   " + lipgloss.NewStyle().Foreground(ocWarnCol()).Render("+ Thinking…") + "\n")
 	}
-	if m.current != "" {
-		b.WriteString("\n" + m.currentView() + "\n")
+	if cv := m.currentViewCapped(); m.current != "" && cv != "" {
+		b.WriteString("\n" + cv + "\n")
 	}
 	if m.iactive != nil {
 		b.WriteString("\n" + m.interactiveView() + "\n")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1313,14 +1313,27 @@ func (m *model) appendAssistantBlock(s string) {
 	m.appendRaw(blockAssistant, s)
 }
 
-func (m *model) appendRaw(kind blockKind, text string) {
-	// Only stay pinned to the bottom if we were already following. A user who
-	// scrolled up to read reasoning must not be yanked to the bottom by every
-	// streamed line that lands — follow is re-engaged by scrolling back down
-	// (m.follow = m.vp.AtBottom()), not by new content arriving.
-	if m.vp.AtBottom() {
+// wantFollow reports whether an append should keep the transcript pinned to
+// the bottom: only when the user is already following (at the bottom). A user
+// scrolled up to read reasoning must not be yanked to the bottom by streamed
+// content landing — follow is re-engaged by scrolling back down (m.follow =
+// m.vp.AtBottom() in the scroll handlers), never by new content arriving.
+// Every append path (raw blocks, assistant merges, tool results, thinking
+// flushes) goes through this so the no-yank guarantee is uniform.
+func (m *model) wantFollow() bool {
+	return m.follow || m.vp.AtBottom()
+}
+
+// keepFollow re-arms follow iff the user was already following; a no-op when
+// scrolled up. Call after appending, before refreshVP.
+func (m *model) keepFollow() {
+	if m.wantFollow() {
 		m.follow = true
 	}
+}
+
+func (m *model) appendRaw(kind blockKind, text string) {
+	m.keepFollow()
 	m.blocks = append(m.blocks, block{kind: kind, text: text})
 	m.refreshVP()
 }
@@ -2184,7 +2197,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.blocks = append(m.blocks, result)
 		}
-		m.follow = true
+		m.keepFollow()
 		m.refreshVP()
 		return m, nil
 
@@ -3591,7 +3604,7 @@ func (m *model) appendAssistant(s string) {
 	if m.inMsg && len(m.blocks) > 0 && m.blocks[len(m.blocks)-1].kind == blockAssistant {
 		m.blocks[len(m.blocks)-1].text += "\n\n" + s // same message: merge
 		m.blocks[len(m.blocks)-1].stale = true
-		m.follow = true
+		m.keepFollow()
 		m.refreshVP()
 		return
 	}
@@ -3656,7 +3669,7 @@ func (m *model) flushThink() {
 	if m.uiMode == opencodeMode {
 		if !m.thinkStart.IsZero() { // collapse the reasoning segment to one line (expandable to the text)
 			m.blocks = append(m.blocks, block{kind: blockThought, text: m.ocThink, live: fmtShortDur(m.nowFn().Sub(m.thinkStart))})
-			m.follow = true
+			m.keepFollow()
 			m.refreshVP()
 			m.thinkStart = time.Time{}
 			m.ocThink = ""

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1777,8 +1777,8 @@ func (m *model) layout() {
 	// so the frame fits and the transcript keeps a scrollable window. A 0 cap
 	// drops the live area (and its separator) entirely.
 	if m.current != "" || m.curThink != "" {
-		if cap := m.streamCap(chrome); cap > 0 {
-			chrome += cap + 1 // + the blank separator above it
+		if liveCap := m.streamCap(chrome); liveCap > 0 {
+			chrome += liveCap + 1 // + the blank separator above it
 		}
 	}
 	// Floor the viewport width too: a degenerate m.width (1–4 cols) would set
@@ -4391,20 +4391,20 @@ func (m *model) fixedChrome() int {
 // that's where new tokens land. A 0 cap means the terminal is too short to
 // show any of it — return "" so the caller drops the area (and its separator).
 func (m *model) currentViewCapped() string {
-	cap := m.streamCap(m.fixedChrome())
-	if cap == 0 {
+	liveCap := m.streamCap(m.fixedChrome())
+	if liveCap == 0 {
 		return ""
 	}
-	return streamTail(m.currentView(), cap)
+	return streamTail(m.currentView(), liveCap)
 }
 
 // thinkViewCapped is thinkView trimmed the same way for the live reasoning line.
 func (m *model) thinkViewCapped() string {
-	cap := m.streamCap(m.fixedChrome())
-	if cap == 0 {
+	liveCap := m.streamCap(m.fixedChrome())
+	if liveCap == 0 {
 		return ""
 	}
-	return streamTail(m.thinkView(), cap)
+	return streamTail(m.thinkView(), liveCap)
 }
 
 // View renders the frame and tracks WHERE it sits on the screen. Mouse events


### PR DESCRIPTION
## What

Two streaming scroll bugs that made reasoning + response unusable on a short terminal. Reported as: "when my terminal is too small to fit the whole response, it's cut off at the top with reasoning traces above it; scrolling up goes straight to the reasoning; I can only see the actual response if I enlarge my terminal."

### Bug 1 — the frame overflows the terminal
The in-flight response/reasoning renders **below** the transcript viewport, and `layout()` budgets its *full* height into chrome. A chunk longer than the screen collapses the viewport to 1 row and renders a frame taller than the terminal — bubbletea's renderer pushes the top rows into terminal scrollback. That's literally the "cut off at the top, reasoning above it" symptom.

**Fix**: cap the live area to `streamCap(fixedChrome)` (`currentViewCapped`/`thinkViewCapped`), so the transcript always keeps a usable window. The capped view keeps the *tail* (where new tokens land). `layout()` budgets the same capped height it paints, so budget and paint stay in sync. `streamCap` reserves up to `minTranscriptRows` (5) for the transcript, scaling the floor down on terminals too short to afford it, and drops the live area entirely when base chrome alone fills the frame.

### Bug 2 — scrolled-up reading gets yanked to the bottom
`appendRaw` force-set `m.follow = true` on every append, so while the user was scrolled up reading reasoning, each streamed response line re-engaged follow mode and yanked them to the bottom.

**Fix**: only stay pinned when already following (`m.vp.AtBottom()`); follow re-engages by scrolling back down, never by new content arriving.

## Testing

`internal/tui/scroll_thinking_test.go` — regression tests covering:
- frame never exceeds terminal height at several sizes (12 / 20 rows)
- the transcript floor holds on a realistic small terminal
- the split stays fair on a degenerate one (live area never exceeds the transcript)
- scroll position survives response streaming (no re-follow yank)
- PgUp walks the whole transcript
- every response line is reachable by scrolling

`go test ./internal/tui/ -run 'Scroll|Thinking|Frame|StreamCap'` green, plus existing scroll/wheel/thinking tests still pass. The two pre-existing `internal/tui` failures (`TestStartupReport*`, they scan the real $HOME skills dir) are untouched.

> **Note**: standalone — based directly on `main` (rebased off the earlier stacked base).