### PR TITLE
fix(tui): bottom-anchor opencode view so the final markdown flush doesn't jump

### DIFF
--- a/internal/tui/md_flush_jump_test.go
+++ b/internal/tui/md_flush_jump_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Reproduction for the residual "jump" the user still sees after the inline
+// frame fix: when the assistant's final markdown render lands, the visible UI
+// shifts. This drives a markdown-heavy turn through the real streaming path
+// (textMsg per newline, then turnDoneMsg) and records the frame geometry at
+// every step so the exact row that jumps is visible in the test output.
+func TestMarkdownFlushDoesNotJump(t *testing.T) {
+	for _, mode := range []string{"default", "opencode"} {
+		t.Run(mode, func(t *testing.T) {
+			runMarkdownFlushJump(t, mode == "opencode")
+		})
+	}
+}
+
+func runMarkdownFlushJump(t *testing.T, oc bool) {
+	t.Helper()
+	m := compactCmdModel()
+	if oc {
+		m.applyUIMode(opencodeMode)
+		t.Cleanup(func() { m.applyUIMode("") })
+	}
+	m.Update(mkWinSize(80, 24))
+	m.busy = true
+	m.turnStart = m.nowFn()
+	m.layout()
+	m.View()
+
+	// A markdown-heavy assistant turn: heading, paragraph, list, code fence.
+	chunks := []string{
+		"## Fixing the jump\n",
+		"\n",
+		"Here is a paragraph of assistant text that wraps a bit at width 80.\n",
+		"\n",
+		"- first item with some words\n",
+		"- second item with more words in it\n",
+		"- third\n",
+		"\n",
+		"```go\n",
+		"func main() {\n",
+		"\tfmt.Println(\"hi\")\n",
+		"}\n",
+		"```\n",
+		"\n",
+		"That is the plan.\n",
+	}
+
+	type snap struct {
+		step             string
+		viewTop, viewH   int
+		frameTop, frameH int
+		inputTop         int
+		screenH          int
+	}
+	var snaps []snap
+	snapIt := func(step string) {
+		m.layout()
+		v := m.View()
+		s := snap{step: step, viewTop: m.viewTop, viewH: m.viewH, frameTop: m.frameTop, frameH: m.frameH, inputTop: m.inputTop, screenH: lipgloss.Height(v)}
+		snaps = append(snaps, s)
+	}
+
+	snapIt("start")
+	for _, c := range chunks {
+		um, _ := m.Update(textMsg(c))
+		m = um.(*model)
+		snapIt("stream:" + strings.TrimSpace(c))
+	}
+	// Partial tail still in m.current (no trailing newline on the last flush):
+	um, _ := m.Update(textMsg("final trailing bit"))
+	m = um.(*model)
+	snapIt("stream:tail")
+
+	// Turn ends: flushCurrent finalizes the merged block into one markdown doc,
+	// busy clears, chrome shrinks back to base.
+	um, _ = m.Update(turnDoneMsg{final: "done"})
+	m = um.(*model)
+	snapIt("turnDone")
+
+	// One more idle render (the next View() after busy clears).
+	m.layout()
+	m.View()
+	snapIt("idle")
+
+	// Find the snapshots bracketing the flush (stream:tail -> turnDone) and the
+	// tallest streaming frame so a failure explains which row moved and when.
+	var pre, post snap
+	for i, s := range snaps {
+		if s.step == "turnDone" {
+			pre, post = snaps[i-1], snaps[i]
+			break
+		}
+	}
+	t.Logf("stream:tail inputTop=%d viewTop=%d viewH=%d -> turnDone inputTop=%d viewTop=%d viewH=%d",
+		pre.inputTop, pre.viewTop, pre.viewH, post.inputTop, post.viewTop, post.viewH)
+
+	// Invariant: the input box's absolute screen row must not move when the
+	// final markdown render lands — that is the visible "jump". The streaming
+	// tail and the busy chrome are transient; the committed transcript + input
+	// position must be stable across turnDone.
+	if pre.inputTop != post.inputTop {
+		t.Errorf("input box jumped across final markdown flush: %d -> %d", pre.inputTop, post.inputTop)
+	}
+	// And the physical screen must stay bottom-anchored (content bottom == terminal bottom).
+	if post.viewTop+post.viewH != m.height {
+		t.Errorf("after flush, frame not bottom-anchored: bottom %d != terminal %d", post.viewTop+post.viewH, m.height)
+	}
+	// Frame must never exceed the terminal (overflow scrolls the top away).
+	for _, s := range snaps {
+		if s.screenH > m.height {
+			t.Errorf("step %q: frame %d rows exceeds terminal %d", s.step, s.screenH, m.height)
+		}
+	}
+}

