### PR TITLE
ci(loupe): run loupe from main

### DIFF
--- a/.github/workflows/whip--loupe-chat.yml
+++ b/.github/workflows/whip--loupe-chat.yml
@@ -63,7 +63,7 @@ jobs:
           include-imports: true
       - name: Respond
         continue-on-error: true
-        uses: context-labs/loupe@v0
+        uses: context-labs/loupe@main
         with:
           config: .loupe/config.json
         env:

--- a/.github/workflows/whip--loupe-review.yml
+++ b/.github/workflows/whip--loupe-review.yml
@@ -64,7 +64,7 @@ jobs:
           include-imports: true
       - name: Review
         continue-on-error: true
-        uses: context-labs/loupe@v0
+        uses: context-labs/loupe@main
         with:
           config: .loupe/config.json
         env:


### PR DESCRIPTION
Run loupe from `main` instead of the `v0` tag, which had fallen 6 commits behind (in-place summary updates, author guard on comment cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)