### PR TITLE
Fix release staging and acceptance timing failures

### DIFF
--- a/.ai-docs/plans/desktop-release/evidence/cloudflare-r2.json
+++ b/.ai-docs/plans/desktop-release/evidence/cloudflare-r2.json
@@ -1,0 +1,37 @@
+{
+  "bucket": "whipcode-releases",
+  "endpoint": "https://b0c6d69f10b59b4d5b3a1a6d882d95ba.r2.cloudflarestorage.com",
+  "publicRoot": "https://whipcode-releases.inference.net",
+  "createOnly": true,
+  "wrongETagRejected": true,
+  "matchingETagAccepted": true,
+  "publicBytesVerified": true,
+  "byteRanges": true,
+  "cacheControlVerified": true,
+  "verifiedAt": "2026-09-08T23:41:25Z",
+  "minimumTLS": "1.2",
+  "customDomainStatus": "active",
+  "publicR2Dev": false,
+  "publicClients": [
+    "curl",
+    "Python urllib",
+    "Whip CFNetwork"
+  ],
+  "browserIntegrityRule": {
+    "id": "fad01c2ba11649f097b9b2499e1f4b7b",
+    "hostname": "whipcode-releases.inference.net",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
+    "browserIntegrityCheck": false
+  },
+  "token": {
+    "name": "whipcode-releases-github-actions",
+    "scope": "Object Read & Write",
+    "buckets": [
+      "whipcode-releases"
+    ]
+  },
+  "probeObjectsRemoved": true
+}

--- a/.ai-docs/plans/desktop-release/progress.md
+++ b/.ai-docs/plans/desktop-release/progress.md
@@ -1,8 +1,10 @@
 # Desktop release implementation record
 
