### PR TITLE
fix(tui): keep inline view bottom-anchored

### DIFF
--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // The transcript must render inline (no alt-screen) so native drag-to-copy
@@ -27,6 +29,33 @@ func TestInlineRendering(t *testing.T) {
 	// click/wheel-only reporting (no motion), asserted by TestMouseDefaultsOn
 	if !m.mouseOn {
 		t.Fatal("mouse capture must default on for wheel scroll")
+	}
+}
+
+func TestInlineViewReturnsToBottomAfterTemporaryGrowth(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 30))
+	m.View()
+	bottom := m.viewTop
+
+	// Busy mode temporarily adds the spinner and its separator. Bubble Tea's
+	// inline renderer scrolls a growing frame upward but cannot move its top back
+	// down when the frame shrinks again.
+	m.busy = true
+	m.layout()
+	grown := m.View()
+	if m.viewTop >= bottom {
+		t.Fatalf("test setup: growing view must move up: %d -> %d", bottom, m.viewTop)
+	}
+
+	m.busy = false
+	m.layout()
+	shrunk := m.View()
+	if m.viewTop != bottom {
+		t.Fatalf("shrunk view must return to bottom: got top %d, want %d", m.viewTop, bottom)
+	}
+	if got, want := lipgloss.Height(shrunk), lipgloss.Height(grown); got != want {
+		t.Fatalf("shrunk render must retain the physical frame height: got %d, want %d", got, want)
 	}
 }
 

--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -59,6 +59,26 @@ func TestInlineViewReturnsToBottomAfterTemporaryGrowth(t *testing.T) {
 	}
 }
 