--- a/internal/tui/md_flush_jump_test.go
+++ b/internal/tui/md_flush_jump_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Reproduction for the residual "jump" the user still sees after the inline
@@ -117,5 +118,83 @@ func runMarkdownFlushJump(t *testing.T, oc bool) {
 		if s.screenH > m.height {
 			t.Errorf("step %q: frame %d rows exceeds terminal %d", s.step, s.screenH, m.height)
 		}
+	}
+}
+
+// Regression for the overlay-anchoring break the first version of the
+// bottom-anchor fix introduced: when the opencode view is short (viewH <
+// height — the streaming phase, where streamCap clamps the viewport to
+// minTranscriptRows), the lead blank rows must be prepended BEFORE the
+// overlays splice, so screen-fixed overlays keep their terminal position.
+// The toast (top-right, row 2) must NOT ride the content down toward the
+// bottom of the screen on a short view, and the completion popup must stay
+// anchored above the input box rather than floating in the blank lead area.
+func TestOpencodeOverlaysAnchoredOnShortView(t *testing.T) {
+	m := compactCmdModel()
+	m.applyUIMode(opencodeMode)
+	t.Cleanup(func() { m.applyUIMode("") })
+	m.Update(mkWinSize(80, 24))
+
+	// Force the short-view condition: a streaming turn holds the viewport at
+	// minTranscriptRows and renders a live tail below it, so viewH < height.
+	m.busy = true
+	m.turnStart = m.nowFn()
+	m.appendAssistant("a short committed line")
+	m.current = "streaming tail text still in flight"
+	m.layout()
+	m.View()
+	if m.viewH >= m.height {
+		t.Fatalf("test setup: view must be short (streaming), got viewH=%d height=%d", m.viewH, m.height)
+	}
+	lead := m.height - m.viewH
+	if m.viewTop != lead {
+		t.Fatalf("viewTop should be lead=%d, got %d", lead, m.viewTop)
+	}
+
+	// Toast: ocSpliceToast paints at frame row y=2 (pad row 2, text row 3).
+	// With lead prepended FIRST, the toast stays at terminal row 2-3. If the
+	// lead were prepended AFTER splicing (the broken first version), the toast
+	// would sit at row lead+2..lead+3. Assert it stayed at the top.
+	m.toast = "Copied to clipboard"
+	m.layout()
+	v := m.View()
+	lines := strings.Split(v, "\n")
+	toastRow := -1
+	for i, l := range lines {
+		if strings.Contains(ansi.Strip(l), "Copied to clipboard") {
+			toastRow = i
+			break
+		}
+	}
+	if toastRow < 0 {
+		t.Fatalf("toast not rendered:\n%s", v)
+	}
+	// text row is y+1 = 3 in ocSpliceToast's [pad, mid, pad] slice.
+	if toastRow != 3 {
+		t.Errorf("toast rode the lead down: row %d, want 3 (terminal top-right); lead=%d\n%s", toastRow, lead, v)
+	}
+
+	// Completion popup: bottom-anchored to the row just above the input box.
+	// Its screen row is viewTop + inputBodyOff - len(rows); on a short view
+	// (viewTop=lead) it must sit above the INPUT, not in the blank lead area.
+	m.toast = ""
+	m.menu = &menu{cands: []cand{{Text: "/cd", Desc: "change dir"}}}
+	m.layout()
+	v = m.View()
+	menuRows := strings.Split(m.menuView(), "\n")
+	wantTop := m.viewTop + m.inputBodyOff - len(menuRows)
+	if wantTop < 0 {
+		wantTop = 0
+	}
+	lines = strings.Split(v, "\n")
+	found := false
+	for i := wantTop; i < wantTop+len(menuRows) && i < len(lines); i++ {
+		if strings.Contains(ansi.Strip(lines[i]), "/cd") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("completion popup not anchored above input: want at row %d (viewTop=%d inputBodyOff=%d), lead=%d\n%s", wantTop, m.viewTop, m.inputBodyOff, lead, v)
 	}
 }

