### PR TITLE
fix(tui): shorten the cwd so the spend survives status-line truncation

### DIFF
--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/context-labs/whip/internal/agent"
 	"github.com/context-labs/whip/internal/config"
 	"github.com/context-labs/whip/internal/llm"
@@ -161,6 +164,31 @@ func TestStatusLineTruncatesCWDNotSpend(t *testing.T) {
 	}
 	if !strings.Contains(v, "inference") {
 		t.Errorf("provider must survive cwd truncation, got %q", v)
+	}
+}
+
+// TestStatusLineCWDTruncationDisplayWidth pins the display-width-correct math:
+// the "…" ellipsis is 3 bytes but 1 column, so a byte-budget leaks cols and the
+// final right-trim clips the spend's tail. With a long path (the worktree case)
+// the cwd must shrink to its tail so the spend — including its "tok" suffix and
+// any "last" segment — survives, and the rendered line must never exceed width.
+func TestStatusLineCWDTruncationDisplayWidth(t *testing.T) {
+	m := statusModel()
+	m.modelName = "m"
+	m.provName = "p"
+	m.agent.AddUsage(llm.Usage{PromptTokens: 20000, CompletionTokens: 900})
+	m.Update(usageMsg(llm.Usage{PromptTokens: 10000, CompletionTokens: 300}))
+	m.width = 80 // matches newGrowModel; tight once the worktree path is long
+
+	v := m.statusView()
+	if !strings.Contains(v, "last 10.0k/300 tok") {
+		t.Errorf("last-response spend (with tok suffix) must survive: %q", v)
+	}
+	if !strings.Contains(v, "20.0k/900 tok") {
+		t.Errorf("session spend must survive: %q", v)
+	}
+	if w := lipgloss.Width(ansi.Strip(v)); w > m.width {
+		t.Errorf("status line width %d exceeds terminal width %d: %q", w, m.width, v)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5230,18 +5230,29 @@ func (m *model) statusView() string {
 	// Instead give the cwd only the space left after the fixed segments —
 	// truncating it to its tail, then dropping it entirely — so the spend
 	// survives whenever the fixed segments fit at all.
+	//
+	// Width math must be display-width aware (lipgloss.Width), not byte len:
+	// the "…" ellipsis is 3 bytes but 1 column, so a byte budget leaks cols
+	// and the final truncLine then clips the spend's tail (e.g. "300 …"
+	// instead of "300 tok"). ansi.TruncateLeft keeps the recognizable tail.
 	right := fmt.Sprintf("   %s   %s   %s", model, m.provName, spend)
 	dir := shortCWD()
-	switch budget := max(m.width, 0) - len(" ") - len(right); {
-	case len(dir) <= budget:
+	const lead = " "
+	budget := max(m.width, 0) - lipgloss.Width(lead) - lipgloss.Width(right)
+	switch {
+	case lipgloss.Width(dir) <= budget:
 		// fits as-is
 	case budget > 1:
-		dir = "…" + dir[len(dir)-budget+1:] // keep the tail, the recognizable part
+		// keep the tail (the recognizable part), prefix "…" which costs 1 col
+		keep := budget - 1
+		if drop := lipgloss.Width(dir) - keep; drop > 0 {
+			dir = "…" + ansi.TruncateLeft(dir, drop, "")
+		}
 	default:
 		dir = "" // no room for the path at all; show only the fixed segments
 	}
-	line := fmt.Sprintf(" %s%s", dir, right)
-	return dimStyle.Render(truncLine(line, max(m.width, 0)))
+	line := lead + dir + right
+	return dimStyle.Render(ansi.Truncate(line, max(m.width, 0), ""))
 }
 
 // shortCWD renders the working directory compactly for the status line: the


### PR DESCRIPTION
## Problem

`TestStatusLineShowsLastResponse` fails when run inside a git worktree whose path is long (e.g. `.worktrees/dynamic-workflows/internal/tui`). The status line's cwd-truncation budget was computed with **byte `len`**, but the `…` ellipsis is 3 bytes / 1 column, so a long path leaked columns and the final right-trim (`truncLine`) clipped the spend's tail:

```
" …fix-statusline-path/internal/tui   m   p   20.0k/900 tok · last 10.0k/300 …"
```
— note `300 …` instead of `300 tok`.

## Fix

`statusView` now uses **display-width-correct math** (`lipgloss.Width`) and `ansi.TruncateLeft` to keep the recognizable tail of the cwd, mirroring the proven truncation in `opencodeStatus`. The cwd yields to the fixed segments (model / provider / spend), shrinking to its tail then dropping entirely — so the spend, including the last-response `tok` suffix, survives whenever the fixed segments fit at all, and the rendered line never exceeds `m.width`.

This is exactly the intent the existing comment already described; the byte-vs-display-width bug was the only thing defeating it.

## Test

- Existing `TestStatusLineTruncatesCWDNotSpend` (width 58, spend survives) — green.
- Existing `TestStatusLineShowsLastResponse` (the worktree-path failure) — now green.
- New `TestStatusLineCWDTruncationDisplayWidth` — long path + last-response segment + a hard `lipgloss.Width(ansi.Strip(v)) ≤ m.width` assertion, pinning the display-width math directly.

`go vet`, `gofmt -s`, `whipvet`, and the full `internal/tui` suite are green.

## Scope

2 files, +44/−5. One function (`statusView`) and one new test. `truncLine` is unchanged and still used in ~20 other places.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI status rendering and tests only; no auth, persistence, or agent behavior changes.
> 
> **Overview**
> Fixes status-line truncation when the working directory is long (e.g. git worktrees): **cwd budget and tail trimming now use terminal column width** (`lipgloss.Width`, `ansi.TruncateLeft` / `ansi.Truncate`) instead of byte `len`, so the single-column `…` ellipsis no longer steals space and a final right-trim no longer clips token spend (e.g. `300 tok` → `300 …`).
> 
> **`statusView`** still yields only the cwd to preserve model, provider, and spend (including the **last** response segment); the final line is capped with display-aware truncation rather than `truncLine`.
> 
> Adds **`TestStatusLineCWDTruncationDisplayWidth`** to assert last/session spend strings survive and `lipgloss.Width(ansi.Strip(v)) ≤ m.width`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf318e668eecb25c48b9dd2bcfd65b52790fd21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->