### PR TITLE
feat: whip -c/--continue, -r/--resume shorthand, and --browse session picker

### DIFF
--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -34,7 +34,7 @@ func cwd() string {
 // -r=<id> are left untouched (the next token being a non-flag means it's the
 // id). Runs before flag.Parse, which stops at the first positional (`up`).
 func normalizeBareResume(args []string) {
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		a := args[i]
 		if a != "-r" && a != "--resume" {
 			continue

--- a/cmd/whip/main.go
+++ b/cmd/whip/main.go
@@ -28,6 +28,25 @@ func cwd() string {
 	return wd
 }
 
+// normalizeBareResume rewrites a trailing bare -r/--resume (no following id) to
+// --browse, so bare `whip --resume` opens the picker instead of erroring
+// "flag needs an argument" — stdlib flag has no optional values. -r <id> and
+// -r=<id> are left untouched (the next token being a non-flag means it's the
+// id). Runs before flag.Parse, which stops at the first positional (`up`).
+func normalizeBareResume(args []string) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a != "-r" && a != "--resume" {
+			continue
+		}
+		// A following non-flag token is the session id (`-r <id>`), not bare.
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			continue
+		}
+		args[i] = "--browse"
+	}
+}
+
 // username is the OS login name, or "unknown" when it can't be resolved
 // (e.g. inside a container without a passwd entry).
 func username() string {
@@ -88,9 +107,15 @@ func main() {
 	modelFlag := flag.String("m", "", "model name from ~/.whip/config.json (default: defaultModel)")
 	providerFlag := flag.String("p", "", "provider to route the model through (default: model's first provider)")
 	versionFlag := flag.Bool("version", false, "print version")
-	resumeFlag := flag.String("resume", "", "resume a previous session by id (or unique prefix)")
+	resumeFlag := flag.String("resume", "", "resume a previous session by id (or unique prefix); bare opens the picker")
+	flag.StringVar(resumeFlag, "r", "", "shorthand for --resume")
+	var continueMode, browseMode bool
+	flag.BoolVar(&continueMode, "c", false, "continue the most recent session in the current directory")
+	flag.BoolVar(&continueMode, "continue", false, "same as -c")
+	flag.BoolVar(&browseMode, "browse", false, "open the session picker at startup (same as bare --resume)")
 	benchFlag := flag.Bool("bench", false, "do full startup init (config, routing, key, agent) then exit; for `task benchmark`")
 	cautiousFlag := flag.Bool("cautious", false, "ask before running commands / writing files")
+	normalizeBareResume(os.Args[1:]) // bare -r/--resume → --browse before flag.Parse (stdlib flag has no optional values)
 	flag.Parse()
 
 	if *versionFlag {
@@ -207,7 +232,7 @@ func main() {
 	// notice still shows on the next launch.
 	go update.Check(version)
 	tui.Version = version // /report names the build in the bug-report bundle
-	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(cwd(), time.Now()), *resumeFlag, *cautiousFlag, firstRun, initialPrompt)
+	sessionID, err := tui.Run(cfg, *modelFlag, *providerFlag, systemPrompt(cwd(), time.Now()), *resumeFlag, *cautiousFlag, firstRun, initialPrompt, continueMode, browseMode)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "whip:", err)
 		os.Exit(1)

--- a/cmd/whip/normalize_resume_test.go
+++ b/cmd/whip/normalize_resume_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeBareResume(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"bare --resume → --browse", []string{"--resume"}, []string{"--browse"}},
+		{"bare -r → --browse", []string{"-r"}, []string{"--browse"}},
+		{"-r <id> unchanged", []string{"-r", "abc123"}, []string{"-r", "abc123"}},
+		{"--resume <id> unchanged", []string{"--resume", "abc123"}, []string{"--resume", "abc123"}},
+		{"-r=<id> unchanged", []string{"-r=abc123"}, []string{"-r=abc123"}},
+		{"--resume=<id> unchanged", []string{"--resume=abc123"}, []string{"--resume=abc123"}},
+		{"bare -r then another flag → --browse then flag", []string{"-r", "--cautious"}, []string{"--browse", "--cautious"}},
+		// -r followed by a non-flag token is `-r <id>` (claude-consistent: the
+		// next token is the session id/name), NOT bare. So `whip -r up do it`
+		// tries to resume session "up" (then fails no-such-id) rather than
+		// opening the picker — picker+prompt uses `--browse up do it` / `-c up …`.
+		{"-r <non-flag> is -r <id>, not bare", []string{"-r", "up", "do", "it"}, []string{"-r", "up", "do", "it"}},
+		{"-r <id> before up → unchanged", []string{"-r", "abc", "up", "go"}, []string{"-r", "abc", "up", "go"}},
+		{"no resume flag → untouched", []string{"-m", "kimi", "up", "hi"}, []string{"-m", "kimi", "up", "hi"}},
+		{"empty args", []string{}, []string{}},
+		{"id that looks flag-ish (- prefix) → treated as flag, so -r is bare", []string{"-r", "-x"}, []string{"--browse", "-x"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := make([]string, len(c.in))
+			copy(got, c.in) // copy so mutation doesn't corrupt the table (non-nil even when empty)
+			normalizeBareResume(got)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("normalizeBareResume(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/whip/sessions.go
+++ b/cmd/whip/sessions.go
@@ -9,8 +9,9 @@ import (
 )
 
 // `whip sessions` — list stored sessions, newest first. The scriptable
-// companion to `whip run`: find a session, then resume it in the TUI or
-// inspect it from a script.
+// companion to `whip run`: find a session, then resume it in the TUI with
+// `whip --resume <id>` (or `-r <id>`), `whip -c` for the newest in this dir,
+// or `whip --browse` for the interactive picker — or inspect from a script.
 func sessionsCLI() error {
 	dir, err := config.Dir()
 	if err != nil {

--- a/docs/features.md
+++ b/docs/features.md
@@ -1063,6 +1063,47 @@ constructed. Combined with `--resume` the replayed history renders first and
 the prompt fires as the next turn, matching `whip run`'s
 prompt-after-resume order.
 
+## Startup resume flags — `whip -c` / `-r` / `--browse`
+
+Three ways to pick up a previous session at launch (`cmd/whip/main.go`,
+wired in `tui.Run`):
+
+- **`whip --resume <id>` / `whip -r <id>`** — resume a specific session by id
+  or unique prefix (`Store.Load`'s prefix scan). `-r` is a shorthand for
+  `--resume`.
+- **`whip --resume` / `whip -r`** (bare, no id) — open the interactive
+  `/resume` session picker at startup (`m.openPicker`, the same UI as
+  in-session `/resume`: arrow keys, last-exchange previews, enter resumes, esc
+  cancels → fresh session). This is the claude-code/pi semantics — pi's `-r`
+  help literally reads "Browse and select session."
+- **`whip -c` / `--continue`** — resume the most-recent ordinary session in
+  the current directory (`Store.LatestInDir(cwd())`, `cwd = ?` filter,
+  excludes subagent transcripts via `task_id = ''`). If none exists in this
+  dir, prints "(no previous session in this directory — starting fresh)" and
+  starts a new session instead of erroring — matches claude-code/pi: "no
+  session here → just start." The full resume path (`m.resume`) rebuilds the
+  agent, restores background subagents, todos, snapshots, and usage.
+- **`whip --browse`** — explicit alias for bare `--resume` (opens the picker);
+  exists so the picker has a name independent of the optional-value trick.
+
+Precedence when several are given: `-r <id>` > `-c` > `--browse` (an explicit
+id is the strongest intent). `whip up <prompt>` combines with all of them: the
+picker/continue/resume runs first, then the prompt submits as the next turn
+after the replay, matching `--resume <id>` + `up`'s prompt-after-resume order.
+Bare `--resume` + `up` is ambiguous (`-r up …` reads as resume-by-id "up"), so
+use `--browse up …` or `-c up …` for picker-then-prompt.
+
+Why bare `--resume` works despite Go's stdlib `flag` having no optional values:
+`normalizeBareResume` (in `cmd/whip/main.go`) pre-scans `os.Args` and rewrites
+a trailing bare `-r`/`--resume` (no following id) to `--browse` before
+`flag.Parse`. A `-r <id>` or `-r=<id>` form is left untouched. No pflag dep.
+
+Tests: `internal/session/session_test.go` — `TestLatestInDir` (newest per dir,
+`sql.ErrNoRows` when none), `TestLatestInDirExcludesSubagentTranscripts`,
+`TestLatestInDirSkipsEmptySessions`. `internal/tui/resume_browse_test.go` —
+`TestContinueRecentResumesNewestInCwd`, `TestContinueRecentNoSessionInDirStartsFresh`,
+`TestBrowseOpensPickerAndEnterResumes`, `TestBrowseNoSessionsPrintsEmptyState`.
+
 Tests: `internal/tui/up_test.go` — `TestInitialPromptSubmitsFirstTurn` (Init
 kickoff → busy turn, authored user message, history entry, one-shot
 consumption), `TestNoInitialPromptNoKickoff` (bare blink Init, empty msg is

--- a/docs/features.md
+++ b/docs/features.md
@@ -1072,38 +1072,22 @@ prompt-after-resume order.
 
 ## Startup resume flags — `whip -c` / `-r` / `--browse`
 
-Three ways to pick up a previous session at launch (`cmd/whip/main.go`,
-wired in `tui.Run`):
+- **`whip -r <id>`** (or `--resume <id>`) — resume a session by id or unique prefix.
+- **`whip -r`** (or `--resume`, bare) — open the `/resume` picker at startup.
+- **`whip -c`** (or `--continue`) — resume the most-recent ordinary session in
+  the current dir; starts fresh (with a notice) if none.
+- **`whip --browse`** — alias for bare `--resume` (the picker).
 
-- **`whip --resume <id>` / `whip -r <id>`** — resume a specific session by id
-  or unique prefix (`Store.Load`'s prefix scan). `-r` is a shorthand for
-  `--resume`.
-- **`whip --resume` / `whip -r`** (bare, no id) — open the interactive
-  `/resume` session picker at startup (`m.openPicker`, the same UI as
-  in-session `/resume`: arrow keys, last-exchange previews, enter resumes, esc
-  cancels → fresh session). This is the claude-code/pi semantics — pi's `-r`
-  help literally reads "Browse and select session."
-- **`whip -c` / `--continue`** — resume the most-recent ordinary session in
-  the current directory (`Store.LatestInDir(cwd())`, `cwd = ?` filter,
-  excludes subagent transcripts via `task_id = ''`). If none exists in this
-  dir, prints "(no previous session in this directory — starting fresh)" and
-  starts a new session instead of erroring — matches claude-code/pi: "no
-  session here → just start." The full resume path (`m.resume`) rebuilds the
-  agent, restores background subagents, todos, snapshots, and usage.
-- **`whip --browse`** — explicit alias for bare `--resume` (opens the picker);
-  exists so the picker has a name independent of the optional-value trick.
+Precedence: `-r <id>` > `-c` > `--browse`. With `whip up <prompt>`, the
+resume/continue/picker runs first and the prompt fires as the next turn
+(`-r up …` reads as resume-by-id "up", so use `--browse up …` for
+picker-then-prompt).
 
-Precedence when several are given: `-r <id>` > `-c` > `--browse` (an explicit
-id is the strongest intent). `whip up <prompt>` combines with all of them: the
-picker/continue/resume runs first, then the prompt submits as the next turn
-after the replay, matching `--resume <id>` + `up`'s prompt-after-resume order.
-Bare `--resume` + `up` is ambiguous (`-r up …` reads as resume-by-id "up"), so
-use `--browse up …` or `-c up …` for picker-then-prompt.
+Bare `--resume` works despite stdlib `flag` having no optional values:
+`normalizeBareResume` (cmd/whip/main.go) rewrites a trailing bare `-r`/
+`--resume` to `--browse` before `flag.Parse`; `-r <id>` and `-r=<id>` are
+left untouched.
 
-Why bare `--resume` works despite Go's stdlib `flag` having no optional values:
-`normalizeBareResume` (in `cmd/whip/main.go`) pre-scans `os.Args` and rewrites
-a trailing bare `-r`/`--resume` (no following id) to `--browse` before
-`flag.Parse`. A `-r <id>` or `-r=<id>` form is left untouched. No pflag dep.
 
 Tests: `internal/session/session_test.go` — `TestLatestInDir` (newest per dir,
 `sql.ErrNoRows` when none), `TestLatestInDirExcludesSubagentTranscripts`,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,6 +50,7 @@ parallel tool calls and background subagents).
 ## Sessions
 
 - [x] SQLite session store with `--resume` / `/resume` picker
+- [x] Startup resume flags: `-c`/`--continue` (most-recent session in the current dir), `-r`/`--resume <id>` (shorthand, resume by id/prefix) and bare `--resume`/`-r` opens the `/resume` picker at startup (claude-code/pi `--resume` = picker; pi `-r` help = "browse and select session"), `--browse` is an explicit alias for the bare form — a pre-scan (`normalizeBareResume`) rewrites trailing bare `-r`/`--resume` to `--browse` before `flag.Parse` since stdlib `flag` has no optional values
 - [x] Session titles: auto-generate a short title from the first exchange
 - [x] `/rename` a session (opencode: ctrl+r prompt dialog) — `/rename [title]`, bare opens an inline prompt prefilled with the current title, draft preserved
 - [x] `/fork` a session (pi: tree-structured JSONL entries with `parentId` — `docs/session-format.md`; opencode forks from any message via a per-message action menu) — `/fork [name]` copies the conversation to a new session with an auto-suggested `(fork #N)` name; `f` in the rewind picker forks from any message

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -525,6 +525,18 @@ func (s *Store) Recent(n int) ([]Meta, error) {
 	return scanMetas(rows)
 }
 
+// LatestInDir returns the most recently updated ordinary session in the given
+// directory (cwd match), for `whip -c/--continue`. Subagent transcripts
+// (task_id != "") are excluded — continuing one would drop the user into a
+// subagent's internal transcript — and rows with no messages are skipped, like
+// Recent. Returns sql.ErrNoRows when no session in dir qualifies.
+func (s *Store) LatestInDir(dir string) (Meta, error) {
+	row := s.db.QueryRowContext(context.Background(), `SELECT id, title, model, provider, cwd, goal, forked_from, fork_seq, tags, pinned, effort, usage_in, usage_cached, usage_out, task_id, sub_usage, updated_at FROM sessions
+		WHERE cwd = ? AND task_id = '' AND EXISTS (SELECT 1 FROM messages WHERE session_id = sessions.id)
+		ORDER BY updated_at DESC LIMIT 1`, dir)
+	return scanMeta(row)
+}
+
 // UserHistory returns user-message contents across ALL sessions (every folder),
 // newest first and de-duplicated, for up-arrow input recall. Order is by the
 // session's last activity then the message's position within it, so the most
@@ -896,26 +908,36 @@ func likeEscape(s string) string {
 	return r.Replace(s)
 }
 
+// scanMeta scans one session row (the column order used by Recent/LatestInDir)
+// from a *sql.Row or *sql.Rows — the single-row factor of scanMetas.
+func scanMeta(row interface{ Scan(dest ...any) error }) (Meta, error) {
+	var m Meta
+	var updated, tags, subUsage string
+	var pinned int
+	if err := row.Scan(&m.ID, &m.Title, &m.Model, &m.Provider, &m.CWD, &m.Goal,
+		&m.ForkedFrom, &m.ForkSeq, &tags, &pinned, &m.Effort,
+		&m.UsageIn, &m.UsageCached, &m.UsageOut, &m.TaskID, &subUsage, &updated); err != nil {
+		return Meta{}, err
+	}
+	if tags != "" {
+		m.Tags = strings.Split(tags, ",")
+	}
+	if subUsage != "" {
+		_ = json.Unmarshal([]byte(subUsage), &m.SubUsage)
+	}
+	m.Pinned = pinned != 0
+	m.UpdatedAt, _ = time.Parse(time.RFC3339, updated)
+	return m, nil
+}
+
 func scanMetas(rows *sql.Rows) ([]Meta, error) {
 	defer func() { _ = rows.Close() }()
 	var out []Meta
 	for rows.Next() {
-		var m Meta
-		var updated, tags, subUsage string
-		var pinned int
-		if err := rows.Scan(&m.ID, &m.Title, &m.Model, &m.Provider, &m.CWD, &m.Goal,
-			&m.ForkedFrom, &m.ForkSeq, &tags, &pinned, &m.Effort,
-			&m.UsageIn, &m.UsageCached, &m.UsageOut, &m.TaskID, &subUsage, &updated); err != nil {
+		m, err := scanMeta(rows)
+		if err != nil {
 			return nil, err
 		}
-		if tags != "" {
-			m.Tags = strings.Split(tags, ",")
-		}
-		if subUsage != "" {
-			_ = json.Unmarshal([]byte(subUsage), &m.SubUsage)
-		}
-		m.Pinned = pinned != 0
-		m.UpdatedAt, _ = time.Parse(time.RFC3339, updated)
 		out = append(out, m)
 	}
 	return out, rows.Err()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -834,5 +836,110 @@ func TestSubagentTranscriptAttributesSubModel(t *testing.T) {
 	}
 	if meta.Model != "sub-model-id" {
 		t.Fatalf("transcript should attribute the sub's model, got %q", meta.Model)
+	}
+}
+
+func TestLatestInDir(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// Two sessions in /a (B newer), one in /b. now() has second precision, so
+	// two saves in the same second tie on ORDER BY updated_at — stamp explicit
+	// timestamps to make "newest" deterministic without a sleep.
+	stamp := func(id string, at time.Time) {
+		if _, err := st.db.ExecContext(context.Background(),
+			`UPDATE sessions SET updated_at=? WHERE id=?`, at.UTC().Format(time.RFC3339), id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a, _ := st.Create("/a", "m", "p")
+	st.Save(a, 0, []llm.Message{{Role: "user", Content: "a"}}, "m", "p")
+	stamp(a, time.Now().Add(-2*time.Hour))
+	b, _ := st.Create("/a", "m", "p")
+	st.Save(b, 0, []llm.Message{{Role: "user", Content: "b"}}, "m", "p")
+	stamp(b, time.Now().Add(-1*time.Hour))
+	c, _ := st.Create("/b", "m", "p")
+	st.Save(c, 0, []llm.Message{{Role: "user", Content: "c"}}, "m", "p")
+	stamp(c, time.Now().Add(-1*time.Hour))
+
+	if meta, err := st.LatestInDir("/a"); err != nil {
+		t.Fatalf("/a: %v", err)
+	} else if meta.ID != b {
+		t.Fatalf("LatestInDir(/a) = %s, want newest %s", meta.ID, b)
+	}
+	if meta, err := st.LatestInDir("/b"); err != nil {
+		t.Fatalf("/b: %v", err)
+	} else if meta.ID != c {
+		t.Fatalf("LatestInDir(/b) = %s, want %s", meta.ID, c)
+	}
+	if _, err := st.LatestInDir("/none"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("LatestInDir(/none) = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestLatestInDirExcludesSubagentTranscripts(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// An ordinary session in /proj, and a subagent transcript whose parent is
+	// in /proj. SaveSubagentTranscript writes cwd="" for the transcript row,
+	// so the cwd filter alone would already exclude it — but the point of this
+	// test is the task_id='' guard. Force the transcript's cwd to /proj so the
+	// only thing keeping it out of LatestInDir is the task_id filter.
+	ordinary, _ := st.Create("/proj", "m", "p")
+	st.Save(ordinary, 0, []llm.Message{{Role: "user", Content: "main"}}, "m", "p")
+	subID, err := st.SaveSubagentTranscript(ordinary, "probe-1",
+		[]llm.Message{{Role: "user", Content: "sub"}}, "sub-m", "sub-p")
+	if err != nil || subID == "" {
+		t.Fatalf("subagent transcript save: id=%q err=%v", subID, err)
+	}
+	if _, err := st.db.ExecContext(context.Background(),
+		`UPDATE sessions SET cwd='/proj', updated_at=? WHERE id=?`, now(), subID); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := st.LatestInDir("/proj")
+	if err != nil {
+		t.Fatalf("/proj: %v", err)
+	}
+	if meta.ID != ordinary {
+		t.Fatalf("LatestInDir(/proj) = %s (subagent transcript), want ordinary %s", meta.ID, ordinary)
+	}
+	if meta.TaskID != "" {
+		t.Fatalf("returned a subagent transcript row: task_id=%q", meta.TaskID)
+	}
+}
+
+func TestLatestInDirSkipsEmptySessions(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// A created-but-never-written session (no messages) in /x, plus a real one.
+	// Stamp timestamps so the empty row (which can't be LatestInDir's pick
+	// anyway — it has no messages) isn't relied on for ordering.
+	empty, _ := st.Create("/x", "m", "p")
+	if _, err := st.db.ExecContext(context.Background(),
+		`UPDATE sessions SET updated_at=? WHERE id=?`,
+		time.Now().Add(-1*time.Hour).UTC().Format(time.RFC3339), empty); err != nil {
+		t.Fatal(err)
+	}
+	full, _ := st.Create("/x", "m", "p")
+	st.Save(full, 0, []llm.Message{{Role: "user", Content: "hi"}}, "m", "p")
+
+	meta, err := st.LatestInDir("/x")
+	if err != nil {
+		t.Fatalf("/x: %v", err)
+	}
+	if meta.ID != full {
+		t.Fatalf("LatestInDir(/x) = %s, want the only session with messages %s", meta.ID, full)
 	}
 }

--- a/internal/tui/resume_browse_test.go
+++ b/internal/tui/resume_browse_test.go
@@ -101,7 +101,9 @@ func TestBrowseOpensPickerAndEnterResumes(t *testing.T) {
 	}
 
 	// Enter on the highlighted row resumes the session, same as /resume.
-	if _, _ = m.pickerKey(tea.KeyMsg{Type: tea.KeyEnter}); false {
+	mm, _ := m.pickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if mm != m {
+		t.Fatal("pickerKey should return the same model")
 	}
 	if m.picker != nil {
 		t.Fatal("enter should dismiss the picker")

--- a/internal/tui/resume_browse_test.go
+++ b/internal/tui/resume_browse_test.go
@@ -1,0 +1,130 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/context-labs/whip/internal/llm"
+	"github.com/context-labs/whip/internal/session"
+)
+
+// resumeBrowseModel builds an idle model wired to a temp session store, the
+// minimal setup for exercising the startup resume paths (continueRecent and
+// openPicker) without driving Run (trust gate + TTY).
+func resumeBrowseModel(t *testing.T) *model {
+	t.Helper()
+	st, err := session.Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	m := compactCmdModel()
+	m.store = st
+	return m
+}
+
+// seedSession persists an ordinary session (with messages so it's not skipped)
+// in cwd. LatestInDir filters cwd = ? before ordering, so a single session per
+// cwd is deterministic without stamping updated_at (now() has only second
+// precision and same-second saves would tie on ORDER BY).
+func seedSession(t *testing.T, st *session.Store, cwd, content string) string {
+	t.Helper()
+	id, err := st.Create(cwd, "m", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Save(id, 0, []llm.Message{{Role: "user", Content: content, Authored: true}}, "m", "p"); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// continueRecent resumes the newest ordinary session in the current directory.
+// Seed one in this cwd and an older one elsewhere; the cwd one must win.
+func TestContinueRecentResumesNewestInCwd(t *testing.T) {
+	m := resumeBrowseModel(t)
+
+	// Sessions in other dirs must never be the pick (cwd filter), regardless of
+	// age. Seed two foreign-dir sessions and one in THIS cwd; the local one wins.
+	seedSession(t, m.store, "/elsewhere", "other")
+	seedSession(t, m.store, "/other-new", "newest-overall")
+	want := seedSession(t, m.store, cwd(), "local work")
+
+	if err := m.continueRecent(); err != nil {
+		t.Fatalf("continueRecent: %v", err)
+	}
+	if m.sessionID != want {
+		t.Fatalf("continueRecent resumed %q, want newest-in-cwd %q", m.sessionID, want)
+	}
+}
+
+// continueRecent with no session in the current dir falls through to a fresh
+// session and prints a notice — it must not error or resume a foreign dir.
+func TestContinueRecentNoSessionInDirStartsFresh(t *testing.T) {
+	m := resumeBrowseModel(t)
+	// Sessions exist, but none in this cwd.
+	seedSession(t, m.store, "/somewhere-else", "x")
+	before := len(m.blocks)
+	hadSession := m.sessionID
+
+	if err := m.continueRecent(); err != nil {
+		t.Fatalf("continueRecent on empty dir should not error: %v", err)
+	}
+	if m.sessionID != hadSession {
+		t.Fatalf("continueRecent resumed a foreign-dir session: sessionID=%q", m.sessionID)
+	}
+	if len(m.blocks) != before+1 {
+		t.Fatalf("expected one notice block, got %d blocks (was %d)", len(m.blocks), before)
+	}
+	if !strings.Contains(ansi.Strip(m.blocks[before].render(m.width)), "no previous session in this directory") {
+		t.Errorf("unexpected notice: %q", m.blocks[before].render(m.width))
+	}
+}
+
+// --browse opens the interactive picker at startup (the same picker /resume
+// uses). Seed a session so the picker has a row, call openPicker, then assert
+// the model is in picker mode and enter on the highlighted row resumes it.
+func TestBrowseOpensPickerAndEnterResumes(t *testing.T) {
+	m := resumeBrowseModel(t)
+	want := seedSession(t, m.store, cwd(), "browse me")
+
+	m.openPicker()
+	if m.picker == nil {
+		t.Fatal("openPicker should set m.picker")
+	}
+	if len(m.picker.metas) != 1 || m.picker.metas[0].ID != want {
+		t.Fatalf("picker row = %+v, want [%s]", m.picker.metas, want)
+	}
+
+	// Enter on the highlighted row resumes the session, same as /resume.
+	if _, _ = m.pickerKey(tea.KeyMsg{Type: tea.KeyEnter}); false {
+	}
+	if m.picker != nil {
+		t.Fatal("enter should dismiss the picker")
+	}
+	if m.sessionID != want {
+		t.Fatalf("picker enter resumed %q, want %q", m.sessionID, want)
+	}
+}
+
+// --browse with no sessions anywhere prints the empty-state notice and leaves
+// the model picker-less, instead of erroring.
+func TestBrowseNoSessionsPrintsEmptyState(t *testing.T) {
+	m := resumeBrowseModel(t)
+	before := len(m.blocks)
+
+	m.openPicker()
+	if m.picker != nil {
+		t.Fatal("openPicker with no sessions should not set a picker")
+	}
+	if len(m.blocks) != before+1 {
+		t.Fatalf("expected one empty-state notice, got %d blocks (was %d)", len(m.blocks), before)
+	}
+	if !strings.Contains(ansi.Strip(m.blocks[before].render(m.width)), "no previous sessions") {
+		t.Errorf("unexpected notice: %q", m.blocks[before].render(m.width))
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -336,7 +337,7 @@ var (
 // config.Load creates it) and triggers the one-time setup wizard.
 // initialPrompt (`whip up <words>`) is submitted as the first turn once the
 // UI is up — after any resume replay, matching `whip run`'s order.
-func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, cautious, firstRun bool, initialPrompt string) (string, error) {
+func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, cautious, firstRun bool, initialPrompt string, continueMode, browseMode bool) (string, error) {
 	// One shared stdin reader for the pre-TUI prompts: a bufio.Reader reads
 	// ahead, so separate readers for the trust gate and the setup wizard would
 	// lose buffered answers (a pasted "y\n2\n…\n" answers both).
@@ -460,12 +461,25 @@ func Run(cfg *config.Config, modelName, provName, sysPrompt, resumeID string, ca
 			m.append(errStyle.Render("sessions disabled: " + serr.Error()))
 		}
 	}
-	if resumeID != "" {
+	// Startup resume: explicit id wins, then -c (most-recent in this dir),
+	// then --browse (interactive picker). initialPrompt (`whip up`) submits as
+	// the first turn after the replay, since it's dispatched into the event
+	// loop after Run returns.
+	if resumeID != "" || continueMode || browseMode {
 		if m.store == nil {
 			return "", errors.New("cannot resume: session store unavailable")
 		}
-		if err := m.resume(resumeID); err != nil {
-			return "", err
+		switch {
+		case resumeID != "":
+			if err := m.resume(resumeID); err != nil {
+				return "", err
+			}
+		case continueMode:
+			if err := m.continueRecent(); err != nil {
+				return "", err
+			}
+		case browseMode:
+			m.openPicker()
 		}
 	}
 	// Pick up whatever the update check recorded: a notice from an earlier
@@ -1013,6 +1027,22 @@ func (m *model) resume(id string) error {
 	}
 	m.seedTranscript(msgs, 1)
 	return nil
+}
+
+// continueRecent resumes the most recently updated ordinary session in the
+// current directory — the `whip -c`/`--continue` path. Starts fresh (with a
+// notice) when none exists in this dir. Subagent transcripts are excluded by
+// LatestInDir.
+func (m *model) continueRecent() error {
+	meta, err := m.store.LatestInDir(cwd())
+	if errors.Is(err, sql.ErrNoRows) {
+		m.append(dimStyle.Render("(no previous session in this directory — starting fresh)"))
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return m.resume(meta.ID)
 }
 
 // seedTranscript re-renders stored messages into the viewport. Blocks are


### PR DESCRIPTION
## Startup resume flags — claude-code / pi / opencode parity

Three ways to pick up a previous session at launch:

| flag | behavior |
|---|---|
| \`whip --resume <id>\` / \`whip -r <id>\` | resume a specific session by id or unique prefix (new \`-r\` shorthand) |
| \`whip --resume\` / \`whip -r\` (bare) | open the interactive \`/resume\` picker at startup (claude-code/pi semantics — pi \`-r\` help: \"Browse and select session\") |
| \`whip -c\` / \`--continue\` | resume the most-recent ordinary session **in the current dir**; starts fresh with a notice if none |
| \`whip --browse\` | explicit alias for bare \`--resume\` (opens the picker) |

Precedence: \`-r <id>\` > \`-c\` > \`--browse\`.

## How bare \`--resume\` works (no new deps)

Go's stdlib \`flag\` has no optional flag values, so bare \`whip --resume\` would error \"flag needs an argument.\" \`normalizeBareResume\` (cmd/whip/main.go) pre-scans \`os.Args\` and rewrites a trailing bare \`-r\`/\`--resume\` (no following id) to \`--browse\` before \`flag.Parse\`. \`-r <id>\` and \`-r=<id>\` are left untouched. No pflag dependency.

## Surfaces

- **cmd/whip/main.go** — flag registrations (\`-c\`/\`--continue\`, \`-r\`/\`--resume\` alias, \`--browse\`) + \`normalizeBareResume\` pre-scan + \`tui.Run\` call updated.
- **internal/tui/tui.go** — \`Run\` signature (+\`continueMode, browseMode bool\`), precedence switch, new \`continueRecent()\` (reuses the full \`m.resume\` path: agent, subagents, todos, snapshots, usage).
- **internal/session/session.go** — \`Store.LatestInDir(dir)\` (\`cwd = ? AND task_id = '' AND EXISTS(messages)\`, excludes subagent transcripts) + factored \`scanMeta\` out of \`scanMetas\` (no decode duplication).
- **\`whip up <prompt>\`** combines with all three: resume/continue/picker runs first, then the prompt submits as the next turn after the replay.

## Why \`-c\` excludes subagent transcripts

opencode's \`-c\` continues the last **root** session. Subagent transcripts have \`task_id != ''\`; continuing one would drop you into a subagent's internal transcript. \`LatestInDir\` filters them out.

## Tests

- \`internal/session/session_test.go\` — \`TestLatestInDir\` (newest per dir, \`sql.ErrNoRows\` when none), \`TestLatestInDirExcludesSubagentTranscripts\`, \`TestLatestInDirSkipsEmptySessions\`.
- \`internal/tui/resume_browse_test.go\` (new) — \`TestContinueRecentResumesNewestInCwd\`, \`TestContinueRecentNoSessionInDirStartsFresh\`, \`TestBrowseOpensPickerAndEnterResumes\`, \`TestBrowseNoSessionsPrintsEmptyState\`.
- \`cmd/whip/normalize_resume_test.go\` (new) — \`TestNormalizeBareResume\`, 12 table cases (bare/\`<id>\`/\`=\`-form/flag-after/positional-after/empty/flag-ish-id).

All green: \`go build ./...\`, \`go vet\`, \`gofmt -l\`, \`go test ./cmd/whip/ ./internal/session/ ./internal/tui/\`.

## Prior art (verified, not guessed)

- **Claude Code** — \`-c\` = most-recent in cwd; \`-r\` optional value, bare → picker; no \`--browse\` flag (\"browse\" = the picker).
- **pi** — \`-c\` = most-recent in current project; \`-r\` bare → picker (help: \"Browse and select session\"); \`--session <id>\`.
- **opencode** — \`-c\` = last root session; \`-s <id>\`; picker is in-TUI (\`/sessions\`).

Plan: \`.ai-docs/plans/resume/README.md\`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI and session lookup changes with clear precedence and tests; no auth or data-migration risk, though `-r up` is intentionally parsed as resume-by-id rather than picker-plus-prompt.
> 
> **Overview**
> Adds **claude-code/pi-style startup session selection**: `-c`/`--continue` resumes the newest ordinary session in the current directory, `-r` is shorthand for `--resume <id>`, and **bare** `-r`/`--resume` (or `--browse`) opens the same interactive `/resume` picker at launch instead of failing with “flag needs an argument.”
> 
> Because Go’s `flag` package cannot express optional values, **`normalizeBareResume`** rewrites trailing bare `-r`/`--resume` to `--browse` before `flag.Parse`; forms with an id (`-r <id>`, `-r=<id>`) stay unchanged. **`tui.Run`** now takes `continueMode` and `browseMode` and applies precedence **explicit id → continue → browse**, still running before an initial `whip up` prompt.
> 
> **`Store.LatestInDir`** backs `-c`: newest session matching `cwd`, excluding subagent transcripts (`task_id != ''`) and empty sessions; row scanning is factored through **`scanMeta`**. Docs/roadmap and unit tests cover normalization, `LatestInDir`, and TUI continue/browse paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b30c0e71ed08f0d0b560ecfc4fa66db772d471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->