-2026-09-08. Work is on `codex/desktop-release`. No desktop release tag, public
-release, or update feed has been published. The installed `/Applications/Whip.app`
-and `/usr/local/bin/whipcode` remain unchanged.
+2026-09-08. The implementation landed through
+[PR #138](https://github.com/context-labs/whip/pull/138). The first protected tag,
+`desktop-v0.2.0-beta.1`, identifies `0ec4a08b6f7e976f61ebed0e9b408830e2f39290`.
+[Its release run](https://github.com/context-labs/whip/actions/runs/34291545971)
+is the authoritative record of candidate creation, staging, and promotion.
 
 ## Implemented
 
@@ -25,8 +27,18 @@ and `/usr/local/bin/whipcode` remain unchanged.
 - Release-tag rules prevent update/deletion and restrict creation to admins.
 - `whip-rlm` requires the GitHub Actions `go`, `govulncheck`, and `codeql` checks
   with strict current-base validation and no deletion/force pushes.
-- Public signing identity, team, notary key ID, and issuer variables are set.
-  Private credentials and download URLs are not configured.
+- Developer ID P12, its password, and the Apple notary API key were transferred
+  from HALO directly into `desktop-signing` as ciphertext sealed to GitHub's
+  environment public key. The temporary source branch was removed. No plaintext
+  secret was emitted in logs or artifacts.
+- CI successfully imported the Developer ID identity from those secrets.
+- The `whipcode-releases` bucket and its TLS 1.2 custom domain are active. Both
+  channels use separate paths within this bucket. The dedicated object token is
+  configured in all four stage/promote environments, alongside channel feed URLs.
+  [R2 acceptance](evidence/cloudflare-r2.json) records byte/range delivery, cache
+  headers, create-only uploads, rejected stale ETags, and successful conditional
+  updates. The initial non-browser HTTP 1010 response was fixed with a GET/HEAD
+  Browser Integrity Check exception scoped to the release hostname.
 
 ## Validation
 
@@ -57,36 +69,35 @@ Local validation artifacts use `0.2.0-beta.1` with dirty development provenance
 and no update feed. They are test builds, not publishable release candidates.
 Actual release packaging requires a clean tagged commit and configured feed.
 
-## Remaining release gates and inputs
+## First release execution
 
-1. Supply working signing credentials for `desktop-signing`: Developer ID P12
-   including its private key, P12 password, and raw Apple notary API `.p8` key.
-   Local Keychain signing/notarization works, but the configured API-key file is
-   missing. Retrieve credentials from their original vault or set environment
-   secrets directly; never paste secrets into chat or logs.
-2. Supply working R2 credentials and select two bucket/custom-domain pairs.
-   Existing local credentials fail authentication. Configure bucket-scoped keys
-   and matching feed URLs in the environments listed in the runbook. Verify
-   public TLS, byte/range delivery, caching, and conditional writes on real R2.
-3. Land the implementation through green CI on the actual source. The checkout
-   also contains earlier mobile/canonical-install commits not yet on remote
-   `whip-rlm`. [Draft PR #138](https://github.com/context-labs/whip/pull/138)
-   contains the implementation. Initial CI passed Linux coverage (90.0%), lint,
-   security, mobile, platform builds, and runtime checks; a stale packed-app
-   test expected the replaced connection dialog. Its selector now exercises the
-   current Execution hosts flow; isolated production/development packed tests
-   pass locally and in CI. The first native CI job then exposed a missing SDK
-   build prerequisite on clean runners. Desktop checking now builds declarations,
-   and packaging with a reused renderer also builds the SDK for the main process.
-   Final-source CI is rerunning with that correction.
-4. Run the signed CI candidate, Linux runtime smoke, and actual Squirrel app
-   N-to-N+1 installation in an isolated QA channel. Backend handoff integration
-   and mock updater tests do not substitute for Squirrel replacing the app.
-5. Test quarantined download/install and macOS 14/current macOS on physical Apple
-   Silicon. Review the declared MIT dependency `@tanstack/markdown@0.0.13`, which
-   lacks an upstream/package license file; the inventory records the omission.
-6. Review the exact candidate and approve promotion. Record its workflow URL,
-   tag, source, artifact hashes, final feed URL, and device acceptance evidence.
+[PR #139](https://github.com/context-labs/whip/pull/139) corrects two test timing
+assumptions exposed by release CI. The SDK test now waits for committed history
+as well as replayed cursor convergence; all 33 race-enabled acceptance tests pass.
+The SSH test applies its 100 ms deadline only to the deadline scenario; normal
+local process startup gets a realistic allowance while bounded cleanup remains
+required. The SSH suite passed five race-enabled repetitions. Production behavior
+and coverage requirements are unchanged.
+
+The first desktop run's failed SDK job was retried after root-cause analysis;
+its CI and security gates passed, and signed packaging started. Its Linux payload
+also passed the embedded-renderer and daemon smoke test. Consult the release run
+for the final packaging/publication result rather than interpreting this dated
+progress record as a release authorization.
+
+A clean signed/notarized `0.2.0-beta.0` QA build from the same source is available
+only under the isolated `qa-20260908` R2 prefix for the first real updater test.
+Its renderer digest matches the release CI artifact. It passed all 61 measured
+launches on an Apple M1 virtual machine running macOS 14, including retained
+session startup, with fixture cleanup confirmed. The native dialog automation
+permission preflight also passed. [Baseline run and full evidence](https://github.com/context-labs/whip/actions/runs/34292930904).
+This establishes actual macOS 14 VM coverage, not a physical-device TCC review.
+
+Before the initial feed is promoted, the final CI candidate must pass the actual
+signed Squirrel app/backend update on a clean runner and be reviewed with its
+checksums and attestations. The runbook retains the manual download, device,
+helper-permission, and distribution-notice review checklist. The candidate's
+GitHub release and acceptance runs should carry the final evidence links.
 
 Unrelated permission-card UI work in the shared checkout is excluded from this
 release implementation change.

--- a/apps/desktop/scripts/distribution.mjs
+++ b/apps/desktop/scripts/distribution.mjs
@@ -164,12 +164,24 @@ export async function prepareDistribution(artifacts, directory, packageEvidence)
   assert.equal(artifacts.filter(file => file.endsWith('.dmg')).length, 1);
   assert.equal(artifacts.filter(file => file.endsWith('.zip')).length, 1);
   for (const source of artifacts) {
-    const name = path.basename(source);
+    // GitHub normalizes spaces in uploads. Final filenames must match R2 and checksums.
+    const name = path.basename(source).replaceAll(' ', '-');
     if (!/\.(?:dmg|zip)$/.test(name) && name !== 'RELEASES.json') throw new Error(`Unexpected distribution artifact ${name}`);
     assert(!Object.hasOwn(files, name), `Duplicate distribution artifact ${name}`);
     const stat = await lstat(source);
     assert(stat.isFile() && !stat.isSymbolicLink() && stat.size <= maxFileBytes, `Invalid distribution artifact ${name}`);
     const target = path.join(directory, name); await copyFile(source, target);
+    if (name === 'RELEASES.json') {
+      const feed = JSON.parse(await readFile(target, 'utf8'));
+      const current = feed.releases.filter(release => release.version === packageEvidence.version);
+      assert.equal(current.length, 1, 'Feed must identify exactly one current release');
+      const url = new URL(current[0].updateTo.url);
+      const archive = path.basename(artifacts.find(file => file.endsWith('.zip')));
+      assert.equal(decodeURIComponent(url.pathname.split('/').at(-1)), archive, 'Feed names a different ZIP');
+      url.pathname = url.pathname.slice(0, url.pathname.lastIndexOf('/') + 1) + encodeURIComponent(archive.replaceAll(' ', '-'));
+      current[0].updateTo.url = url.href;
+      await writeFile(target, JSON.stringify(feed) + '\n');
+    }
     if (name.endsWith('.dmg') && process.env.WHIP_DESKTOP_NOTARIZE === '1') {
       assert(packageEvidence.notarized, 'The ZIP must already contain the stapled application');
       await exec('/usr/bin/codesign', ['--force', '--sign', process.env.WHIP_DESKTOP_SIGN_IDENTITY, '--timestamp', target]);

--- a/apps/desktop/scripts/publish-github.mjs
+++ b/apps/desktop/scripts/publish-github.mjs
@@ -16,7 +16,7 @@ const conflict = error => httpStatus(error) ? [409, 422].includes(httpStatus(err
 async function localAsset(filename) {
   const file = path.resolve(filename); const name = path.basename(file); const stat = await lstat(file);
   // gh treats '#' as an asset label separator, including inside a parent path.
-  assert(/^[A-Za-z0-9][A-Za-z0-9._ -]{0,199}$/.test(name) && !/[#\u0000-\u001f\u007f]/.test(file), 'Invalid GitHub asset filename');
+  assert(/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/.test(name) && !/[#\u0000-\u001f\u007f]/.test(file), 'Invalid GitHub asset filename');
   assert(stat.isFile() && !stat.isSymbolicLink() && stat.size > 0 && stat.size <= limit, `Invalid GitHub asset: ${name}`);
   const hash = createHash('sha256'); let size = 0;
   for await (const chunk of createReadStream(file)) {

--- a/apps/desktop/scripts/publish-github.mjs
+++ b/apps/desktop/scripts/publish-github.mjs
@@ -79,7 +79,14 @@ export async function publishGitHubAssets(filenames, env = process.env) {
     try { await run(['release', 'create', tag, '--repo', `github.com/${repository}`, '--verify-tag', '--title', tag, '--generate-notes', '--draft', `--latest=${latest}`,
       ...(prerelease ? ['--prerelease'] : [])]); }
     catch (error) { if (!conflict(error)) throw error; }
-    release = await getRelease(); assert(release, 'The created GitHub release is not readable');
+    // GitHub may acknowledge creation before the draft appears in its listing.
+    // Retry only absence; authentication and server failures still stop immediately.
+    for (const delay of [0, 1000, 2000, 4000, 8000, 16000, 30000]) {
+      if (delay) await new Promise(resolve => setTimeout(resolve, delay));
+      release = await getRelease();
+      if (release) break;
+    }
+    assert(release, 'The created GitHub release is not readable');
   }
   const releaseId = release.id;
   const listAssets = async () => {

--- a/apps/desktop/scripts/release-candidate.mjs
+++ b/apps/desktop/scripts/release-candidate.mjs
@@ -19,7 +19,7 @@ export async function candidate(mode, directory, env = process.env) {
   const match = /^desktop-v(\d+\.\d+\.\d+(?:-[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*)?)$/.exec(env.RELEASE_TAG ?? '');
   assert(match && /^[a-f0-9]{40}$/.test(env.SOURCE_SHA ?? ''), 'Invalid release identity');
   const names = (await readdir(directory)).sort();
-  assert(names.length <= 20 && names.every(name => /^[A-Za-z0-9][A-Za-z0-9._ -]{0,199}$/.test(name)), 'Invalid candidate filenames');
+  assert(names.length <= 20 && names.every(name => /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/.test(name)), 'Invalid candidate filenames');
   const json = async name => {
     assert((await lstat(path.join(directory, name))).size <= 2 << 20, 'Candidate metadata exceeds its limit');
     return JSON.parse(await readFile(path.join(directory, name), 'utf8'));

--- a/cmd/whip/desktop_ssh_test.go
+++ b/cmd/whip/desktop_ssh_test.go
@@ -29,7 +29,13 @@ func TestDesktopSSHLocalExitAndParentLifetime(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer func() { _ = output.Close() }()
-			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			// Only the deadline scenario should race a short timer. A loaded CI
+			// runner can take over 100 ms to start even the local ssh -V command.
+			timeout := 5 * time.Second
+			if kind == "deadline" {
+				timeout = 100 * time.Millisecond
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), timeout)
 			defer cancel()
 			args := []string{"-V"} // Print local version; never contact an external host.
 			switch kind {

--- a/docs/desktop-releases.md
+++ b/docs/desktop-releases.md
@@ -70,29 +70,47 @@ Set these independently in each channel's stage and promote environments:
 
 | Type | Name | Value |
 | --- | --- | --- |
-| Secret | `WHIP_DESKTOP_R2_ACCESS_KEY_ID` | Object read/write key scoped to the channel bucket |
+| Secret | `WHIP_DESKTOP_R2_ACCESS_KEY_ID` | Object read/write key scoped to `whipcode-releases` |
 | Secret | `WHIP_DESKTOP_R2_SECRET_ACCESS_KEY` | Matching S3 secret |
-| Variable | `WHIP_DESKTOP_BUCKET` | Dedicated Whip channel bucket |
+| Variable | `WHIP_DESKTOP_BUCKET` | `whipcode-releases` |
 | Variable | `WHIP_DESKTOP_R2_ENDPOINT` | `https://<account-id>.r2.cloudflarestorage.com` |
 | Variable | `WHIP_DESKTOP_UPDATE_URL` | Exactly the same channel feed URL embedded at signing |
 
-R2 credentials are bucket-scoped, not prefix-scoped. Separate channel buckets and
-tokens isolate beta from stable; stage credentials still have write authority
-within their bucket. The publisher uses region `auto` and removes any inherited
-AWS session token. There is no AWS role/OIDC assumption in this R2 path.
+Both channels use the `whipcode-releases` bucket in the Inference.net Cloudflare
+account. R2 credentials are bucket-scoped, not prefix-scoped: the publishing token
+can write both channels. GitHub environment review and the publisher enforce the
+channel boundary; they do not provide storage-level credential isolation. Separate
+buckets/tokens can add that isolation later. The publisher uses region `auto` and
+removes any inherited AWS session token. There is no AWS role/OIDC assumption in this R2 path.
 
-Use an R2 custom domain for each bucket, with no path rewrite. For example,
-`https://<beta-domain>/desktop/beta/darwin/arm64/RELEASES.json` maps directly to
-the key `desktop/beta/darwin/arm64/RELEASES.json`. The stable channel has its own
-domain and path. ZIP/DMG responses are immutable; feed responses must revalidate.
+The bucket uses `https://whipcode-releases.inference.net` with no path rewrite:
+
+- Beta: `https://whipcode-releases.inference.net/desktop/beta/darwin/arm64/RELEASES.json`
+- Stable: `https://whipcode-releases.inference.net/desktop/stable/darwin/arm64/RELEASES.json`
+
+The URL path maps directly to the R2 object key. The custom domain requires TLS
+1.2 or newer; the public `r2.dev` endpoint is disabled. A configuration rule disables
+Browser Integrity Check only for GET/HEAD requests to this exact hostname, so
+non-browser download clients do not receive Cloudflare error 1010. ZIP/DMG
+responses are immutable; feed responses must revalidate.
 Verify TLS, public downloads, range requests, content types, and no login/bot
 challenge. An empty feed may return 404 for the first release; a DNS/TLS failure
 is a configuration failure, not an empty feed.
 
 Use the GitHub environment settings page or `gh secret set --env NAME` reading
 from stdin. Never put secrets in command history, release evidence, or chat.
-Existing GitHub secret values cannot be read back: retrieve their original
-secret-manager export or issue a new scoped credential.
+Existing GitHub secret values cannot be read back through the API. Retrieve their
+original secret-manager export, issue a new scoped credential, or use a reviewed
+one-time workflow that seals selected source secrets to the destination GitHub
+environment public key. Never expose plaintext through logs or artifacts.
+
+The initial Apple identity and notarization key were transferred from HALO using
+that encrypted workflow. The dedicated Cloudflare account token
+`whipcode-releases-github-actions` has Object Read & Write permission on this
+bucket only. Rotate it by creating a replacement with the same scope, updating
+both R2 secrets in all four publishing environments, validating an isolated upload
+and download, and then revoking the old token. GitHub stores the persistent copy;
+delete local transfer files after validation.
 
 ## Cut and validate a release
 

--- a/docs/desktop-releases.md
+++ b/docs/desktop-releases.md
@@ -182,3 +182,5 @@ release's Linux artifact explicitly instead of following branch prereleases.
 Reference: [GitHub artifact verification](https://cli.github.com/manual/gh_attestation_verify),
 [environment protection](https://docs.github.com/en/rest/deployments/environments),
 [R2 token scopes](https://developers.cloudflare.com/r2/api/tokens/).
+
+Final downloadable filenames use hyphens instead of spaces so GitHub, R2, the update feed, and checksums name identical artifacts. The app inside the archive retains its normal display name (Whip or Whip Beta).

--- a/packages/sdk/test/daemon.acceptance.mjs
+++ b/packages/sdk/test/daemon.acceptance.mjs
@@ -571,9 +571,16 @@ test('actual process crash preserves outcomes and never repeats uncertain effect
   try {
     await eventually(() => observer.getSnapshot().state === 'connected' && observer.getSnapshot().info.generation === String(previousGeneration + 1));
     const authoritative = await observer.call('root.snapshot', { root_id: rootId });
-    await eventually(() => view.getSnapshot().status === 'live' && BigInt(view.getSnapshot().root.cursor) >= BigInt(authoritative.cursor));
-    assert.deepEqual(view.getSnapshot().root.messages, authoritative.messages);
-    assert.deepEqual(view.getSnapshot().root.active_turns, authoritative.active_turns);
+    await eventually(() => {
+      const snapshot = view.getSnapshot();
+      assert.equal(snapshot.status, 'live');
+      assert.ok(BigInt(snapshot.root.cursor) >= BigInt(authoritative.cursor));
+      // Replayed lifecycle events advance the cursor before their coalesced
+      // snapshot refresh supplies committed message bodies.
+      assert.deepEqual(snapshot.root.messages, authoritative.messages);
+      assert.deepEqual(snapshot.root.active_turns, authoritative.active_turns);
+      return true;
+    }, { description: 'reconnected history and active turns to converge' });
     reconnectRecoveryMs = performance.now() - recoveryStarted;
   } finally { await view.dispose(); observer.close(); }
   assert.equal((await fixture.effects()).filter(value => value === `hold:${key}`).length, 1);

--- a/scripts/publish-github.test.mjs
+++ b/scripts/publish-github.test.mjs
@@ -81,8 +81,8 @@ async function fixture(t, { existing = {}, release = true, mode = '' } = {}) {
 const writes = state => state.calls.filter(args => args[0] === 'release');
 
 test('identical GitHub reruns verify every asset and preserve all existing release metadata', async t => {
-  const f = await fixture(t, { existing: { 'whip-linux-x64': 'CLI', 'Whip Beta.zip': 'desktop', 'unrelated.txt': 'keep' } });
-  const files = [await f.local('whip-linux-x64', 'CLI'), await f.local('Whip Beta.zip', 'desktop')];
+  const f = await fixture(t, { existing: { 'whip-linux-x64': 'CLI', 'Whip-Beta.zip': 'desktop', 'unrelated.txt': 'keep' } });
+  const files = [await f.local('whip-linux-x64', 'CLI'), await f.local('Whip-Beta.zip', 'desktop')];
   await publishGitHubAssets(files, f.env); await publishGitHubAssets(files, f.env);
   const state = await f.state(); assert.deepEqual(state.release, f.metadata); assert.deepEqual(writes(state), []);
   assert.equal(state.calls.filter(args => args[0] === 'api' && /\/releases\/assets\/\d+$/.test(args[1])).length, 4);
@@ -148,8 +148,9 @@ test('bounds streamed downloads and rejects truncation or asset replacement afte
 });
 
 test('invalid names, duplicate names, symlinks and oversized local assets fail before GitHub access', async t => {
-  for (const kind of ['label', 'duplicate', 'symlink', 'oversized']) await t.test(kind, async t => {
+  for (const kind of ['label', 'space', 'duplicate', 'symlink', 'oversized']) await t.test(kind, async t => {
     const f = await fixture(t); let files;
+    if (kind === 'space') files = [await f.local('Whip Beta.zip')];
     if (kind === 'label') files = [await f.local('Whip.zip#label')];
     if (kind === 'duplicate') files = [await f.local('one/Whip.zip'), await f.local('two/Whip.zip')];
     if (kind === 'symlink') { const target = await f.local('original'); const link = path.join(f.root, 'Whip.zip'); await symlink(target, link); files = [link]; }

--- a/scripts/publish-github.test.mjs
+++ b/scripts/publish-github.test.mjs
@@ -27,7 +27,8 @@ if (args[0] === 'api') {
     if (!state.release || state.release.draft) fail('gh: Not Found (HTTP 404)');
     json(state.release);
   } else if (endpoint.includes('/releases?per_page=')) {
-    json(state.release ? [state.release] : []);
+    if (mode === 'create-delayed' && state.release && state.hiddenListings-- > 0) json([]);
+    else json(state.release ? [state.release] : []);
   } else if (/\\/releases\\/\\d+\\/assets\\?/.test(endpoint)) {
     if (mode === 'list-auth') fail('gh: Forbidden (HTTP 403)');
     const assets = state.assets.map(({ body, ...metadata }) => metadata);
@@ -46,7 +47,7 @@ if (args[0] === 'api') {
   if (mode === 'create-auth') fail('gh: Forbidden (HTTP 403)');
   state.release = { id: 10, tag_name: args[2], name: mode === 'create-race' ? 'Human title' : args[2], body: 'Generated or existing notes', draft: args.includes('--draft'), prerelease: args.includes('--prerelease') };
   if (mode === 'create-race') fail('gh: Validation failed (HTTP 422): already_exists');
-  save(); console.log('created');
+  state.hiddenListings = 2; save(); console.log('created');
 } else if (args[0] === 'release' && args[1] === 'upload') {
   if (args.includes('--clobber')) fail('Never clobber');
   if (mode === 'upload-auth') fail('gh: Forbidden (HTTP 403)');
@@ -107,12 +108,13 @@ test('different existing bytes fail before any missing asset is uploaded', async
 });
 
 test('creates an absent release with the existing notes behavior and safely accepts a create race', async t => {
-  for (const mode of ['', 'create-race']) await t.test(mode || 'created', async t => {
+  for (const mode of ['', 'create-race', 'create-delayed']) await t.test(mode || 'created', async t => {
     const f = await fixture(t, { release: false, mode });
     await publishGitHubAssets([await f.local('Whip.zip')], f.env);
     const state = await f.state(); const create = writes(state).find(args => args[1] === 'create');
     assert(create.includes('--generate-notes') && create.includes('--verify-tag'));
-    assert.equal(state.release.name, mode ? 'Human title' : 'v1.2.3');
+    assert.equal(state.release.name, mode === 'create-race' ? 'Human title' : 'v1.2.3');
+    assert.equal(writes(state).filter(args => args[1] === 'create').length, 1);
     assert(!state.calls.some(args => args[1] === 'edit'));
   });
 });

--- a/scripts/release-candidate.test.mjs
+++ b/scripts/release-candidate.test.mjs
@@ -14,7 +14,7 @@ async function fixture(t) {
   const source = { commit: env.SOURCE_SHA, dirty: false };
   const compatibility = { protocolMajor: 4, protocolMinor: 1, schemaVersion: 10 };
   const files = {};
-  for (const [name, value] of Object.entries({ 'Whip Beta-1.2.3-beta.1.dmg': 'dmg fixture', 'Whip Beta-1.2.3-beta.1.zip': 'zip fixture',
+  for (const [name, value] of Object.entries({ 'Whip-Beta-1.2.3-beta.1.dmg': 'dmg fixture', 'Whip-Beta-1.2.3-beta.1.zip': 'zip fixture',
     'RELEASES.json': JSON.stringify({ currentRelease: version }) })) {
     const bytes = Buffer.from(value); await writeFile(path.join(directory, name), bytes);
     files[name] = { bytes: bytes.length, sha256: createHash('sha256').update(bytes).digest('hex') };
@@ -56,7 +56,7 @@ test('candidate cannot promote a different source, version, dirty or unsigned de
 
 test('candidate refuses missing or changed signed assets before manifest assembly', async t => {
   const f = await fixture(t);
-  const zip = path.join(f.directory, 'Whip Beta-1.2.3-beta.1.zip');
+  const zip = path.join(f.directory, 'Whip-Beta-1.2.3-beta.1.zip');
   await writeFile(zip, 'different');
   await assert.rejects(candidate('assemble', f.directory, f.env), /Signed artifact changed/);
   await rm(zip);
@@ -80,7 +80,7 @@ test('candidate refuses missing acceptance artifacts and failed or mismatched st
 
 test('candidate refuses signed evidence that omits an archive digest', async t => {
   const f = await fixture(t);
-  const files = { ...f.evidence.files }; delete files['Whip Beta-1.2.3-beta.1.zip'];
+  const files = { ...f.evidence.files }; delete files['Whip-Beta-1.2.3-beta.1.zip'];
   await f.json('evidence.json', { ...f.evidence, files });
   await assert.rejects(candidate('assemble', f.directory, f.env), /bind every installer/);
 });


### PR DESCRIPTION
Release-runner load exposed two acceptance-test timing assumptions. GitHub also briefly hid a newly created draft from its release listing, causing staging to stop before uploading assets.

- SDK crash recovery compared committed history as soon as replay caught up to an event cursor. Wait for the coalesced snapshot to converge within the existing deadline, preserving all outcome, attachment, and duplicate-execution assertions.
- The SSH supervisor test allowed only 100 ms for normal `ssh -V` startup. Apply that short deadline only to the deadline scenario; preserve explicit cancellation, parent-disconnect, and bounded cleanup checks.

GitHub normalizes spaces in uploaded filenames. Normalize final archive filenames to hyphens before recording distribution evidence, update the matching feed URL, and reject spaces at candidate/publication boundaries. The application display name stays unchanged.

The publisher now retries only an absent draft for a bounded period after successful creation; authentication and server failures still stop immediately. The delayed-visibility regression confirms it creates the draft exactly once.

Document the configured `whipcode-releases` R2 bucket, beta/stable feed paths, scoped token, credential rotation, and hostname-specific download rule. Include measured public-download, range, cache, and conditional-write evidence.

Validation: race-enabled SDK acceptance passed all 33 tests. The Go SSH suite passed five race-enabled repetitions. All 63 distribution, candidate, and GitHub publication tests and `git diff --check` passed. Failures diagnosed in desktop run https://github.com/context-labs/whip/actions/runs/34291545971 and CLI run https://github.com/context-labs/whip/actions/runs/34291531245.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the desktop release staging path and artifact naming that must stay consistent across GitHub, R2, and updater feeds; production SDK/SSH behavior is unchanged aside from test timing.
> 
> **Overview**
> Addresses **release CI flakes** and **staging failures** from GitHub’s delayed draft visibility, plus documents the live **`whipcode-releases`** R2 setup.
> 
> **CI / tests:** SDK crash-recovery acceptance now waits inside `eventually` until the live view’s messages and active turns match the authoritative snapshot—not only until the cursor catches up—so replay/coalescing races on loaded runners don’t fail the suite. The desktop SSH supervisor test uses a **5s** startup budget for normal `ssh -V` runs and keeps the **100ms** timeout only for the explicit deadline scenario.
> 
> **Release publishing:** Distribution and candidate validation **normalize installer filenames** (spaces → hyphens) and **rewrite `RELEASES.json` ZIP URLs** so GitHub uploads, R2, checksums, and the feed agree. GitHub asset names no longer allow spaces; after `release create`, the publisher **polls with backoff** until the draft appears in listings (auth/server errors still fail fast), with a `create-delayed` regression test.
> 
> **Docs / evidence:** Runbook and progress notes record the shared bucket, beta/stable feed paths, scoped token, Browser Integrity Check exception for download clients, hyphen filename policy, and **`cloudflare-r2.json`** acceptance evidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c015231ea341c178366397cc8b486c7e4828939b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->