### PR TITLE
Boot new installs in opencode UI mode

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -505,6 +505,13 @@ relay: full device login + key mint, store round-trip, key validation),
   rewiring incl. wrap-split links, end-to-end renderMarkdown, user echo).
 - **Command palette** (ctrl+p) with sub-panels for model/effort/goal/compaction
   and ←/→ steppers for the compaction level — `palette.go`.
+- **UI mode** (`UIMode` config key): `"opencode"` (the default on a fresh
+  install) selects the full-screen, sidebar-backed opencode render mode
+  (`internal/tui/opencode.go`); `""` is the classic inline whip look. The
+  default is seeded by `config.Default()` and only applies on first run — an
+  existing config's `UIMode` (including `""` saved by a user who switched to
+  classic) is honored as-is on reload. Toggle live with ctrl+p → "UI mode"
+  (`setUIMode`, which persists the choice).
 - **Mouse**: `/mouse` toggles capture; with capture off the terminal's native
   selection works, with it on shift-drag selects. `"mouse": false` in config
   disables capture at startup.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,7 @@ type Config struct {
 	TaskModel       string `json:"taskModel,omitempty"`       // model subagents (the task tool) run on; "" = the built-in default
 	TaskProvider    string `json:"taskProvider,omitempty"`    // provider for the subagent model; "" = the model's default routing
 	Theme           string `json:"theme,omitempty"`           // "light", "dark", or "" (auto-detect at startup)
-	UIMode          string `json:"uiMode,omitempty"`          // "" (classic whip look) or "opencode" (reproduces opencode's TUI palette/glyphs/logo); Default() ships "opencode", so unset-on-first-run boots opencode
+	UIMode          string `json:"uiMode,omitempty"`          // "" (classic whip look) or "opencode" (reproduces opencode's TUI palette/glyphs/logo)
 	Sidebar         *bool  `json:"sidebar,omitempty"`         // opencode-mode sidebar; nil = shown when the terminal is ≥120 cols, false = hidden at startup (ctrl+x b still toggles)
 	Mouse           *bool  `json:"mouse,omitempty"`           // false disables capture so native terminal selection works
 	Thinking        *bool  `json:"thinking,omitempty"`        // nil defaults to on; false hides reasoning tokens (ctrl+o)
@@ -627,13 +627,7 @@ func Default() *Config {
 	return &Config{
 		DefaultModel: "kimi-k3-fast",
 		CompactModel: DefaultCompactModel,
-		// New installs boot in opencode render mode (the full-screen,
-		// sidebar-backed layout). An existing user who switched to the classic
-		// look keeps it: setUIMode persists "" to cfg.UIMode, and "" (not nil)
-		// is what Load returns — so the default only applies on first run.
-		// The literal mirrors tui.opencodeMode; tui owns the name, config owns
-		// the default value.
-		UIMode: "opencode",
+		UIMode:       "opencode",
 		//nolint:gosec // G101: APIKeyEnv holds env var NAMES, not credentials
 		Providers: map[string]Provider{
 			"inference-net": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,7 @@ type Config struct {
 	TaskModel       string `json:"taskModel,omitempty"`       // model subagents (the task tool) run on; "" = the built-in default
 	TaskProvider    string `json:"taskProvider,omitempty"`    // provider for the subagent model; "" = the model's default routing
 	Theme           string `json:"theme,omitempty"`           // "light", "dark", or "" (auto-detect at startup)
-	UIMode          string `json:"uiMode,omitempty"`          // "" (default whip look) or "opencode" (reproduces opencode's TUI palette/glyphs/logo)
+	UIMode          string `json:"uiMode,omitempty"`          // "" (classic whip look) or "opencode" (reproduces opencode's TUI palette/glyphs/logo); Default() ships "opencode", so unset-on-first-run boots opencode
 	Sidebar         *bool  `json:"sidebar,omitempty"`         // opencode-mode sidebar; nil = shown when the terminal is ≥120 cols, false = hidden at startup (ctrl+x b still toggles)
 	Mouse           *bool  `json:"mouse,omitempty"`           // false disables capture so native terminal selection works
 	Thinking        *bool  `json:"thinking,omitempty"`        // nil defaults to on; false hides reasoning tokens (ctrl+o)
@@ -627,6 +627,13 @@ func Default() *Config {
 	return &Config{
 		DefaultModel: "kimi-k3-fast",
 		CompactModel: DefaultCompactModel,
+		// New installs boot in opencode render mode (the full-screen,
+		// sidebar-backed layout). An existing user who switched to the classic
+		// look keeps it: setUIMode persists "" to cfg.UIMode, and "" (not nil)
+		// is what Load returns — so the default only applies on first run.
+		// The literal mirrors tui.opencodeMode; tui owns the name, config owns
+		// the default value.
+		UIMode: "opencode",
 		//nolint:gosec // G101: APIKeyEnv holds env var NAMES, not credentials
 		Providers: map[string]Provider{
 			"inference-net": {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,12 @@ func TestLoadSaveDefaults(t *testing.T) {
 	if cfg.DefaultModel != "kimi-k3-fast" || cfg.Providers["inference-net"].BaseURL != "https://api.inference.net/v1" {
 		t.Fatalf("defaults: %+v", cfg)
 	}
+	// New installs boot in opencode render mode. An explicit "" (classic look)
+	// set by setUIMode persists and is honored on reload — only a missing file
+	// seeds "opencode".
+	if cfg.UIMode != "opencode" {
+		t.Fatalf("first-run UIMode = %q, want %q", cfg.UIMode, "opencode")
+	}
 	cfg.DefaultModel = "glm-5.2-fast"
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -24,6 +30,23 @@ func TestLoadSaveDefaults(t *testing.T) {
 	cfg2, err := Load()
 	if err != nil || cfg2.DefaultModel != "glm-5.2-fast" {
 		t.Fatalf("reload: %+v %v", cfg2, err)
+	}
+	if cfg2.UIMode != "opencode" {
+		t.Fatalf("reload UIMode = %q, want %q", cfg2.UIMode, "opencode")
+	}
+
+	// A user who toggled to the classic look persists "" and keeps it on reload
+	// (the opencode default must only apply on first run, not override a choice).
+	cfg2.UIMode = ""
+	if err := cfg2.Save(); err != nil {
+		t.Fatal(err)
+	}
+	cfg3, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg3.UIMode != "" {
+		t.Fatalf("opt-out UIMode = %q, want empty (classic)", cfg3.UIMode)
 	}
 }
 


### PR DESCRIPTION
## What

New installs now open in the **opencode** render mode (full-screen, sidebar-backed layout from `internal/tui/opencode.go`) instead of the classic inline whip look.

## Why

Opencode mode is the richer default — sidebar, alt-screen, block wordmark. It should be what a first-time user sees; the classic look stays available as an explicit opt-out.

## How (option A — minimal, no surprise)

`config.Default()` seeds `UIMode: "opencode"`. The default applies **only on first run** (missing config file):

- `UIMode` semantics are unchanged: `"opencode"` = opencode render, `""` = classic whip look.
- `setUIMode` (ctrl+p → "UI mode") persists the user's choice to `cfg.UIMode`; `""` (classic) is honored as-is on reload.
- No migration, no sentinel, no flip under existing users — they keep whatever they configured.

## Changes

- `internal/config/config.go` — `Default()` sets `UIMode: "opencode"`; field comment corrected (`""` was "default whip look", now "classic whip look" — the word *default* moved to `Default()`).
- `internal/config/config_test.go` — pin the first-run default, the reload default, and the opt-out round-trip (`""` persists and survives reload).
- `docs/features.md` — document the `UIMode` surface and the new default.

## Test

`go test -race ./internal/config/` ✅ green.

`internal/tui` has a pre-existing cwd-path-sensitive flake (`TestStatusLineShowsLastResponse`): it hardcodes width 80 and the status-line cwd compaction can't fit the `last 10.0k/300 tok` segment when the test runs from a deep worktree path like `…/.worktrees/set-opencode-default/internal/tui`. It passes from the shallow `…/whip` path and in CI's shallow clone. This PR doesn't touch `internal/tui/` at all (diff is `internal/config` + docs only); the flake is out of scope and worth a separate fix.

```
$ go test -race ./internal/config/
ok  	github.com/context-labs/whip/internal/config   1.300s
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> First-run default only; no migration or override of existing user config, limited to config seeding and documentation.
> 
> **Overview**
> **New installs** now get `UIMode: "opencode"` from `config.Default()` when `~/.whip/config.json` is created on first `Load()` — full-screen opencode TUI instead of the classic inline look.
> 
> Existing configs are unchanged: saved `uiMode` (including `""` after opting out via ctrl+p → UI mode) is loaded as-is with no migration. The `UIMode` field comment now calls empty string the **classic** look; **opencode** is the first-run default only.
> 
> Tests assert first-run/reload default and that persisting `""` survives reload. `docs/features.md` documents the setting and toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5308fe18a1014aead57f896ffbdde6b7092cdc68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->