+func TestInlineFrameHeightIsCappedByTerminal(t *testing.T) {
+	m := compactCmdModel()
+	m.Update(mkWinSize(80, 9))
+	m.View()
+
+	m.busy = true
+	m.layout()
+	m.View() // The busy frame is 10 rows tall, one more than the terminal.
+
+	m.busy = false
+	m.layout()
+	shrunk := m.View()
+	if got, want := lipgloss.Height(shrunk), m.height; got != want {
+		t.Fatalf("shrunk render must not retain an oversized frame: got %d rows, want %d", got, want)
+	}
+	if got, want := m.viewTop+m.viewH, m.height; got != want {
+		t.Fatalf("shrunk content must remain bottom-anchored: got bottom %d, want %d", got, want)
+	}
+}
+
 func stripAll(s string) string {
 	out := strings.Builder{}
 	i := 0

--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -71,8 +71,15 @@ func TestInlineFrameHeightIsCappedByTerminal(t *testing.T) {
 	m.busy = false
 	m.layout()
 	shrunk := m.View()
-	if got, want := lipgloss.Height(shrunk), m.height; got != want {
-		t.Fatalf("shrunk render must not retain an oversized frame: got %d rows, want %d", got, want)
+
+	// Bubble Tea drops rows from the top when a frame exceeds the terminal.
+	// viewTop must describe the content after that clipping, not its position in
+	// the oversized string returned by View.
+	lead := len(shrunk) - len(strings.TrimLeft(shrunk, "\n"))
+	dropped := max(lipgloss.Height(shrunk)-m.height, 0)
+	physicalContentTop := max(lead-dropped, 0)
+	if m.viewTop != physicalContentTop {
+		t.Fatalf("viewTop must account for renderer clipping: got %d, want %d", m.viewTop, physicalContentTop)
 	}
 	if got, want := m.viewTop+m.viewH, m.height; got != want {
 		t.Fatalf("shrunk content must remain bottom-anchored: got bottom %d, want %d", got, want)

--- a/internal/tui/opencode.go
+++ b/internal/tui/opencode.go
@@ -1126,7 +1126,8 @@ func (m *model) setUIMode(mode string) tea.Cmd {
 	// WindowSizeMsg resets the re-anchor sentinel — without it viewTop stays
 	// at opencode's pinned 0 and every mouse row maps above the pointer until
 	// the next resize. View() recomputes viewTop from this sentinel.
-	m.viewTop = 1 << 30
+	m.viewTop, m.frameTop = 1<<30, 1<<30
+	m.frameH = 0
 	m.cfg.UIMode = mode
 	if m.cfgExtra == nil {
 		m.cfgExtra = map[string]string{}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5044,7 +5044,8 @@ func (m *model) thinkViewCapped() string {
 // shrinking frame back down. Keep the physical frame at its tallest height
 // since the last resize and prepend blank anchor rows when content shrinks;
 // this returns the visible UI to the terminal bottom instead of leaving it
-// stranded toward the top. Mouse coordinates use viewTop, after that padding.
+// stranded toward the top. Bubble Tea clips oversized frames from the top, so
+// cap the tracked frame to the terminal before deriving mouse coordinates.
 func (m *model) View() string {
 	m.syncInputPlaceholder()
 	v := m.viewBody()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -222,8 +222,10 @@ type model struct {
 	inputTop     int
 	inputLines   []string    // the input box's rendered lines, ANSI-stripped
 	vpLead       int         // top blank rows viewportView last dropped (selection row mapping)
-	viewTop      int         // screen row of the view's first line (View tracks it; mouse Y is absolute)
-	viewH        int         // height of the last rendered view
+	viewTop      int         // screen row of the view's content (mouse Y is absolute)
+	viewH        int         // height of the view's content, excluding inline anchor padding
+	frameTop     int         // screen row of Bubble Tea's physical inline render frame
+	frameH       int         // tallest inline frame since the last terminal resize
 	themeHow     string      // how auto theme detection resolved (env var, OSC query, …) — captured at startup/theme change for /report; never re-queried
 	uiMode       string      // "" = default whip look; "opencode" = opencode render mode (see opencode.go)
 	sessTitle    string      // cached session title for the opencode sidebar (from the store; updated on title/rename)
@@ -2171,10 +2173,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		resized := w != m.width // width change → re-wrap the whole transcript
 		m.width, m.height = w, msg.Height
-		// re-anchor the view position: after a resize (and on the first size
-		// at startup) assume the view sits at the bottom — the next View()
-		// computes viewTop = height - viewH from this sentinel.
-		m.viewTop = 1 << 30
+		// Re-anchor the view after a resize (and on the first size). The next
+		// View computes both the physical inline frame and its content from
+		// the terminal bottom; frameH starts a new high-water mark.
+		m.viewTop, m.frameTop = 1<<30, 1<<30
+		m.frameH = 0
 		m.input.SetWidth(w - 2)
 		if resized {
 			m.refreshVP() // every block re-renders at the new width (floored at minRenderWidth)
@@ -5036,14 +5039,12 @@ func (m *model) thinkViewCapped() string {
 	return streamTail(m.thinkView(), liveCap)
 }
 
-// View renders the frame and tracks WHERE it sits on the screen. Mouse events
-// arrive in absolute screen coordinates, so every click/drag mapping needs the
-// view's top row. The inline view starts bottom-anchored (Run moves the cursor
-// to the last row before the first paint); bubbletea's renderer scrolls the
-// top UP when the view grows past the bottom and keeps it FIXED when the view
-// shrinks — so the top row only ever decreases between resizes:
-// viewTop = min(viewTop, height - viewH). A resize resets the sentinel
-// (WindowSizeMsg handler) and the next render re-anchors to the bottom.
+// View renders the frame and tracks WHERE its content sits on the screen.
+// Bubble Tea's inline renderer can move a growing frame up but cannot move a
+// shrinking frame back down. Keep the physical frame at its tallest height
+// since the last resize and prepend blank anchor rows when content shrinks;
+// this returns the visible UI to the terminal bottom instead of leaving it
+// stranded toward the top. Mouse coordinates use viewTop, after that padding.
 func (m *model) View() string {
 	m.syncInputPlaceholder()
 	v := m.viewBody()
@@ -5079,7 +5080,13 @@ func (m *model) View() string {
 		if m.uiMode == opencodeMode {
 			m.viewTop = 0 // altscreen: the view is drawn from row 0, so mouse Y maps directly
 		} else {
-			m.viewTop = max(min(m.viewTop, m.height-m.viewH), 0)
+			m.frameH = max(m.frameH, m.viewH)
+			m.frameTop = max(min(m.frameTop, m.height-m.frameH), 0)
+			lead := m.frameH - m.viewH
+			if lead > 0 {
+				v = strings.Repeat("\n", lead) + v
+			}
+			m.viewTop = m.frameTop + lead
 		}
 	}
 	// Record the input box's absolute screen rows for drag-select. The input is

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -225,7 +225,7 @@ type model struct {
 	viewTop      int         // screen row of the view's content (mouse Y is absolute)
 	viewH        int         // height of the view's content, excluding inline anchor padding
 	frameTop     int         // screen row of Bubble Tea's physical inline render frame
-	frameH       int         // tallest inline frame since the last terminal resize
+	frameH       int         // tallest fitting inline frame since the last terminal resize
 	themeHow     string      // how auto theme detection resolved (env var, OSC query, …) — captured at startup/theme change for /report; never re-queried
 	uiMode       string      // "" = default whip look; "opencode" = opencode render mode (see opencode.go)
 	sessTitle    string      // cached session title for the opencode sidebar (from the store; updated on title/rename)
@@ -5080,9 +5080,9 @@ func (m *model) View() string {
 		if m.uiMode == opencodeMode {
 			m.viewTop = 0 // altscreen: the view is drawn from row 0, so mouse Y maps directly
 		} else {
-			m.frameH = max(m.frameH, m.viewH)
+			m.frameH = min(max(m.frameH, m.viewH), m.height)
 			m.frameTop = max(min(m.frameTop, m.height-m.frameH), 0)
-			lead := m.frameH - m.viewH
+			lead := max(m.frameH-m.viewH, 0)
 			if lead > 0 {
 				v = strings.Repeat("\n", lead) + v
 			}


### PR DESCRIPTION
## Summary
- keep the inline Bubble Tea render frame at its high-water height
- add leading anchor rows when temporary UI content disappears
- preserve mouse-coordinate mapping across frame growth and UI mode changes
- add a regression test covering busy-state growth and shrinkage

## Root cause
Bubble Tea can scroll a growing inline frame upward, but when the frame shrinks it keeps the physical top fixed. Temporary rows such as the busy spinner therefore left the visible TUI stranded toward the top of the terminal.

## Testing
- `go test ./internal/tui -count=1`
- `git diff --check`
- `go test ./...` *(all relevant packages pass; unrelated browser integration tests require a remote-debugging Chrome and failed during temporary profile cleanup)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inline View layout and screen-row tracking used for mouse mapping; behavior is localized to non-opencode inline mode and covered by new tests.
> 
> **Overview**
> Fixes inline (non–alt-screen) TUI layout so temporary UI growth (e.g. the busy spinner) no longer leaves the session stuck toward the top of the terminal after the extra rows go away.
> 
> **Inline rendering:** Tracks a **physical frame** (`frameTop` / `frameH`) at the tallest height since the last resize, prepends blank **anchor** lines when content shrinks so Bubble Tea’s frame size stays stable, and derives `viewTop` from that so the UI stays **bottom-anchored**. When the rendered frame is taller than the terminal, `viewTop` accounts for top clipping so mouse hit-testing still lines up. Resizes and leaving opencode mode reset the frame sentinel the same way as before for `viewTop`.
> 
> **Tests:** Regression coverage for busy on/off returning to the prior bottom position (with unchanged physical frame height) and for clipped oversized frames on a short terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd61be6f41708a3bb501682faaed8af021d65ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->