--- a/internal/tui/md_flush_jump_test.go
+++ b/internal/tui/md_flush_jump_test.go
@@ -182,10 +182,7 @@ func TestOpencodeOverlaysAnchoredOnShortView(t *testing.T) {
 	m.layout()
 	v = m.View()
 	menuRows := strings.Split(m.menuView(), "\n")
-	wantTop := m.viewTop + m.inputBodyOff - len(menuRows)
-	if wantTop < 0 {
-		wantTop = 0
-	}
+	wantTop := max(m.viewTop+m.inputBodyOff-len(menuRows), 0)
 	lines = strings.Split(v, "\n")
 	found := false
 	for i := wantTop; i < wantTop+len(menuRows) && i < len(lines); i++ {

--- a/internal/tui/opencode.go
+++ b/internal/tui/opencode.go
@@ -1017,13 +1017,18 @@ func (m *model) ocOverlayRows(v string, rows []string) string {
 
 // ocMenuOverlay draws the completion popup ON TOP of the frame, bottom-anchored
 // to the row just above the input box (opencode's autocomplete position) — the
-// frame beneath never reflows while typing.
+// frame beneath never reflows while typing. inputBodyOff is the input's offset
+// within viewBody (pre-anchor-padding); View prepends `lead` blank rows to
+// bottom-anchor the frame, so the popup's screen row is viewTop (== lead) +
+// inputBodyOff, not inputBodyOff alone — otherwise a short view floats the
+// popup into the blank area above the content instead of above the input.
 func (m *model) ocMenuOverlay(v string) string {
 	rows := strings.Split(m.menuView(), "\n")
-	if len(rows) > m.inputBodyOff { // clip the top if there's no room above the box
-		rows = rows[len(rows)-m.inputBodyOff:]
+	room := m.viewTop + m.inputBodyOff // terminal rows above the input box (lead + content offset)
+	if len(rows) > room {              // clip the top if there's no room above the box
+		rows = rows[len(rows)-room:]
 	}
-	return ocSpliceAt(v, rows, opencodeLeftMargin, m.inputBodyOff-len(rows))
+	return ocSpliceAt(v, rows, opencodeLeftMargin, room-len(rows))
 }
 
 // opencodeAttribution renders opencode's per-response attribution line:

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5059,6 +5059,39 @@ func (m *model) View() string {
 		gap := strings.Repeat(" ", opencodeRightGap) // breathing room between the panels
 		v = lipgloss.JoinHorizontal(lipgloss.Top, v, gap, m.sidebarView(lipgloss.Height(v)))
 	}
+	if m.height > 0 {
+		m.viewH = lipgloss.Height(v)
+		if m.uiMode == opencodeMode {
+			// Bottom-anchor the altscreen view BEFORE the overlays splice: the
+			// transcript viewport shrinks to minTranscriptRows while a response
+			// streams (streamCap reserves the rest for the live tail), then
+			// snaps to its natural height when the final markdown flushes and
+			// the live tail drops. Top-anchoring (viewTop=0) made that delta a
+			// visible jump — the input and status bar slid down the instant
+			// markdown landed. Prepend blank rows so the content's bottom sits
+			// at the terminal bottom in both phases; inputTop stays pinned. The
+			// altscreen repaints from row 0 every frame, so (unlike the inline
+			// branch) no high-water mark is needed — lead = height - viewH each
+			// paint. Overlays splice AFTER (onto the anchored frame) so their
+			// frame-relative Y stays anchored to terminal geometry: the toast
+			// keeps its top-right row, centered dialogs keep the upper third,
+			// and the completion popup sits above the input — instead of all of
+			// them riding the content down by `lead` on a short view.
+			lead := max(m.height-m.viewH, 0)
+			if lead > 0 {
+				v = strings.Repeat("\n", lead) + v
+			}
+			m.viewTop = lead // content's real screen row; mouse Y maps through it
+		} else {
+			m.frameH = min(max(m.frameH, m.viewH), m.height)
+			m.frameTop = max(min(m.frameTop, m.height-m.frameH), 0)
+			lead := max(m.frameH-m.viewH, 0)
+			if lead > 0 {
+				v = strings.Repeat("\n", lead) + v
+			}
+			m.viewTop = m.frameTop + lead
+		}
+	}
 	if m.uiMode == opencodeMode {
 		switch { // floating dialogs over the dimmed session, opencode-style
 		case m.palette != nil:
@@ -5074,34 +5107,6 @@ func (m *model) View() string {
 		}
 		if m.toast != "" {
 			v = m.ocSpliceToast(v) // top-right toast, over everything
-		}
-	}
-	if m.height > 0 {
-		m.viewH = lipgloss.Height(v)
-		if m.uiMode == opencodeMode {
-			// Bottom-anchor the altscreen view: the transcript viewport is
-			// shrunk to minTranscriptRows while a response streams (streamCap
-			// reserves the rest for the live tail), then snaps to its natural
-			// height when the final markdown flushes and the live tail drops.
-			// Top-anchoring (viewTop=0) makes that delta a visible jump — the
-			// input and status bar slide down the instant markdown lands.
-			// Prepend blank rows so the content's bottom sits at the terminal
-			// bottom in both phases; inputTop stays pinned. The altscreen
-			// repaints from row 0 every frame, so (unlike the inline branch)
-			// no high-water mark is needed — lead = height - viewH each paint.
-			lead := max(m.height-m.viewH, 0)
-			if lead > 0 {
-				v = strings.Repeat("\n", lead) + v
-			}
-			m.viewTop = lead // content's real screen row; mouse Y maps through it
-		} else {
-			m.frameH = min(max(m.frameH, m.viewH), m.height)
-			m.frameTop = max(min(m.frameTop, m.height-m.frameH), 0)
-			lead := max(m.frameH-m.viewH, 0)
-			if lead > 0 {
-				v = strings.Repeat("\n", lead) + v
-			}
-			m.viewTop = m.frameTop + lead
 		}
 	}
 	// Record the input box's absolute screen rows for drag-select. The input is

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5079,7 +5079,21 @@ func (m *model) View() string {
 	if m.height > 0 {
 		m.viewH = lipgloss.Height(v)
 		if m.uiMode == opencodeMode {
-			m.viewTop = 0 // altscreen: the view is drawn from row 0, so mouse Y maps directly
+			// Bottom-anchor the altscreen view: the transcript viewport is
+			// shrunk to minTranscriptRows while a response streams (streamCap
+			// reserves the rest for the live tail), then snaps to its natural
+			// height when the final markdown flushes and the live tail drops.
+			// Top-anchoring (viewTop=0) makes that delta a visible jump — the
+			// input and status bar slide down the instant markdown lands.
+			// Prepend blank rows so the content's bottom sits at the terminal
+			// bottom in both phases; inputTop stays pinned. The altscreen
+			// repaints from row 0 every frame, so (unlike the inline branch)
+			// no high-water mark is needed — lead = height - viewH each paint.
+			lead := max(m.height-m.viewH, 0)
+			if lead > 0 {
+				v = strings.Repeat("\n", lead) + v
+			}
+			m.viewTop = lead // content's real screen row; mouse Y maps through it
 		} else {
 			m.frameH = min(max(m.frameH, m.viewH), m.height)
 			m.frameTop = max(min(m.frameTop, m.height-m.frameH), 0)


### PR DESCRIPTION
## Problem

In **opencode (altscreen) mode**, the input box and status bar slid down the instant the assistant's final markdown render landed — a **9-row jump** on a 24-row terminal.

This is a *different* transition than the one the prior `fix-tui-jump` PR (#142) fixed — that one handled the inline renderer's inability to shrink a frame back down. This one is the streaming→flushed height delta.

## Root cause

While a response streams, `streamCap` shrinks the transcript viewport to `minTranscriptRows` (5) to reserve room for the live `currentView` tail below it. At `turnDone` the partial tail flushes into the transcript as one glamour-rendered markdown doc, the live area disappears, and the viewport snaps to its natural height.

The altscreen `View()` branch was **top-anchored** (`viewTop = 0`), so that streaming→flushed height delta moved everything on screen:

| phase | viewH | inputTop |
|---|---|---|
| streaming tail | 15 | 9 |
| turnDone (flushed) | 24 | 18 |

The **inline** branch already absorbed this with the `frameH` high-water-mark + lead-row padding from #142; the opencode branch skipped that entirely (`m.viewTop = 0`).

## Fix

Bottom-anchor the altscreen view the same way: prepend `lead = height - viewH` blank rows so the content's bottom sits at the terminal bottom in both phases, and set `viewTop = lead` so mouse-row math (`y - viewTop - vpTopRows - contentPad + YOffset + vpLead`) stays correct.

The altscreen repaints from row 0 every frame, so unlike the inline branch it needs no high-water mark — just `height - viewH` each paint.

`inputTop` now stays pinned across the flush in **both** render modes (21 in inline, 18 in opencode).

## Test

`TestMarkdownFlushDoesNotJump` drives a markdown-heavy turn (heading + paragraph + list + code fence) through the real streaming path (`textMsg` per chunk, then `turnDoneMsg`) in **both** modes and asserts the input box's screen row is stable across the flush. It **failed before** this change (`9 -> 18` in opencode) and **passes after**.

Full `internal/tui` suite passes; `go build`/`go vet` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes altscreen layout, input positioning, and overlay splice order—user-visible TUI behavior with dedicated regression tests but no security or data paths.
> 
> **Overview**
> Fixes a visible layout **jump in opencode (altscreen) mode** when streaming ends and the assistant’s final markdown is committed: the transcript viewport grows as the live tail disappears, and top-anchoring had been sliding the input and chrome down with that height change.
> 
> **`View()` now bottom-anchors opencode before overlays splice in:** it prepends `lead = height - viewH` blank rows, sets `viewTop = lead`, and keeps the content bottom pinned to the terminal across streaming vs flushed phases (inline mode still uses the existing `frameH` high-water + lead padding). **Completion popup placement** in `ocMenuOverlay` accounts for that lead by using `viewTop + inputBodyOff` for room and splice Y, so the menu stays above the input instead of floating in the padded area.
> 
> Adds **`TestMarkdownFlushDoesNotJump`** (default + opencode) asserting stable `inputTop` across `turnDone`, bottom anchoring, and no frame taller than the terminal; **`TestOpencodeOverlaysAnchoredOnShortView`** guards toast and autocomplete rows on short streaming views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437951fd54b7965acdc798cf59ac1833b0487883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->